### PR TITLE
feat: cz-cli task param system, JDBC datasource binding, execute improvements

### DIFF
--- a/packages/clickzetta-sdk/src/studio/execute.ts
+++ b/packages/clickzetta-sdk/src/studio/execute.ts
@@ -15,6 +15,9 @@ export interface ExecuteAdhocParams {
   adhocVcId: number
   dataFileContent: string
   params?: unknown
+  datasourceId?: number
+  sessionSchemaName?: string
+  dsType?: number
 }
 
 export function executeAdhoc(config: StudioConfig, params: ExecuteAdhocParams) {
@@ -32,6 +35,9 @@ export function executeAdhoc(config: StudioConfig, params: ExecuteAdhocParams) {
     adhocVcId: params.adhocVcId,
     dataFileContent: params.dataFileContent,
     params: params.params,
+    ...(params.datasourceId != null && { datasourceId: params.datasourceId }),
+    ...(params.sessionSchemaName != null && { sessionSchemaName: params.sessionSchemaName }),
+    ...(params.dsType != null && { dsType: params.dsType }),
   },
     {
       env: "prod",

--- a/packages/cz-cli/src/commands/datasource.ts
+++ b/packages/cz-cli/src/commands/datasource.ts
@@ -91,14 +91,14 @@ async function apiSampleData(sc: StudioConfig, params: { id: number; nameSpace: 
 // ---------------------------------------------------------------------------
 // Resolve datasource by name or id
 // ---------------------------------------------------------------------------
-interface ResolvedDatasource {
+export interface ResolvedDatasource {
   id: number
   name: string
   dsType?: number
   connectionParams?: unknown
 }
 
-async function resolveDatasource(sc: StudioConfig, nameOrId: string): Promise<ResolvedDatasource> {
+export async function resolveDatasource(sc: StudioConfig, nameOrId: string): Promise<ResolvedDatasource> {
   const n = Number(nameOrId)
   if (Number.isFinite(n) && n > 0) {
     // Fetch detail by listing with no filter and finding by id

--- a/packages/cz-cli/src/commands/datasource.ts
+++ b/packages/cz-cli/src/commands/datasource.ts
@@ -15,15 +15,17 @@ const DS_TYPE_MAP: Record<string, number> = {
   selectdb: 16, tidb: 17, mariadb: 18, polardb: 19, hologres: 20,
   db2: 21, greenplum: 22, oracle: 25, dm: 26, cos: 27, redis: 43,
   databricks: 44, automq: 45, redshift: 46, s3: 38, dynamodb: 51,
+  aurora_mysql: 39, aurora_postgresql: 40, polardb_postgresql: 48,
 }
 
 const DS_TYPE_NAMES: Record<number, string> = {
   1: "LakeHouse", 2: "Kafka", 3: "Hive", 4: "ClickHouse", 5: "MySQL",
   7: "PostgreSQL", 8: "SqlServer", 9: "Oss", 10: "Hbase", 11: "Odps",
   12: "MongoDB", 13: "ElasticSearch7", 14: "Doris", 15: "StarRocks",
-  16: "SelectDB", 17: "TiDB", 18: "MariaDB", 19: "PolarDB", 20: "Hologres",
+  16: "SelectDB", 17: "TiDB", 18: "MariaDB", 19: "PolarDB MySQL", 20: "Hologres",
   21: "DB2", 22: "Greenplum", 25: "Oracle", 26: "DM", 27: "COS",
-  38: "S3", 43: "Redis", 44: "Databricks", 45: "AutoMQ", 46: "Redshift",
+  38: "S3", 39: "Aurora MySQL", 40: "Aurora PostgreSQL", 43: "Redis",
+  44: "Databricks", 45: "AutoMQ", 46: "Redshift", 48: "PolarDB PostgreSQL",
   51: "DynamoDB",
 }
 

--- a/packages/cz-cli/src/commands/task.ts
+++ b/packages/cz-cli/src/commands/task.ts
@@ -424,6 +424,12 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
             const rawParams = (detailObj.paramValueList ?? detailData.paramValueList) as unknown[] | undefined
             const rawInputParams = (detailObj.inputParamValueList ?? detailData.inputParamValueList) as unknown[] | undefined
             const rawOutputParams = (detailObj.outputParamValueList ?? detailData.outputParamValueList) as unknown[] | undefined
+            // Parse adhocConfigs for JDBC datasource binding (datasourceId + sessionSchemaName)
+            const adhocConfigsRaw = detailObj.adhocConfigs ?? detailData.adhocConfigs
+            const adhocConfigs = (() => {
+              if (!adhocConfigsRaw) return null
+              try { return JSON.parse(String(adhocConfigsRaw)) as Record<string, unknown> } catch { return null }
+            })()
             const merged = {
               task_id: normalizedDetail.task_id ?? fileId,
               task_name: normalizedDetail.task_name,
@@ -431,6 +437,9 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
               params: Array.isArray(rawParams) && rawParams.length > 0 ? rawParams : undefined,
               input_params: Array.isArray(rawInputParams) && rawInputParams.length > 0 ? rawInputParams : undefined,
               output_params: Array.isArray(rawOutputParams) && rawOutputParams.length > 0 ? rawOutputParams : undefined,
+              datasource_id: adhocConfigs?.datasourceId ?? detailData.datasourceId ?? undefined,
+              session_schema_name: adhocConfigs?.sessionSchemaName ?? detailData.sessionSchemaName ?? undefined,
+              ds_type: adhocConfigs?.dsType ?? detailData.dsType ?? undefined,
               schedule_config: scheduleConfig,
             }
             logOperation("task content", { ok: true })
@@ -790,6 +799,8 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
             .option("content", { type: "string", describe: "Override script content" })
             .option("file", { alias: "f", type: "string", describe: "Read override content from file" })
             .option("param", { type: "array", string: true, describe: "Parameter KEY=VALUE" })
+            .option("datasource", { type: "number", describe: "Datasource ID for JDBC tasks (auto-resolved from task config if omitted)" })
+            .option("database", { type: "string", describe: "Database/schema to USE for JDBC tasks (auto-resolved from task config if omitted)" })
             .option("max-wait-seconds", {
               type: "number",
               default: 300,
@@ -847,6 +858,18 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
             const params = Object.keys(cliParams).length > 0 || Object.keys(savedDefaults).length > 0
               ? { ...savedDefaults, ...cliParams }
               : undefined
+            // Resolve JDBC datasource config from adhocConfigs (--datasource/--database override)
+            const adhocConfigsRaw = data?.adhocConfigs ?? taskDetail?.adhocConfigs
+            const adhocConfigs = (() => {
+              if (!adhocConfigsRaw) return null
+              try { return JSON.parse(String(adhocConfigsRaw)) as Record<string, unknown> } catch { return null }
+            })()
+            const datasourceId = argv.datasource != null
+              ? Number(argv.datasource)
+              : (adhocConfigs?.datasourceId as number | undefined)
+            const sessionSchemaName = (argv.database as string | undefined)
+              ?? (adhocConfigs?.sessionSchemaName as string | undefined)
+            const dsType = adhocConfigs?.dsType as number | undefined
             // Warn if content has unresolved ${...} placeholders after merging
             const unresolvedPlaceholders = (content ?? "").match(/\$\{[^}]+\}/g)
               ?.filter((ph) => {
@@ -884,6 +907,9 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
               adhocVcId: 0,
               dataFileContent: content,
               params,
+              datasourceId,
+              sessionSchemaName,
+              dsType,
             })
             const execData = resp.data as Record<string, unknown> | undefined
             const runInstanceId = execData?.scheduleInstanceId ?? execData?.instanceId

--- a/packages/cz-cli/src/commands/task.ts
+++ b/packages/cz-cli/src/commands/task.ts
@@ -21,6 +21,7 @@ import { resolveTaskId, resolveNodeId, resolveFolderIdByName } from "../resolver
 import { normalizeTaskIdentity } from "../identity.js"
 import { t } from "../locale.js"
 import { resolveConnectionConfig } from "../connection/config.js"
+import { resolveDatasource } from "./datasource.js"
 import { convertAgentCron } from "../cron-adapter.js"
 
 function formatIsoStartOfDay(value: string | undefined | null): string {
@@ -799,7 +800,7 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
             .option("content", { type: "string", describe: "Override script content" })
             .option("file", { alias: "f", type: "string", describe: "Read override content from file" })
             .option("param", { type: "array", string: true, describe: "Parameter KEY=VALUE" })
-            .option("datasource", { type: "number", describe: "Datasource ID for JDBC tasks (auto-resolved from task config if omitted)" })
+            .option("datasource", { type: "string", describe: "Datasource name or ID for JDBC tasks (auto-resolved from task config if omitted)" })
             .option("database", { type: "string", describe: "Database/schema to USE for JDBC tasks (auto-resolved from task config if omitted)" })
             .option("max-wait-seconds", {
               type: "number",
@@ -858,18 +859,23 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
             const params = Object.keys(cliParams).length > 0 || Object.keys(savedDefaults).length > 0
               ? { ...savedDefaults, ...cliParams }
               : undefined
-            // Resolve JDBC datasource config from adhocConfigs (--datasource/--database override)
+            // Parse adhocConfigs for JDBC datasource binding
             const adhocConfigsRaw = data?.adhocConfigs ?? taskDetail?.adhocConfigs
             const adhocConfigs = (() => {
               if (!adhocConfigsRaw) return null
               try { return JSON.parse(String(adhocConfigsRaw)) as Record<string, unknown> } catch { return null }
             })()
-            const datasourceId = argv.datasource != null
-              ? Number(argv.datasource)
-              : (adhocConfigs?.datasourceId as number | undefined)
+            // Resolve JDBC datasource: --datasource flag > adhocConfigs > none
+            // When --datasource is provided, look up dsType automatically via datasource API
+            let datasourceId = adhocConfigs?.datasourceId as number | undefined
+            let dsType = adhocConfigs?.dsType as number | undefined
             const sessionSchemaName = (argv.database as string | undefined)
               ?? (adhocConfigs?.sessionSchemaName as string | undefined)
-            const dsType = adhocConfigs?.dsType as number | undefined
+            if (argv.datasource != null) {
+              const resolved = await resolveDatasource(sc, String(argv.datasource))
+              datasourceId = resolved.id
+              dsType = resolved.dsType ?? dsType
+            }
             // Warn if content has unresolved ${...} placeholders after merging
             const unresolvedPlaceholders = (content ?? "").match(/\$\{[^}]+\}/g)
               ?.filter((ph) => {


### PR DESCRIPTION
## Summary

This PR merges the `feat/cz-cli-ts-rewrite` branch into `main`, including 143 commits of feature work and bug fixes. The changes most relevant to this session are highlighted below.

## Task Parameter System

- `task save-content --params` now auto-detects `paramType=system` for built-in system params (`bizdate`, `sys_biz_day`, `sys_biz_datetime`, `sys_plan_day`, `sys_plan_datetime`, `sys_plan_timestamp`, `sys_task_id`, `sys_task_name`, `sys_task_owner`) and time expressions starting with `$[`
- `task content` now returns `params`, `input_params`, `output_params` fields from the raw API response
- `task execute` auto-loads saved `manual` params as defaults; `--param KEY=VAL` overrides; warns to stderr when unresolved `${placeholders}` remain after merge (SQL tasks will fail; Python/Shell silently keep literal strings)

## JDBC Task Datasource Binding

- `task content` parses `adhocConfigs` and returns `datasource_id`, `session_schema_name`, `ds_type` fields
- `task execute` auto-resolves JDBC datasource config from saved `adhocConfigs`; new `--datasource <name|id>` and `--database <db>` flags for override or new tasks
- `--datasource` accepts name or numeric ID; `dsType` is auto-resolved via datasource API (fixes `dsType is null` error on new JDBC tasks)
- Added missing JDBC-supported datasource types: Aurora MySQL (39), Aurora PostgreSQL (40), PolarDB PostgreSQL (48); fixed PolarDB (19) display name

## Runs Refill

- `runs refill --from/--to` describe updated to clarify `YYYY-MM-DD` (day boundary) vs `YYYY-MM-DDTHH:MM:SS` (exact datetime for hourly/minutely task backfills)

## SKILL / Documentation

- Added Rule 3.1 to SKILL.template.md: 补数/回填 → `runs refill` routing hint
- Updated `cz-cli-inner/SKILL.md` with new `execute`, `refill`, `save-content` behavior
- `locale.ts` `task_content` message updated to describe `params` field and `paramType` semantics

## Testing

All changes verified against live ClickZetta Lakehouse environment:
- SQL/Python/Shell task param injection (manual + system types)
- JDBC task execute with saved adhocConfigs (auto-resolve)
- JDBC task execute with `--datasource aliyun_mysql --database clickzetta_authority` (new task, name lookup)
- `task content` returning datasource fields
- `runs refill` datetime format behavior