### PR TITLE
feat(cz-cli): support CZ_FORMAT env var for default output format

### DIFF
--- a/packages/cz-cli/src/cli.ts
+++ b/packages/cz-cli/src/cli.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs"
 import { VERSION } from "./version.js"
-import { outputState, parseOutputArgs, renderOutput } from "./output/index.js"
+import { defaultFormat, outputState, parseOutputArgs, renderOutput } from "./output/index.js"
 
 export interface GlobalArgs {
   profile?: string
@@ -76,7 +76,7 @@ export function createCli(args: string[]) {
     .option("format", {
       type: "string",
       choices: ["json", "pretty", "table", "csv", "text", "jsonl", "toon"] as const,
-      default: "json",
+      default: defaultFormat(),
       describe: "Output format",
     })
     .option("field", {

--- a/packages/cz-cli/src/execute.ts
+++ b/packages/cz-cli/src/execute.ts
@@ -2,7 +2,7 @@
  * Programmatic execution of cz-cli commands.
  * Reuses the same top-level argument classification as the real CLI, but captures output and exit code.
  */
-import { outputState } from "./output/index.js"
+import { defaultFormat, outputState } from "./output/index.js"
 import { createCli } from "./cli.js"
 import { registerCommands } from "./register-commands.js"
 import { classifyCliArgs, emitNoProfile } from "./run-cli.js"
@@ -32,7 +32,7 @@ async function executeInternal(command: string, extraArgs?: string[]): Promise<E
   const args = splitArgs(command)
   if (extraArgs) args.push(...extraArgs)
   if (!args.includes("--format") && !args.some((arg) => arg.startsWith("--format="))) {
-    args.push("--format", "json")
+    args.push("--format", defaultFormat())
   }
 
   const chunks: string[] = []

--- a/packages/cz-cli/src/output/index.ts
+++ b/packages/cz-cli/src/output/index.ts
@@ -1,5 +1,13 @@
 import { formatJson, formatPretty, formatTable, formatTableNoHeader, formatCsv, formatCsvNoHeader, formatJsonl, formatToon, formatText } from "./formatter.js"
 
+const VALID_FORMATS = new Set(["json", "pretty", "table", "csv", "text", "jsonl", "toon"])
+
+export function defaultFormat(): string {
+  const env = process.env.CZ_FORMAT?.trim()
+  if (env && VALID_FORMATS.has(env)) return env
+  return "json"
+}
+
 export const EXIT_OK = 0
 export const EXIT_BIZ_ERROR = 1
 export const EXIT_USAGE_ERROR = 2
@@ -67,7 +75,7 @@ export function successRows(
   if (opts?.aiMessage) payload.ai_message = opts.aiMessage
   if (opts?.extra) Object.assign(payload, opts.extra)
 
-  const format = opts?.format ?? "json"
+  const format = opts?.format ?? defaultFormat()
   const field = opts?.field ?? outputState.field
   const noHeader = opts?.noHeader ?? false
   let output: string

--- a/packages/cz-cli/test/output.test.ts
+++ b/packages/cz-cli/test/output.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { error, successRows } from "../src/output/index.js"
+import { defaultFormat, error, successRows } from "../src/output/index.js"
 
 const originalStdoutWrite = process.stdout.write.bind(process.stdout)
 const originalStderrWrite = process.stderr.write.bind(process.stderr)
@@ -87,5 +87,41 @@ describe("error output formatting", () => {
     })
 
     expect(output.stdout).toBe('{\n  "error": {\n    "code": "CZLH-42000",\n    "message": "schema not found"\n  }\n}\n')
+  })
+})
+
+describe("defaultFormat", () => {
+  const savedFormat = process.env.CZ_FORMAT
+
+  const restore = () => {
+    if (savedFormat === undefined) {
+      delete process.env.CZ_FORMAT
+    } else {
+      process.env.CZ_FORMAT = savedFormat
+    }
+  }
+
+  test("returns json when CZ_FORMAT is not set", () => {
+    delete process.env.CZ_FORMAT
+    expect(defaultFormat()).toBe("json")
+    restore()
+  })
+
+  test("returns the value of CZ_FORMAT when set to a valid format", () => {
+    process.env.CZ_FORMAT = "table"
+    expect(defaultFormat()).toBe("table")
+    restore()
+  })
+
+  test("returns json when CZ_FORMAT is set to an invalid format", () => {
+    process.env.CZ_FORMAT = "invalid"
+    expect(defaultFormat()).toBe("json")
+    restore()
+  })
+
+  test("trims whitespace from CZ_FORMAT value", () => {
+    process.env.CZ_FORMAT = "  csv  "
+    expect(defaultFormat()).toBe("csv")
+    restore()
   })
 })


### PR DESCRIPTION
Consolidate the hardcoded 'json' default into a shared defaultFormat() function that reads the CZ_FORMAT environment variable, allowing users to set a persistent default output format without passing --format on every invocation.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
