### PR TITLE
Feature/analytics agent cli

### DIFF
--- a/analytics-agent-commits.html
+++ b/analytics-agent-commits.html
@@ -1,0 +1,514 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>analytics-agent CLI — Commit 总结</title>
+<style>
+  /* ── Reset & base ── */
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg: #0f1117;
+    --surface: #1a1d2e;
+    --surface2: #232740;
+    --border: #2e3354;
+    --accent: #5c73f2;
+    --accent2: #7c3aed;
+    --teal: #0ea5c9;
+    --green: #22c55e;
+    --yellow: #f59e0b;
+    --red: #ef4444;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --mono: 'JetBrains Mono', 'Fira Code', monospace;
+  }
+  html, body { height: 100%; background: var(--bg); color: var(--text);
+    font-family: 'Inter', 'Segoe UI', system-ui, sans-serif; }
+
+  /* ── Deck layout ── */
+  .deck { width: 100%; }
+  .slide {
+    min-height: 100vh;
+    display: flex; flex-direction: column; justify-content: center; align-items: center;
+    padding: 48px 60px;
+    position: relative;
+    overflow: hidden;
+  }
+  .slide::before {
+    content: '';
+    position: absolute; inset: 0;
+    background: radial-gradient(ellipse 60% 50% at 80% 20%, rgba(92,115,242,.12) 0%, transparent 70%),
+                radial-gradient(ellipse 50% 60% at 10% 90%, rgba(14,165,201,.08) 0%, transparent 70%);
+    pointer-events: none;
+  }
+
+  /* ── Slide 1 — Cover ── */
+  .cover { text-align: center; gap: 20px; }
+  .cover .eyebrow {
+    font-size: 13px; letter-spacing: .14em; text-transform: uppercase;
+    color: var(--teal); font-weight: 600;
+    background: rgba(14,165,201,.1); border: 1px solid rgba(14,165,201,.3);
+    padding: 5px 16px; border-radius: 999px; display: inline-block; margin-bottom: 12px;
+  }
+  .cover h1 {
+    font-size: clamp(2rem, 5vw, 3.4rem); font-weight: 800;
+    background: linear-gradient(135deg, #fff 0%, var(--accent) 60%, var(--teal) 100%);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    line-height: 1.15; margin-bottom: 16px;
+  }
+  .cover .subtitle { font-size: 1.1rem; color: var(--muted); max-width: 560px; margin: 0 auto 32px; }
+  .cover .meta {
+    display: flex; gap: 32px; justify-content: center; flex-wrap: wrap;
+    font-size: .85rem; color: var(--muted);
+  }
+  .cover .meta span { display: flex; align-items: center; gap: 6px; }
+  .cover .meta .dot { width: 8px; height: 8px; border-radius: 50%; }
+  .dot-blue { background: var(--accent); }
+  .dot-teal { background: var(--teal); }
+  .dot-green { background: var(--green); }
+
+  /* ── Section header ── */
+  .section-header { text-align: center; }
+  .commit-badge {
+    display: inline-flex; align-items: center; gap: 8px;
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: 8px; padding: 6px 14px; margin-bottom: 20px;
+  }
+  .commit-badge .sha {
+    font-family: var(--mono); font-size: .8rem; color: var(--teal);
+    background: rgba(14,165,201,.1); padding: 2px 8px; border-radius: 4px;
+  }
+  .commit-badge .date { font-size: .8rem; color: var(--muted); }
+  .section-header h2 {
+    font-size: clamp(1.6rem, 3.5vw, 2.4rem); font-weight: 700;
+    margin-bottom: 10px;
+  }
+  .section-header p { color: var(--muted); font-size: 1rem; max-width: 640px; margin: 0 auto; }
+
+  /* ── Content grid ── */
+  .content-grid {
+    display: grid; gap: 18px; width: 100%; max-width: 1100px; margin: 28px auto 0;
+  }
+  .cols-2 { grid-template-columns: 1fr 1fr; }
+  .cols-3 { grid-template-columns: repeat(3, 1fr); }
+
+  /* ── Card ── */
+  .card {
+    background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+    padding: 22px 24px;
+    position: relative; overflow: hidden;
+    transition: border-color .2s;
+  }
+  .card:hover { border-color: var(--accent); }
+  .card::after {
+    content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+    background: linear-gradient(90deg, var(--accent), var(--teal));
+    opacity: 0; transition: opacity .2s;
+  }
+  .card:hover::after { opacity: 1; }
+  .card-icon { font-size: 1.6rem; margin-bottom: 10px; }
+  .card h3 { font-size: 1rem; font-weight: 700; margin-bottom: 8px; color: #fff; }
+  .card p { font-size: .875rem; color: var(--muted); line-height: 1.6; }
+  .card ul { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+  .card ul li { font-size: .85rem; color: var(--muted); display: flex; align-items: flex-start; gap: 8px; }
+  .card ul li::before { content: '▸'; color: var(--accent); flex-shrink: 0; margin-top: 1px; }
+
+  /* ── Command list ── */
+  .cmd-group { margin-bottom: 14px; }
+  .cmd-group-title {
+    font-size: .75rem; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--teal); font-weight: 600; margin-bottom: 8px;
+  }
+  .cmd-row {
+    display: flex; align-items: flex-start; gap: 10px;
+    margin-bottom: 6px;
+  }
+  .cmd {
+    font-family: var(--mono); font-size: .78rem;
+    background: rgba(92,115,242,.12); color: var(--accent);
+    border: 1px solid rgba(92,115,242,.25); border-radius: 5px;
+    padding: 2px 8px; white-space: nowrap; flex-shrink: 0;
+  }
+  .cmd-desc { font-size: .8rem; color: var(--muted); line-height: 1.5; }
+
+  /* ── Diff view ── */
+  .diff-block {
+    background: #0d0f1a; border: 1px solid var(--border); border-radius: 10px;
+    font-family: var(--mono); font-size: .78rem; overflow: hidden;
+  }
+  .diff-header {
+    background: var(--surface); padding: 8px 16px;
+    font-size: .75rem; color: var(--muted); border-bottom: 1px solid var(--border);
+  }
+  .diff-body { padding: 12px 16px; line-height: 1.7; }
+  .diff-add { color: var(--green); }
+  .diff-del { color: var(--red); }
+  .diff-ctx { color: #4a5568; }
+
+  /* ── Pill tags ── */
+  .tag {
+    display: inline-flex; align-items: center; gap: 4px;
+    font-size: .75rem; padding: 3px 10px; border-radius: 999px;
+    font-weight: 600; white-space: nowrap;
+  }
+  .tag-blue  { background: rgba(92,115,242,.15); color: var(--accent);  border: 1px solid rgba(92,115,242,.3); }
+  .tag-teal  { background: rgba(14,165,201,.12);  color: var(--teal);   border: 1px solid rgba(14,165,201,.3); }
+  .tag-green { background: rgba(34,197,94,.12);   color: var(--green);  border: 1px solid rgba(34,197,94,.3); }
+  .tag-red   { background: rgba(239,68,68,.12);   color: var(--red);    border: 1px solid rgba(239,68,68,.3); }
+  .tag-yellow{ background: rgba(245,158,11,.12);  color: var(--yellow); border: 1px solid rgba(245,158,11,.3); }
+  .tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+
+  /* ── Highlight box ── */
+  .highlight-box {
+    background: linear-gradient(135deg, rgba(92,115,242,.08), rgba(14,165,201,.06));
+    border: 1px solid rgba(92,115,242,.25); border-radius: 10px;
+    padding: 16px 20px;
+  }
+  .highlight-box .label {
+    font-size: .72rem; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--accent); font-weight: 700; margin-bottom: 6px;
+  }
+  .highlight-box p { font-size: .875rem; color: var(--text); line-height: 1.6; }
+
+  /* ── Timeline connector ── */
+  .timeline {
+    display: flex; flex-direction: column; gap: 0; width: 100%; max-width: 900px;
+    position: relative;
+  }
+  .timeline::before {
+    content: ''; position: absolute; left: 28px; top: 32px; bottom: 32px;
+    width: 2px; background: linear-gradient(180deg, var(--accent), var(--teal), var(--green));
+  }
+  .timeline-item {
+    display: flex; gap: 20px; align-items: flex-start; padding: 16px 0;
+  }
+  .tl-dot {
+    width: 18px; height: 18px; border-radius: 50%; border: 3px solid var(--bg);
+    flex-shrink: 0; margin-top: 4px; position: relative; z-index: 1;
+    margin-left: 20px;
+  }
+  .tl-content { flex: 1; }
+  .tl-content h4 { font-size: .95rem; font-weight: 700; margin-bottom: 4px; }
+  .tl-content p { font-size: .83rem; color: var(--muted); line-height: 1.55; }
+
+  /* ── Divider ── */
+  .slide-divider { width: 60px; height: 3px; border-radius: 2px; margin: 0 auto 24px; }
+
+  /* ── Responsive ── */
+  @media (max-width: 768px) {
+    .cols-2, .cols-3 { grid-template-columns: 1fr; }
+    .slide { padding: 32px 20px; }
+  }
+</style>
+</head>
+<body>
+<div class="deck">
+
+<!-- ═══════════════════════════════════════════════════════════ SLIDE 1 — Cover -->
+<section class="slide cover">
+  <div>
+    <div class="eyebrow">Code Review · analytics-agent</div>
+    <h1>Analytics Agent CLI<br>三次提交总结</h1>
+    <p class="subtitle">由 zhaxinmeng（xinmeng.zha）提交，涵盖全新命令新增、参数校验收紧、接口修复与功能补全</p>
+    <div class="meta">
+      <span><span class="dot dot-blue"></span>Commit 1 — 2026-06-14 · 添加命令</span>
+      <span><span class="dot dot-teal"></span>Commit 2 — 2026-06-14 · 参数校验</span>
+      <span><span class="dot dot-green"></span>Commit 3 — 2026-06-15 · 接口修复</span>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════ SLIDE 2 — Commit 1 Overview -->
+<section class="slide" style="background: linear-gradient(160deg, #0f1117 0%, #141828 100%);">
+  <div style="width:100%;max-width:1100px;">
+    <div class="section-header">
+      <div class="commit-badge">
+        <span class="sha">0e6da6c</span>
+        <span class="date">2026-06-14 15:28</span>
+      </div>
+      <h2>Commit 1 — 添加 analytics-agent CLI 命令</h2>
+      <p>新增 683 行核心实现，从零构建完整的 Analytics Agent 命令体系</p>
+    </div>
+    <div class="content-grid cols-3" style="margin-top:32px;">
+      <div class="card">
+        <div class="card-icon">📂</div>
+        <h3>改动范围</h3>
+        <ul>
+          <li>新增 <code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">analytics-agent.ts</code> (683 行)</li>
+          <li>注册命令至 cli.ts / register-commands.ts / run-cli.ts</li>
+          <li>profile-store 新增 <code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">readAgentEndpoint</code></li>
+          <li>setup 命令增加 <code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">--analysis-agent-endpoint</code></li>
+          <li>新增 e2e 测试 &amp; profile-store 单元测试</li>
+        </ul>
+        <div class="tags" style="margin-top:14px;">
+          <span class="tag tag-blue">+807 行</span>
+          <span class="tag tag-teal">12 文件</span>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🌐</div>
+        <h3>统一 HTTP 请求层</h3>
+        <ul>
+          <li>读取 profile 中的 <code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">analysis_agent_endpoint</code></li>
+          <li>携带 x-clickzetta-token / Authorization / traceparent</li>
+          <li>openSessionAuth 路由使用独立 token header</li>
+          <li>支持 <code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">--format json/table</code> 输出</li>
+          <li>支持 <code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">--body</code> 传完整 JSON 覆盖</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="card-icon">🛠️</div>
+        <h3>工具函数</h3>
+        <ul>
+          <li><code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">parseJsonObject</code> / <code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">parseJsonArray</code></li>
+          <li><code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">mergeBody</code> — 合并 body 与 CLI 参数</li>
+          <li><code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">encodePath</code> — URL 路径安全编码</li>
+          <li><code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">buildUrl</code> — 构造带 tenantId 的完整 URL</li>
+          <li><code style="font-family:var(--mono);font-size:.78rem;color:var(--teal)">undefinedIfEmpty</code> — 清理空对象</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════ SLIDE 3 — Commit 1 Commands -->
+<section class="slide">
+  <div style="width:100%;max-width:1100px;">
+    <div class="section-header">
+      <h2>Commit 1 — 命令树详解</h2>
+      <p style="color:var(--muted)">四大子命令组，覆盖数据源管理、域管理、服务检测与会话控制</p>
+    </div>
+    <div class="content-grid cols-2" style="margin-top:28px;">
+      <div class="card">
+        <h3 style="color:var(--teal);margin-bottom:14px;">📊 datasource — 11 条子命令</h3>
+        <div class="cmd-group">
+          <div class="cmd-row"><span class="cmd">types</span><span class="cmd-desc">获取支持的数据源类型列表</span></div>
+          <div class="cmd-row"><span class="cmd">schema</span><span class="cmd-desc">获取数据源 Schema 信息</span></div>
+          <div class="cmd-row"><span class="cmd">list</span><span class="cmd-desc">列出所有数据源</span></div>
+          <div class="cmd-row"><span class="cmd">meta &lt;id&gt;</span><span class="cmd-desc">获取数据源 Meta 信息</span></div>
+          <div class="cmd-row"><span class="cmd">browse &lt;id&gt;</span><span class="cmd-desc">浏览数据源目录</span></div>
+          <div class="cmd-row"><span class="cmd">search-tables &lt;id&gt;</span><span class="cmd-desc">搜索数据源中的表</span></div>
+          <div class="cmd-row"><span class="cmd">show-table &lt;id&gt; &lt;name&gt;</span><span class="cmd-desc">查看表元数据</span></div>
+          <div class="cmd-row"><span class="cmd">create / update / delete</span><span class="cmd-desc">增删改数据源</span></div>
+          <div class="cmd-row"><span class="cmd">load &lt;id&gt;</span><span class="cmd-desc">将表加载到 Analytics Agent</span></div>
+        </div>
+      </div>
+      <div class="card">
+        <h3 style="color:var(--accent);margin-bottom:14px;">🗂️ domain — 域 &amp; 会话管理</h3>
+        <div class="cmd-group">
+          <div class="cmd-group-title">domain</div>
+          <div class="cmd-row"><span class="cmd">list / create / update</span><span class="cmd-desc">域生命周期管理</span></div>
+          <div class="cmd-row"><span class="cmd">detail &lt;id&gt;</span><span class="cmd-desc">查看域详情（含绑定表）</span></div>
+          <div class="cmd-row"><span class="cmd">delete &lt;id&gt;</span><span class="cmd-desc">删除域</span></div>
+          <div class="cmd-row"><span class="cmd">table add &lt;id&gt;</span><span class="cmd-desc">向域添加表</span></div>
+        </div>
+        <div class="cmd-group" style="margin-top:12px;">
+          <div class="cmd-group-title">session（text2insight）</div>
+          <div class="cmd-row"><span class="cmd">create</span><span class="cmd-desc">创建安全 session</span></div>
+          <div class="cmd-row"><span class="cmd">run [session-id]</span><span class="cmd-desc">发起 text2insight 查询</span></div>
+          <div class="cmd-row"><span class="cmd">result [question-id]</span><span class="cmd-desc">轮询查询结果（支持 --wait）</span></div>
+          <div class="cmd-row"><span class="cmd">stop</span><span class="cmd-desc">停止运行中的查询</span></div>
+        </div>
+        <div class="cmd-group" style="margin-top:12px;">
+          <div class="cmd-group-title">service</div>
+          <div class="cmd-row"><span class="cmd">enabled</span><span class="cmd-desc">检查租户是否开启 Analytics Agent</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════ SLIDE 4 — Commit 2 -->
+<section class="slide" style="background: linear-gradient(160deg, #0f1117 0%, #12181f 100%);">
+  <div style="width:100%;max-width:1100px;">
+    <div class="section-header">
+      <div class="commit-badge">
+        <span class="sha">66c7c1c</span>
+        <span class="date">2026-06-14 20:12</span>
+      </div>
+      <h2>Commit 2 — 参数校验收紧</h2>
+      <p>创建 session 必须指定 domainId，查询结果必须指定 questionId；同步新增命名规范文档</p>
+    </div>
+    <div class="content-grid cols-2" style="margin-top:32px;">
+      <div class="card">
+        <h3 style="margin-bottom:16px;">🔒 session create — domain-id 变为必填</h3>
+        <div class="diff-block">
+          <div class="diff-header">packages/cz-cli/src/commands/analytics-agent.ts</div>
+          <div class="diff-body">
+            <div class="diff-del">- .option("domain-id", { type: "number",</div>
+            <div class="diff-del">-   describe: "Domain ID" })</div>
+            <div class="diff-add">+ .option("domain-id", { type: "number",</div>
+            <div class="diff-add">+   demandOption: true,</div>
+            <div class="diff-add">+   describe: "Domain ID" })</div>
+          </div>
+        </div>
+        <div class="highlight-box" style="margin-top:14px;">
+          <div class="label">变更原因</div>
+          <p>每个 session 都必须关联一个 domain，domain 决定可查询的数据范围；不传 domainId 会导致后端报错，提前在 CLI 层校验更友好。</p>
+        </div>
+      </div>
+      <div class="card">
+        <h3 style="margin-bottom:16px;">🔒 session result — question-id 变为必填</h3>
+        <div class="diff-block">
+          <div class="diff-header">packages/cz-cli/src/commands/analytics-agent.ts</div>
+          <div class="diff-body">
+            <div class="diff-del">- "result [question-id]",</div>
+            <div class="diff-add">+ "result &lt;question-id&gt;",</div>
+            <div class="diff-ctx">  "Poll a text2insight question result",</div>
+            <div class="diff-del">- .positional("question-id", { type: "number",</div>
+            <div class="diff-del">-   describe: "Question ID" })</div>
+            <div class="diff-add">+ .positional("question-id", { type: "number",</div>
+            <div class="diff-add">+   demandOption: true,</div>
+            <div class="diff-add">+   describe: "Question ID" })</div>
+          </div>
+        </div>
+        <div class="highlight-box" style="margin-top:14px;">
+          <div class="label">变更原因</div>
+          <p>轮询结果必须知道是哪个问题（question），缺少该参数无法发起有效请求；语法从 <code style="font-family:var(--mono);font-size:.8rem;color:var(--teal)">[可选]</code> 改为 <code style="font-family:var(--mono);font-size:.8rem;color:var(--teal)">&lt;必填&gt;</code>。</p>
+        </div>
+      </div>
+    </div>
+    <div class="content-grid" style="grid-template-columns:1fr;margin-top:16px;">
+      <div class="card">
+        <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;">
+          <span style="font-size:1.3rem;">📄</span>
+          <h3>新增：docs/datagpt-naming-review.md（99 行）</h3>
+        </div>
+        <p style="font-size:.875rem;color:var(--muted);line-height:1.6;">
+          梳理 <strong style="color:var(--text)">datagpt</strong>、<strong style="color:var(--text)">analytics-agent</strong>、<strong style="color:var(--text)">text2insight</strong> 等术语的规范用法，确保 CLI 命令名称、API 路径、文档与代码注释保持一致性。
+        </p>
+        <div class="tags">
+          <span class="tag tag-yellow">命名规范</span>
+          <span class="tag tag-teal">datagpt</span>
+          <span class="tag tag-teal">analytics-agent</span>
+          <span class="tag tag-teal">text2insight</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════ SLIDE 5 — Commit 3 -->
+<section class="slide">
+  <div style="width:100%;max-width:1100px;">
+    <div class="section-header">
+      <div class="commit-badge">
+        <span class="sha">0ff4af4</span>
+        <span class="date">2026-06-15 14:33 · CZPDEV-24802</span>
+      </div>
+      <h2>Commit 3 — Analytics Agent 接口修复</h2>
+      <p>补全缺失路由、修复业务错误检测、新增 domain table remove 与 session list 命令</p>
+    </div>
+    <div class="content-grid cols-3" style="margin-top:28px;">
+      <div class="card">
+        <div class="card-icon">➕</div>
+        <h3>新增路由</h3>
+        <div class="cmd-group" style="margin-top:8px;">
+          <div class="cmd-group-title">domainTableRemove</div>
+          <div style="font-family:var(--mono);font-size:.75rem;color:var(--red);background:#0d0f1a;border-radius:6px;padding:8px 10px;line-height:1.6;">
+            DELETE /open/api/v1/analytics-agent/<br>
+            &nbsp;&nbsp;domains/:domainId/tables/:tableId
+          </div>
+        </div>
+        <div class="cmd-group" style="margin-top:12px;">
+          <div class="cmd-group-title">sessionList</div>
+          <div style="font-family:var(--mono);font-size:.75rem;color:var(--teal);background:#0d0f1a;border-radius:6px;padding:8px 10px;line-height:1.6;">
+            POST /open/session/list
+          </div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🐛</div>
+        <h3>业务错误检测修复</h3>
+        <p style="font-size:.83rem;color:var(--muted);line-height:1.6;margin-bottom:12px;">
+          后端始终返回 HTTP 200，通过响应体中 <code style="font-family:var(--mono);font-size:.78rem;color:var(--yellow)">success: false</code> 表达业务失败，原代码未检测此状态。
+        </p>
+        <div class="highlight-box">
+          <div class="label">新增 extractBusinessError()</div>
+          <p>兼容两种格式：<br>
+          ① <code style="font-family:var(--mono);font-size:.75rem;color:var(--teal)">{data: {success:false, code, message}}</code><br>
+          ② <code style="font-family:var(--mono);font-size:.75rem;color:var(--teal)">{success:false, code, message}</code><br>
+          检测到业务错误后调用 <code style="font-family:var(--mono);font-size:.75rem;color:var(--red)">error()</code> 提前返回，不再误报成功。</p>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-icon">✨</div>
+        <h3>新增 CLI 命令</h3>
+        <div class="cmd-group" style="margin-top:8px;">
+          <div class="cmd-group-title">domain table remove</div>
+          <div class="cmd-row">
+            <span class="cmd">remove &lt;domain-id&gt; &lt;table-id&gt;</span>
+          </div>
+          <p style="font-size:.8rem;color:var(--muted);">从指定 domain 中移除绑定的表</p>
+        </div>
+        <div class="cmd-group" style="margin-top:14px;">
+          <div class="cmd-group-title">session list</div>
+          <div class="cmd-row">
+            <span class="cmd">list --domain-id &lt;id&gt;</span>
+          </div>
+          <p style="font-size:.8rem;color:var(--muted);">列出 text2insight sessions；domain-id 必填，支持 --source-type / --source-id 过滤</p>
+        </div>
+      </div>
+    </div>
+    <div class="content-grid" style="grid-template-columns:1fr;margin-top:16px;">
+      <div class="diff-block">
+        <div class="diff-header">executeAnalyticsCommand — 业务错误检测注入点</div>
+        <div class="diff-body">
+          <div class="diff-ctx">&nbsp; const payload = await requestAnalytics(argv, route, body, query)</div>
+          <div class="diff-add">+ const bizErr = extractBusinessError(payload)</div>
+          <div class="diff-add">+ if (bizErr) {</div>
+          <div class="diff-add">+   logOperation(name, { ok: false, timeMs: Date.now() - t0 })</div>
+          <div class="diff-add">+   error(bizErr.code, bizErr.message, { format })</div>
+          <div class="diff-add">+   return</div>
+          <div class="diff-add">+ }</div>
+          <div class="diff-ctx">&nbsp; logOperation(name, { ok: true, timeMs: Date.now() - t0 })</div>
+          <div class="diff-ctx">&nbsp; success(unwrapResponse(payload), { format, timeMs: Date.now() - t0 })</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════ SLIDE 6 — Summary -->
+<section class="slide" style="background: linear-gradient(160deg, #0f1117 0%, #141828 100%);">
+  <div style="width:100%;max-width:900px;">
+    <div class="section-header" style="margin-bottom:36px;">
+      <div class="slide-divider" style="background:linear-gradient(90deg,var(--accent),var(--teal));"></div>
+      <h2>总结</h2>
+      <p>三次提交完整构建了 analytics-agent CLI 子系统</p>
+    </div>
+    <div class="timeline">
+      <div class="timeline-item">
+        <div class="tl-dot" style="background:var(--accent);"></div>
+        <div class="tl-content">
+          <h4>Commit 1 · 0e6da6c — 从零构建</h4>
+          <p>新增 analytics-agent 命令体系（683行），包含 datasource（11条）、domain（含table）、service、session 四大子命令组；实现统一 HTTP 层、工具函数、e2e 测试。</p>
+          <div class="tags" style="margin-top:8px;"><span class="tag tag-blue">+807 行</span><span class="tag tag-blue">12 文件</span><span class="tag tag-green">新功能</span></div>
+        </div>
+      </div>
+      <div class="timeline-item">
+        <div class="tl-dot" style="background:var(--teal);"></div>
+        <div class="tl-content">
+          <h4>Commit 2 · 66c7c1c — 参数收紧</h4>
+          <p>session create 的 domain-id 改为必填；session result 的 question-id 改为必填位置参数；新增命名规范文档统一术语。</p>
+          <div class="tags" style="margin-top:8px;"><span class="tag tag-teal">+102 行</span><span class="tag tag-yellow">校验增强</span></div>
+        </div>
+      </div>
+      <div class="timeline-item">
+        <div class="tl-dot" style="background:var(--green);"></div>
+        <div class="tl-content">
+          <h4>Commit 3 · 0ff4af4 — 接口修复（CZPDEV-24802）</h4>
+          <p>新增 domainTableRemove 与 sessionList 路由；实现 extractBusinessError() 修复 HTTP 200 包裹业务错误的误报问题；补全 domain table remove 与 session list 命令。</p>
+          <div class="tags" style="margin-top:8px;"><span class="tag tag-green">+73 行</span><span class="tag tag-red">Bug Fix</span><span class="tag tag-green">新命令</span></div>
+        </div>
+      </div>
+    </div>
+    <div style="text-align:center;margin-top:40px;font-size:.8rem;color:var(--muted);">
+      Branch: <code style="font-family:var(--mono);color:var(--teal)">feature/analytics-agent-cli</code> &nbsp;·&nbsp; Author: xinmeng.zha
+    </div>
+  </div>
+</section>
+
+</div>
+</body>
+</html>

--- a/docs/datagpt-naming-review.md
+++ b/docs/datagpt-naming-review.md
@@ -1,0 +1,99 @@
+# DataGPT CLI 命名规范审查报告
+
+## 现有 cz-cli 命名模式（参考基准）
+
+| 模式 | 示例 |
+|---|---|
+| 简单 CRUD 动词 | `list`, `create`, `describe`, `drop`, `delete`, `update` |
+| 资源-名词式子命令 | `datasource catalogs`, `datasource objects` |
+| 状态/信息查看 | `workspace current`, `profile status`, `runs stats` |
+| 获取结果 | `job result`, `runs logs` |
+| 操作动词 | `execute`, `deploy`, `undeploy`, `refill`, `rerun`, `stop` |
+| 连接测试 | `datasource test` |
+| 异步模式 | `sql --sync`（用 flag 控制，不拆分独立命令） |
+| 分页 | `--page` / `--page-size` 选项（不拆分独立命令） |
+| 别名 | `["detail", "show"]` 数组语法，`["logs", "log"]` |
+
+---
+
+## 审查发现（按严重程度排列）
+
+### 阻断级 — 与现有命令直接冲突
+
+| # | 文档当前写法 | 应改为 | 原因 |
+|---|---|---|---|
+| 1 | `datasource verify` | `datasource test` | 现有 `datasource test` 已实现连接验证，同一概念应用同一动词。 |
+| 2 | `datasource list-databases` | `datasource catalogs` | 现有 `datasource catalogs <datasource>` 使用名词形式。 |
+| 3 | `datasource list-tables` | `datasource objects` | 现有 `datasource objects <ds> <catalog>` 已实现该功能。 |
+| 4 | `datasource list-columns` | **删除**，用 `datasource describe` | 现有 `datasource describe <ds> <catalog> <object>` 已返回列详情。 |
+| 5 | `datasource preview-table` | `datasource preview` | 遵循 `table preview <name>` 模式，仅保留动词。 |
+| 6 | `session get-answer` | `session result` | 遵循 `job result` 模式，用名词表示获取输出。 |
+| 7 | `session poll-answer` | `session wait` | 遵循 `runs wait <id>` 模式。 |
+| 8 | `datasource search` | **删除**，用 `datasource list --search` | 现有 `datasource list` 已支持 `--name` 过滤，加 `--search` 即可。 |
+| 9 | `datasource load-async` | `datasource load --async` | 遵循 `sql --sync` 模式，用 flag 控制，不拆命令。 |
+| 10 | `metric search` | `metric list` + 过滤选项 | 同 #8。 |
+
+### 高优 — 动词-名词复合形式应改为资源优先
+
+| # | 文档当前写法 | 应改为 | 原因 |
+|---|---|---|---|
+| 11 | `domain add-table` | `domain table add` | 资源优先模式，table 是被操作的资源。 |
+| 12 | `domain remove-table` | `domain table remove` | 同上。 |
+| 13 | `domain discover-joins` | `domain joins discover` | 资源优先。 |
+| 14 | `domain apply-joins` | `domain joins apply` | 资源优先。 |
+| 15 | `domain get-discover-joins-result` | `domain joins result` | 5 个词 → 3 个词，过于冗长。 |
+| 16 | `domain add-relation` / `remove-relation` | `domain relation add` / `domain relation remove` | 资源优先。 |
+| 17 | `domain list-relations` | `domain relation list` | 资源优先。 |
+| 18 | `domain list-relations-by-target` | `domain relation list --target-type X --target-id Y` | 用选项代替复合名称。 |
+| 19 | `table set-semantics` | `table semantics set` | 资源优先。 |
+| 20 | `table get-semantics` | `table semantics get` | 资源优先。 |
+| 21 | `table set-semantics-prop` | `table semantics prop` | 连字符过多。 |
+| 22 | `table batch-detail` | `table semantics list` | 对齐 `list` 模式。 |
+| 23 | `column set-virtual` | `column virtual set` | 资源优先。 |
+| 24 | `column compile-virtual` | `column virtual compile` | 资源优先。 |
+| 25 | `column remove-virtual` | `column virtual delete` | 资源优先，且 `remove` → `delete`。 |
+| 26 | `column list-virtual` | `column virtual list` | 资源优先。 |
+| 27 | `datasource query-tables` | `datasource tables` 或合并到 `objects` | 动词-名词复合形式。 |
+
+### 高优 — `--safe`/`--open`/`--paged` 等模式变体应改用 flag
+
+| # | 文档当前写法 | 应改为 | 原因 |
+|---|---|---|---|
+| 28 | `session create-safe` | `session create` | 当前 open flow 固定创建 safe session，不再暴露 safe 模式开关。 |
+| 29 | `session open` / `open-paged` | `session list --page N --page-size M` | 分页在现有 `datasource list` 中通过选项控制。 |
+| 30 | `session run-open` | `session run` | 当前 open flow 固定调用 `/open/text2insight/query`，不再暴露 open 模式开关。 |
+| 31 | `session stop-open` | `session stop` | 当前 open flow 固定调用 `/open/text2insight/stop`。 |
+| 32 | `metric calculate-async` | `metric calculate --async` | 与 `load --async` 模式一致。 |
+
+### 高优 — 动词选择不一致
+
+| # | 文档当前写法 | 应改为 | 原因 |
+|---|---|---|---|
+| 33 | `knowledge add` | `knowledge create` | `add` 用于向父资源添加子项。创建独立资源用 `create`（`schema create`、`table create`、`profile create`、`task create`）。 |
+| 34 | `knowledge remove` | `knowledge delete` | `remove` 用于从父资源中移除。删除独立资源用 `delete` 或 `drop`（`profile delete`、`schema drop`）。 |
+| 35 | `tenant is-allowed` | `tenant status` 或 `tenant allowed` | 遵循 `workspace current` / `profile status` 模式。 |
+
+### 中优 — 结构 / 命名冲突
+
+| # | 问题 | 建议 |
+|---|---|---|
+| 36 | `datagpt table` 与顶层 `table` 命令冲突 | 用户容易混淆。顶层 `table` 管理数据库表（DESCRIBE、DROP 等），`datagpt table` 做语义配置。建议重命名为 `datagpt semantics`（其子命令就是 `set`/`get` 语义）或 `datagpt dataset`（API 已使用 `--dataset-id`）。 |
+| 37 | `datagpt domain delete` vs `schema drop` | `delete` 可以（与 `profile delete` 一致），但应在 DataGPT 内部保持一致，不要混用 `delete` 和 `remove`。 |
+| 38 | `answer-builder` 顶层含连字符 | `ai-guide` 已使用连字符，此处一致。但名称偏长，可考虑 `builder` 或 `answer`。 |
+| 39 | `knowledge maintain` | 文档中语义不明。如果是更新操作，应叫 `knowledge update`。 |
+
+---
+
+## 总结
+
+文档中的命名问题可归纳为四类：
+
+1. **同一概念、不同动词** — 应使用 cz-cli 已有动词：`verify`→`test`、`get-answer`→`result`、`poll-answer`→`wait`、`add`→`create`、`remove`→`delete`
+
+2. **动词-名词复合形式** — 应重组为资源优先的子命令结构：`add-table`→`table add`、`set-semantics`→`semantics set`、`set-virtual`→`virtual set`、`discover-joins`→`joins discover`、`list-relations`→`relation list`
+
+3. **模式变体拆分独立命令** — 应合并或内聚到固定 open flow：`*-async`→`--async`、`*-paged`→`--page`；session 的 safe/open 变体由当前 open API 路径固定承载，不再暴露为 CLI flag
+
+4. **冗余命令** — 应合并到已有模式：`search`→`list --filter`、`list-columns`→`describe`、`list-tables`→`objects`、`list-databases`→`catalogs`
+
+老板给出的 `ask`→`run` 示例正是此类修改的典型代表——同一概念在 cz-cli 中已有对应动词时，优先沿用。

--- a/packages/cz-cli/src/cli.ts
+++ b/packages/cz-cli/src/cli.ts
@@ -104,7 +104,7 @@ export function createCli(args: string[]) {
       const aiMessage = "Run the command with --help to see available options and usage."
       const message = (msg && msg.trim() !== "") ? msg : (() => {
         const KNOWN_FLAGS = new Set(["profile", "p", "jdbc", "pat", "username", "password", "service", "protocol", "instance", "workspace", "schema", "s", "vcluster", "v", "format", "field", "debug", "d", "help", "h", "version", "target", "t"])
-        const KNOWN_COMMANDS = new Set(["sql", "schema", "table", "workspace", "status", "profile", "task", "runs", "attempts", "job", "agent", "serve", "setup", "update", "datasource", "ai-gateway"])
+        const KNOWN_COMMANDS = new Set(["sql", "schema", "table", "workspace", "status", "profile", "task", "runs", "attempts", "job", "agent", "serve", "setup", "update", "datasource", "ai-gateway", "analytics-agent"])
         const unknownFlags = args.filter((a) => a.startsWith("-")).map((a) => a.replace(/^-+/, "").split("=")[0]).filter((a) => !KNOWN_FLAGS.has(a))
         if (unknownFlags.length > 0) return `Unknown argument: ${unknownFlags[0]}`
         const topLevelCmd = args.find((a) => !a.startsWith("-"))

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -362,6 +362,29 @@ function renderSummary(summary: string): string {
   return text.replace(/\*\*(.+?)\*\*/g, "$1").replace(/__(.+?)__/g, "$1").replace(/^#{1,6}\s+/gm, "")
 }
 
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+function startSpinner(label: string): { stop: () => void } {
+  if (!process.stderr.isTTY) return { stop: () => {} }
+  let frame = 0
+  const t0 = Date.now()
+  const write = (text: string) => process.stderr.write(text)
+  const render = () => {
+    const elapsed = ((Date.now() - t0) / 1000).toFixed(1)
+    const line = `\r${SPINNER_FRAMES[frame % SPINNER_FRAMES.length]} ${label} (${elapsed}s)`
+    write(line)
+    frame++
+  }
+  render()
+  const id = setInterval(render, 100)
+  return {
+    stop: () => {
+      clearInterval(id)
+      write("\r\x1b[K") // clear the spinner line
+    },
+  }
+}
+
 async function executeSessionRunCommand(
   name: string,
   argv: Record<string, unknown>,
@@ -390,11 +413,16 @@ async function executeSessionRunCommand(
     const pollBody = { questionId }
     const deadline = Date.now() + timeoutMs
     let payload: unknown
-    do {
-      payload = await requestAnalytics(argv, ROUTES.sessionResult, pollBody, {}, ctx)
-      if (isTerminalResponse(payload) || Date.now() >= deadline) break
-      await Bun.sleep(intervalMs)
-    } while (true)
+    const spinner = startSpinner("Agent 正在分析")
+    try {
+      do {
+        payload = await requestAnalytics(argv, ROUTES.sessionResult, pollBody, {}, ctx)
+        if (isTerminalResponse(payload) || Date.now() >= deadline) break
+        await Bun.sleep(intervalMs)
+      } while (true)
+    } finally {
+      spinner.stop()
+    }
     logOperation(name, { ok: true, timeMs: Date.now() - t0 })
     const summary = extractSummaryString(payload) ?? extractFinalSummary(payload)
     if (summary) {

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -290,6 +290,51 @@ function isTerminalResponse(payload: unknown): boolean {
   return ["finish", "finish_stop", "error"].includes(latestResponseDataType(payload))
 }
 
+async function executeSessionRunCommand(
+  name: string,
+  argv: Record<string, unknown>,
+  body: Record<string, unknown>,
+): Promise<void> {
+  const format = typeof argv.format === "string" ? argv.format : "json"
+  const timeoutMs = typeof argv["timeout-ms"] === "number" ? argv["timeout-ms"] : 360_000
+  const intervalMs = typeof argv["interval-ms"] === "number" ? argv["interval-ms"] : 2_000
+  const t0 = Date.now()
+  try {
+    const ctx = await resolveAnalyticsContext(argv)
+    const runPayload = await requestAnalytics(argv, ROUTES.sessionRun, body, {}, ctx)
+    const bizErr = extractBusinessError(runPayload)
+    if (bizErr) {
+      logOperation(name, { ok: false, timeMs: Date.now() - t0 })
+      error(bizErr.code, bizErr.message, { format })
+      return
+    }
+    const runData = unwrapResponse(runPayload) as Record<string, unknown>
+    const questionId = runData.questionId
+    if (!questionId) {
+      logOperation(name, { ok: false, timeMs: Date.now() - t0 })
+      error("ANALYTICS_AGENT_ERROR", "session run did not return a questionId", { format, extra: { response: runData } })
+      return
+    }
+    const pollBody = { questionId }
+    const deadline = Date.now() + timeoutMs
+    let payload: unknown
+    do {
+      payload = await requestAnalytics(argv, ROUTES.sessionResult, pollBody, {}, ctx)
+      if (isTerminalResponse(payload) || Date.now() >= deadline) break
+      await Bun.sleep(intervalMs)
+    } while (true)
+    logOperation(name, { ok: true, timeMs: Date.now() - t0 })
+    success(unwrapResponse(payload), { format, timeMs: Date.now() - t0 })
+  } catch (err) {
+    logOperation(name, { ok: false, timeMs: Date.now() - t0 })
+    if (isHandledCliError(err)) return
+    error("ANALYTICS_AGENT_ERROR", err instanceof Error ? err.message : String(err), {
+      format,
+      ...(err instanceof AnalyticsHttpError ? { extra: { request: err.request } } : {}),
+    })
+  }
+}
+
 async function executeAnalyticsCommand(
   name: string,
   argv: Record<string, unknown>,
@@ -701,13 +746,15 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
           )
           .command(
             "run [session-id]",
-            "Start a text2insight query in a session",
+            "Start a text2insight query and wait for the result",
             (y) =>
               y
                 .positional("session-id", { type: "number", describe: "Session ID" })
                 .option("domain-id", { type: "number", describe: "Domain ID" })
                 .option("msg", { type: "string", describe: "Question text" })
                 .option("model-name", { type: "string", describe: "Model name" })
+                .option("interval-ms", { type: "number", describe: "Polling interval in milliseconds" })
+                .option("timeout-ms", { type: "number", describe: "Polling timeout in milliseconds" })
                 .option("body", { type: "string", describe: "Full request body as JSON object" }),
             async (argv) => {
               const modelSettings = undefinedIfEmpty(mergeBody({}, {
@@ -719,7 +766,7 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 msg: argv.msg,
                 modelSettings,
               })
-              await executeAnalyticsCommand("analytics-agent session run", argv as Record<string, unknown>, ROUTES.sessionRun, body)
+              await executeSessionRunCommand("analytics-agent session run", argv as Record<string, unknown>, body)
             },
           )
           .command(

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -1,0 +1,683 @@
+import type { Argv } from "yargs"
+import { createTraceparent } from "@clickzetta/sdk"
+import type { GlobalArgs } from "../cli.js"
+import { commandGroup } from "../command-group.js"
+import { readAgentEndpoint } from "../connection/profile-store.js"
+import { success, error, handledError, isHandledCliError } from "../output/index.js"
+import { getStudioContext } from "./studio-context.js"
+import { logOperation } from "../logger.js"
+
+const ROUTES = {
+  datasourceTypes: { method: "GET", path: "/open/api/v1/datasources/types" },
+  datasourceSchema: { method: "GET", path: "/open/api/v1/datasources/schema" },
+  datasourceList: { method: "GET", path: "/open/api/v1/datasources" },
+  datasourceMeta: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/datasources/${encodePath(argv["datasource-id"])}/meta` },
+  datasourceBrowse: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/datasources/${encodePath(argv["datasource-id"])}/browse` },
+  datasourceSearchTables: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/datasources/${encodePath(argv["datasource-id"])}/tables/search` },
+  datasourceShowTable: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/datasources/${encodePath(argv["datasource-id"])}/tables/${encodePath(argv["table-name"])}` },
+  datasourceLoad: { method: "POST", path: (argv: Record<string, unknown>) => `/open/api/v1/datasources/${encodePath(argv["datasource-id"])}/load` },
+  datasourceCreate: { method: "POST", path: "/open/api/v1/datasources" },
+  datasourceUpdate: { method: "PUT", path: (argv: Record<string, unknown>) => `/open/api/v1/datasources/${encodePath(argv["datasource-id"])}` },
+  datasourceDelete: { method: "DELETE", path: (argv: Record<string, unknown>) => `/open/api/v1/datasources/${encodePath(argv["datasource-id"])}` },
+  datagptEnabled: { method: "GET", path: "/open/api/v1/analytics-agent/datagpt/enabled" },
+  domainList: { method: "GET", path: "/open/api/v1/analytics-agent/domains" },
+  domainCreate: { method: "POST", path: "/open/api/v1/analytics-agent/domains" },
+  domainUpdate: { method: "PUT", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}` },
+  domainDetail: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}` },
+  domainDelete: { method: "DELETE", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}` },
+  domainTableAdd: { method: "POST", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}/tables` },
+  sessionCreate: { method: "POST", path: "/open/session/safe_new", openSessionAuth: true },
+  sessionRun: { method: "POST", path: "/open/text2insight/query", openSessionAuth: true },
+  sessionResult: { method: "POST", path: "/open/safe_question_poll", openSessionAuth: true },
+  sessionStop: { method: "POST", path: "/open/text2insight/stop", openSessionAuth: true },
+} as const
+
+type AnalyticsRoute = {
+  method: string
+  path: string | ((argv: Record<string, unknown>) => string)
+  tenantIdQuery?: boolean
+  openSessionAuth?: boolean
+}
+
+interface AnalyticsRequestInfo {
+  method: string
+  path: string
+  query: Record<string, string>
+  tenantId: number | string
+  status?: number
+  requestId?: string
+}
+
+class AnalyticsHttpError extends Error {
+  constructor(
+    message: string,
+    readonly request: AnalyticsRequestInfo,
+  ) {
+    super(message)
+  }
+}
+
+function parseJsonObject(raw: string | undefined, fieldName: string): Record<string, unknown> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(`${fieldName} must be a JSON object`)
+    }
+    return parsed as Record<string, unknown>
+  } catch (err) {
+    throw new Error(`Invalid ${fieldName}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+function parseOptionalJsonObject(raw: string | undefined, fieldName: string): Record<string, unknown> | undefined {
+  if (!raw) return undefined
+  return parseJsonObject(raw, fieldName)
+}
+
+function parseJsonArray(raw: string | undefined, fieldName: string): unknown[] | undefined {
+  if (!raw) return undefined
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      throw new Error(`${fieldName} must be a JSON array`)
+    }
+    return parsed
+  } catch (err) {
+    throw new Error(`Invalid ${fieldName}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+function mergeBody(
+  body: Record<string, unknown>,
+  extra: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.entries(extra).reduce<Record<string, unknown>>(
+    (result, [key, value]) => (value === undefined ? result : { ...result, [key]: value }),
+    { ...body },
+  )
+}
+
+function undefinedIfEmpty(value: Record<string, unknown>): Record<string, unknown> | undefined {
+  return Object.keys(value).length === 0 ? undefined : value
+}
+
+function encodePath(value: unknown): string {
+  return encodeURIComponent(String(value ?? ""))
+}
+
+function normalizeEndpoint(value: string): string {
+  return value.replace(/\/+$/, "")
+}
+
+function routePath(route: AnalyticsRoute, argv: Record<string, unknown>): string {
+  return typeof route.path === "string" ? route.path : route.path(argv)
+}
+
+function buildUrl(
+  endpoint: string,
+  route: AnalyticsRoute,
+  argv: Record<string, unknown>,
+  query: Record<string, unknown>,
+  tenantId: number | string,
+): string {
+  const url = new URL(normalizeEndpoint(endpoint) + routePath(route, argv))
+  Object.entries({ ...(route.tenantIdQuery === false ? {} : { tenantId }), ...query }).forEach(([key, value]) => {
+    if (value !== undefined) url.searchParams.set(key, String(value))
+  })
+  return url.toString()
+}
+
+function requestInfo(
+  url: string,
+  route: AnalyticsRoute,
+  argv: Record<string, unknown>,
+  tenantId: number | string,
+  status?: number,
+  requestId?: string,
+): AnalyticsRequestInfo {
+  return {
+    method: route.method,
+    path: routePath(route, argv),
+    query: Object.fromEntries(new URL(url).searchParams.entries()),
+    tenantId,
+    ...(status !== undefined ? { status } : {}),
+    ...(requestId ? { requestId } : {}),
+  }
+}
+
+function responseRequestId(text: string): string | undefined {
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>
+    return typeof parsed.requestId === "string" ? parsed.requestId : undefined
+  } catch {
+    return undefined
+  }
+}
+
+async function requestAnalytics(
+  argv: Record<string, unknown>,
+  route: AnalyticsRoute,
+  body: Record<string, unknown>,
+  query: Record<string, unknown> = {},
+): Promise<unknown> {
+  const format = typeof argv.format === "string" ? argv.format : "json"
+  const endpoint = readAgentEndpoint(typeof argv.profile === "string" ? argv.profile : undefined)
+  if (!endpoint) {
+    handledError(
+      "NO_ANALYSIS_AGENT_ENDPOINT",
+      "No analysis agent endpoint configured for the active profile. Set profiles.<name>.analysis_agent_endpoint first.",
+      {
+        format,
+        extra: {
+          next_steps: [
+            "cz-cli profile update <profile> analysis_agent_endpoint <URL>",
+            "cz-cli profile create <name> ... --analysis-agent-endpoint <URL>",
+          ],
+        },
+      },
+    )
+  }
+
+  const studio = await getStudioContext(argv)
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    "x-clickzetta-token": studio.token,
+    Authorization: studio.token,
+    traceparent: createTraceparent(),
+    userId: String(studio.userId),
+    instanceId: String(studio.instanceId),
+    accountId: String(studio.tenantId),
+    tenantId: String(studio.tenantId),
+    instanceName: studio.instanceName,
+    workspaceName: studio.workspaceName,
+    workspaceId: String(studio.workspaceId),
+    projectId: String(studio.projectId),
+    ...studio.customHeaders,
+  }
+  const url = buildUrl(endpoint, route, argv, query, studio.tenantId)
+  const requestBody = route.openSessionAuth
+    ? mergeBody(body, { tenantId: studio.tenantId, userId: studio.userId, loginToken: studio.token })
+    : body
+  const response = await fetch(url, {
+    method: route.method,
+    headers,
+    ...(route.method === "GET" ? {} : { body: JSON.stringify(requestBody) }),
+    signal: AbortSignal.timeout(300_000),
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    throw new AnalyticsHttpError(
+      `HTTP ${response.status}: ${text.slice(0, 500)}`,
+      requestInfo(url, route, argv, studio.tenantId, response.status, responseRequestId(text)),
+    )
+  }
+  if (!text) return {}
+  try {
+    return JSON.parse(text)
+  } catch (err) {
+    throw new Error(`Invalid JSON response: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+function unwrapResponse(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return payload
+  const data = (payload as Record<string, unknown>).data
+  return data ?? payload
+}
+
+function latestResponseDataType(payload: unknown): string {
+  const data = unwrapResponse(payload)
+  if (!data || typeof data !== "object" || Array.isArray(data)) return ""
+  const responses = (data as Record<string, unknown>).responses
+  if (!Array.isArray(responses) || responses.length === 0) return ""
+  const latest = responses.at(-1)
+  if (!latest || typeof latest !== "object" || Array.isArray(latest)) return ""
+  const dataType = (latest as Record<string, unknown>).dataType
+  return typeof dataType === "string" ? dataType : ""
+}
+
+function isTerminalResponse(payload: unknown): boolean {
+  return ["finish", "finish_stop", "error"].includes(latestResponseDataType(payload))
+}
+
+async function executeAnalyticsCommand(
+  name: string,
+  argv: Record<string, unknown>,
+  route: AnalyticsRoute,
+  body: Record<string, unknown>,
+  query: Record<string, unknown> = {},
+): Promise<void> {
+  const format = typeof argv.format === "string" ? argv.format : "json"
+  const t0 = Date.now()
+  try {
+    const payload = await requestAnalytics(argv, route, body, query)
+    logOperation(name, { ok: true, timeMs: Date.now() - t0 })
+    success(unwrapResponse(payload), { format, timeMs: Date.now() - t0 })
+  } catch (err) {
+    logOperation(name, { ok: false, timeMs: Date.now() - t0 })
+    if (isHandledCliError(err)) return
+    error("ANALYTICS_AGENT_ERROR", err instanceof Error ? err.message : String(err), {
+      format,
+      ...(err instanceof AnalyticsHttpError ? { extra: { request: err.request } } : {}),
+    })
+  }
+}
+
+async function executeAnalyticsPollCommand(
+  name: string,
+  argv: Record<string, unknown>,
+  route: AnalyticsRoute,
+  body: Record<string, unknown>,
+  query: Record<string, unknown> = {},
+): Promise<void> {
+  const format = typeof argv.format === "string" ? argv.format : "json"
+  const timeoutMs = typeof argv["timeout-ms"] === "number" ? argv["timeout-ms"] : 360_000
+  const intervalMs = typeof argv["interval-ms"] === "number" ? argv["interval-ms"] : 2_000
+  const t0 = Date.now()
+  try {
+    const deadline = Date.now() + timeoutMs
+    const poll = async (): Promise<unknown> => {
+      const payload = await requestAnalytics(argv, route, body, query)
+      if (isTerminalResponse(payload) || Date.now() >= deadline) return payload
+      await Bun.sleep(intervalMs)
+      return poll()
+    }
+    const payload = await poll()
+    logOperation(name, { ok: true, timeMs: Date.now() - t0 })
+    success(unwrapResponse(payload), { format, timeMs: Date.now() - t0 })
+  } catch (err) {
+    logOperation(name, { ok: false, timeMs: Date.now() - t0 })
+    if (isHandledCliError(err)) return
+    error("ANALYTICS_AGENT_ERROR", err instanceof Error ? err.message : String(err), {
+      format,
+      ...(err instanceof AnalyticsHttpError ? { extra: { request: err.request } } : {}),
+    })
+  }
+}
+
+export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
+  cli.command("analytics-agent", "Analytics Agent APIs", (yargs) => {
+    yargs
+      .command("datasource", "Manage Analytics Agent datasources", (datasource) => {
+        datasource
+          .command(
+            "types",
+            "List supported datasource types",
+            (y) => y,
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent datasource types", argv as Record<string, unknown>, ROUTES.datasourceTypes, {})
+            },
+          )
+          .command(
+            "schema",
+            "Show datasource connection schema",
+            (y) =>
+              y.option("type", { type: "string", demandOption: true, describe: "Datasource type" }),
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent datasource schema", argv as Record<string, unknown>, ROUTES.datasourceSchema, {}, {
+                type: argv.type,
+              })
+            },
+          )
+          .command(
+            "list",
+            "List datasources",
+            (y) =>
+              y
+                .option("name", { type: "string", describe: "Filter by datasource name" })
+                .option("with-detail", { type: "boolean", describe: "Include datasource detail" }),
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent datasource list", argv as Record<string, unknown>, ROUTES.datasourceList, {}, {
+                name: argv.name,
+                withDetail: argv["with-detail"],
+              })
+            },
+          )
+          .command(
+            "meta <datasource-id>",
+            "Show datasource browse metadata",
+            (y) => y.positional("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" }),
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent datasource meta", argv as Record<string, unknown>, ROUTES.datasourceMeta, {})
+            },
+          )
+          .command(
+            "browse <datasource-id>",
+            "Browse datasource children",
+            (y) =>
+              y
+                .positional("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
+                .option("path", { type: "string", describe: "Browse path, for example workspace:w/schema:s" })
+                .option("name", { type: "string", describe: "Filter child names" })
+                .option("page-num", { type: "number", describe: "Page number" })
+                .option("page-size", { type: "number", describe: "Page size" }),
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent datasource browse", argv as Record<string, unknown>, ROUTES.datasourceBrowse, {}, {
+                path: argv.path,
+                name: argv.name,
+                pageNum: argv["page-num"],
+                pageSize: argv["page-size"],
+              })
+            },
+          )
+          .command(
+            "search-tables <datasource-id>",
+            "Search tables in a datasource",
+            (y) =>
+              y
+                .positional("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
+                .option("keyword", { type: "string", demandOption: true, describe: "Table search keyword" })
+                .option("path", { type: "string", describe: "Search path" })
+                .option("page-num", { type: "number", describe: "Page number" })
+                .option("page-size", { type: "number", describe: "Page size" }),
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent datasource search-tables", argv as Record<string, unknown>, ROUTES.datasourceSearchTables, {}, {
+                keyword: argv.keyword,
+                path: argv.path,
+                pageNum: argv["page-num"],
+                pageSize: argv["page-size"],
+              })
+            },
+          )
+          .command(
+            "show-table <datasource-id> <table-name>",
+            "Show datasource table metadata",
+            (y) =>
+              y
+                .positional("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
+                .positional("table-name", { type: "string", demandOption: true, describe: "Table name" })
+                .option("path", { type: "string", describe: "Table path" })
+                .option("include-columns", { type: "boolean", describe: "Include column metadata" })
+                .option("include-preview", { type: "boolean", describe: "Include preview rows" })
+                .option("preview-size", { type: "number", describe: "Preview row count" }),
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent datasource show-table", argv as Record<string, unknown>, ROUTES.datasourceShowTable, {}, {
+                path: argv.path,
+                includeColumns: argv["include-columns"],
+                includePreview: argv["include-preview"],
+                previewSize: argv["preview-size"],
+              })
+            },
+          )
+          .command(
+            "create",
+            "Create datasource",
+            (y) =>
+              y
+                .option("name", { type: "string", describe: "Datasource name" })
+                .option("type", { type: "string", describe: "Datasource type" })
+                .option("connection", { type: "string", describe: "Datasource connection JSON object" })
+                .option("validate-only", { type: "boolean", describe: "Validate connection without creating datasource" })
+                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+            async (argv) => {
+              const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                name: argv.name,
+                type: argv.type,
+                connection: parseOptionalJsonObject(argv.connection, "--connection"),
+                validateOnly: argv["validate-only"],
+              })
+              await executeAnalyticsCommand("analytics-agent datasource create", argv as Record<string, unknown>, ROUTES.datasourceCreate, body)
+            },
+          )
+          .command(
+            "update <datasource-id>",
+            "Update datasource",
+            (y) =>
+              y
+                .positional("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
+                .option("name", { type: "string", describe: "Datasource name" })
+                .option("type", { type: "string", describe: "Datasource type" })
+                .option("connection", { type: "string", describe: "Datasource connection JSON object" })
+                .option("validate-only", { type: "boolean", describe: "Validate connection without updating datasource" })
+                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+            async (argv) => {
+              const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                name: argv.name,
+                type: argv.type,
+                connection: parseOptionalJsonObject(argv.connection, "--connection"),
+                validateOnly: argv["validate-only"],
+              })
+              await executeAnalyticsCommand("analytics-agent datasource update", argv as Record<string, unknown>, ROUTES.datasourceUpdate, body)
+            },
+          )
+          .command(
+            "delete <datasource-id>",
+            "Delete datasource",
+            (y) => y.positional("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" }),
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent datasource delete", argv as Record<string, unknown>, ROUTES.datasourceDelete, {})
+            },
+          )
+          .command(
+            "load <datasource-id>",
+            "Load datasource table into Analytics Agent",
+            (y) =>
+              y
+                .positional("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
+                .option("path", { type: "string", describe: "Table path" })
+                .option("table-name", { type: "string", describe: "Table name" })
+                .option("display-name", { type: "string", describe: "Dataset display name" })
+                .option("description", { type: "string", describe: "Dataset description" })
+                .option("domain-ids", { type: "string", describe: "Domain IDs JSON array" })
+                .option("mode", { type: "number", describe: "Dataset mode" })
+                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+            async (argv) => {
+              const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                path: argv.path,
+                tableName: argv["table-name"],
+                displayName: argv["display-name"],
+                description: argv.description,
+                domainIds: parseJsonArray(argv["domain-ids"], "--domain-ids"),
+                mode: argv.mode,
+              })
+              await executeAnalyticsCommand("analytics-agent datasource load", argv as Record<string, unknown>, ROUTES.datasourceLoad, body)
+            },
+          )
+        return commandGroup(datasource, "analytics-agent datasource")
+      })
+      .command("domain", "Manage Analytics Agent domains", (domain) => {
+        domain
+          .command(
+            "list",
+            "List domains",
+            (y) => y.option("with-tables", { type: "boolean", describe: "Include bound tables" }),
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent domain list", argv as Record<string, unknown>, ROUTES.domainList, {}, {
+                withTables: argv["with-tables"],
+              })
+            },
+          )
+          .command(
+            "create",
+            "Create domain",
+            (y) =>
+              y
+                .option("name", { type: "string", describe: "Domain name" })
+                .option("description", { type: "string", describe: "Domain description" })
+                .option("datasource-id", { type: "number", describe: "Datasource ID" })
+                .option("sample-questions", { type: "string", describe: "Sample questions JSON array" })
+                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+            async (argv) => {
+              const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                name: argv.name,
+                description: argv.description,
+                datasourceId: argv["datasource-id"],
+                sampleQuestions: parseJsonArray(argv["sample-questions"], "--sample-questions"),
+              })
+              await executeAnalyticsCommand("analytics-agent domain create", argv as Record<string, unknown>, ROUTES.domainCreate, body)
+            },
+          )
+          .command(
+            "update <domain-id>",
+            "Update domain",
+            (y) =>
+              y
+                .positional("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
+                .option("name", { type: "string", describe: "Domain name" })
+                .option("description", { type: "string", describe: "Domain description" })
+                .option("datasource-id", { type: "number", describe: "Datasource ID" })
+                .option("sample-questions", { type: "string", describe: "Sample questions JSON array" })
+                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+            async (argv) => {
+              const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                name: argv.name,
+                description: argv.description,
+                datasourceId: argv["datasource-id"],
+                sampleQuestions: parseJsonArray(argv["sample-questions"], "--sample-questions"),
+              })
+              await executeAnalyticsCommand("analytics-agent domain update", argv as Record<string, unknown>, ROUTES.domainUpdate, body)
+            },
+          )
+          .command(
+            "detail <domain-id>",
+            "Show domain detail",
+            (y) =>
+              y
+                .positional("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
+                .option("with-tables", { type: "boolean", describe: "Include bound tables" }),
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent domain detail", argv as Record<string, unknown>, ROUTES.domainDetail, {}, {
+                withTables: argv["with-tables"],
+              })
+            },
+          )
+          .command(
+            "delete <domain-id>",
+            "Delete domain",
+            (y) => y.positional("domain-id", { type: "number", demandOption: true, describe: "Domain ID" }),
+            async (argv) => {
+              await executeAnalyticsCommand("analytics-agent domain delete", argv as Record<string, unknown>, ROUTES.domainDelete, {})
+            },
+          )
+          .command(
+            "table",
+            "Manage domain tables",
+            (table) => {
+              table.command(
+                "add <domain-id>",
+                "Add table to domain",
+                (y) =>
+                  y
+                    .positional("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
+                    .option("datasource-id", { type: "number", describe: "Datasource ID" })
+                    .option("path", { type: "string", describe: "Table path" })
+                    .option("table-name", { type: "string", describe: "Table name" })
+                    .option("display-name", { type: "string", describe: "Dataset display name" })
+                    .option("description", { type: "string", describe: "Dataset description" })
+                    .option("body", { type: "string", describe: "Full request body as JSON object" }),
+                async (argv) => {
+                  const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                    datasourceId: argv["datasource-id"],
+                    path: argv.path,
+                    tableName: argv["table-name"],
+                    displayName: argv["display-name"],
+                    description: argv.description,
+                  })
+                  await executeAnalyticsCommand("analytics-agent domain table add", argv as Record<string, unknown>, ROUTES.domainTableAdd, body)
+                },
+              )
+              return commandGroup(table, "analytics-agent domain table")
+            },
+          )
+        return commandGroup(domain, "analytics-agent domain")
+      })
+      .command("service", "Check Analytics Agent service capability", (service) => {
+        service.command(
+          "enabled",
+          "Check whether the current tenant has Analytics Agent enabled",
+          (y) => y,
+          async (argv) => {
+            await executeAnalyticsCommand("analytics-agent service enabled", argv as Record<string, unknown>, ROUTES.datagptEnabled, {})
+          },
+        )
+        return commandGroup(service, "analytics-agent service")
+      })
+      .command("session", "Manage Analytics Agent text2insight sessions", (session) => {
+        session
+          .command(
+            "create",
+            "Create a safe text2insight session",
+            (y) =>
+              y
+                .option("domain-id", { type: "number", describe: "Domain ID" })
+                .option("title", { type: "string", describe: "Session title" })
+                .option("source-type", { type: "string", describe: "Session sourceType" })
+                .option("source-id", { type: "number", describe: "Session sourceId" })
+                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+            async (argv) => {
+              const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                domainId: argv["domain-id"],
+                title: argv.title,
+                sourceType: argv["source-type"],
+                sourceId: argv["source-id"],
+              })
+              await executeAnalyticsCommand("analytics-agent session create", argv as Record<string, unknown>, ROUTES.sessionCreate, body)
+            },
+          )
+          .command(
+            "run [session-id]",
+            "Start a text2insight query in a session",
+            (y) =>
+              y
+                .positional("session-id", { type: "number", describe: "Session ID" })
+                .option("domain-id", { type: "number", describe: "Domain ID" })
+                .option("msg", { type: "string", describe: "Question text" })
+                .option("model-name", { type: "string", describe: "Model name" })
+                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+            async (argv) => {
+              const modelSettings = undefinedIfEmpty(mergeBody({}, {
+                model_name: argv["model-name"],
+              }))
+              const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                domainId: argv["domain-id"],
+                sessionId: argv["session-id"],
+                msg: argv.msg,
+                modelSettings,
+              })
+              await executeAnalyticsCommand("analytics-agent session run", argv as Record<string, unknown>, ROUTES.sessionRun, body)
+            },
+          )
+          .command(
+            "result [question-id]",
+            "Poll a text2insight question result",
+            (y) =>
+              y
+                .positional("question-id", { type: "number", describe: "Question ID" })
+                .option("wait", { type: "boolean", describe: "Poll until finish, finish_stop, error, or timeout" })
+                .option("interval-ms", { type: "number", describe: "Polling interval in milliseconds" })
+                .option("timeout-ms", { type: "number", describe: "Polling timeout in milliseconds" })
+                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+            async (argv) => {
+              const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                questionId: argv["question-id"],
+              })
+              if (argv.wait) {
+                await executeAnalyticsPollCommand("analytics-agent session result", argv as Record<string, unknown>, ROUTES.sessionResult, body)
+                return
+              }
+              await executeAnalyticsCommand("analytics-agent session result", argv as Record<string, unknown>, ROUTES.sessionResult, body)
+            },
+          )
+          .command(
+            "stop [session-id] [question-id]",
+            "Stop a running text2insight question",
+            (y) =>
+              y
+                .positional("session-id", { type: "number", describe: "Session ID" })
+                .positional("question-id", { type: "number", describe: "Question ID" })
+                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+            async (argv) => {
+              const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                sessionId: argv["session-id"],
+                questionId: argv["question-id"],
+              })
+              await executeAnalyticsCommand("analytics-agent session stop", argv as Record<string, unknown>, ROUTES.sessionStop, body)
+            },
+          )
+        return commandGroup(session, "analytics-agent session")
+      })
+    return commandGroup(yargs, "analytics-agent")
+  })
+}

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -26,6 +26,8 @@ const ROUTES = {
   domainDetail: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}` },
   domainDelete: { method: "DELETE", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}` },
   domainTableAdd: { method: "POST", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}/tables` },
+  domainTableRemove: { method: "DELETE", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}/tables/${encodePath(argv["table-id"])}` },
+  sessionList: { method: "POST", path: "/open/session/list" },
   sessionCreate: { method: "POST", path: "/open/session/safe_new", openSessionAuth: true },
   sessionRun: { method: "POST", path: "/open/text2insight/query", openSessionAuth: true },
   sessionResult: { method: "POST", path: "/open/safe_question_poll", openSessionAuth: true },
@@ -227,6 +229,42 @@ function unwrapResponse(payload: unknown): unknown {
   return data ?? payload
 }
 
+/**
+ * Analytics Agent backend always returns HTTP 200, using `success: false`
+ * inside the envelope to signal business errors. Detect that here so callers
+ * can route to the error path instead of the success path.
+ *
+ * The response can be either:
+ *   - `{data: {code, message, success: false, ...}}` (domain/datasource APIs)
+ *   - `{code, message, success: false, ...}` (already unwrapped by some routes)
+ */
+function extractBusinessError(payload: unknown): { code: string; message: string } | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null
+  const p = payload as Record<string, unknown>
+
+  // Case 1: top-level envelope — {data: {success: false, code, message}}
+  const inner = p.data
+  if (inner && typeof inner === "object" && !Array.isArray(inner)) {
+    const d = inner as Record<string, unknown>
+    if (d.success === false) {
+      return {
+        code: typeof d.code === "string" ? d.code : "ANALYTICS_AGENT_ERROR",
+        message: typeof d.message === "string" ? d.message : "Unknown error",
+      }
+    }
+  }
+
+  // Case 2: already-unwrapped — {success: false, code, message}
+  if (p.success === false) {
+    return {
+      code: typeof p.code === "string" ? p.code : "ANALYTICS_AGENT_ERROR",
+      message: typeof p.message === "string" ? p.message : "Unknown error",
+    }
+  }
+
+  return null
+}
+
 function latestResponseDataType(payload: unknown): string {
   const data = unwrapResponse(payload)
   if (!data || typeof data !== "object" || Array.isArray(data)) return ""
@@ -253,6 +291,12 @@ async function executeAnalyticsCommand(
   const t0 = Date.now()
   try {
     const payload = await requestAnalytics(argv, route, body, query)
+    const bizErr = extractBusinessError(payload)
+    if (bizErr) {
+      logOperation(name, { ok: false, timeMs: Date.now() - t0 })
+      error(bizErr.code, bizErr.message, { format })
+      return
+    }
     logOperation(name, { ok: true, timeMs: Date.now() - t0 })
     success(unwrapResponse(payload), { format, timeMs: Date.now() - t0 })
   } catch (err) {
@@ -578,6 +622,17 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                   await executeAnalyticsCommand("analytics-agent domain table add", argv as Record<string, unknown>, ROUTES.domainTableAdd, body)
                 },
               )
+              table.command(
+                "remove <domain-id> <table-id>",
+                "Remove table from domain",
+                (y) =>
+                  y
+                    .positional("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
+                    .positional("table-id", { type: "number", demandOption: true, describe: "Table ID" }),
+                async (argv) => {
+                  await executeAnalyticsCommand("analytics-agent domain table remove", argv as Record<string, unknown>, ROUTES.domainTableRemove, {})
+                },
+              )
               return commandGroup(table, "analytics-agent domain table")
             },
           )
@@ -596,6 +651,24 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
       })
       .command("session", "Manage Analytics Agent text2insight sessions", (session) => {
         session
+          .command(
+            "list",
+            "List text2insight sessions",
+            (y) =>
+              y
+                .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
+                .option("source-type", { type: "string", describe: "Session sourceType" })
+                .option("source-id", { type: "number", describe: "Session sourceId" })
+                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+            async (argv) => {
+              const body = mergeBody(parseJsonObject(argv.body, "--body"), {
+                domainId: argv["domain-id"],
+                sourceType: argv["source-type"],
+                sourceId: argv["source-id"],
+              })
+              await executeAnalyticsCommand("analytics-agent session list", argv as Record<string, unknown>, ROUTES.sessionList, body)
+            },
+          )
           .command(
             "create",
             "Create a safe text2insight session",

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -601,7 +601,7 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
             "Create a safe text2insight session",
             (y) =>
               y
-                .option("domain-id", { type: "number", describe: "Domain ID" })
+                .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
                 .option("title", { type: "string", describe: "Session title" })
                 .option("source-type", { type: "string", describe: "Session sourceType" })
                 .option("source-id", { type: "number", describe: "Session sourceId" })
@@ -640,11 +640,11 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
             },
           )
           .command(
-            "result [question-id]",
+            "result <question-id>",
             "Poll a text2insight question result",
             (y) =>
               y
-                .positional("question-id", { type: "number", describe: "Question ID" })
+                .positional("question-id", { type: "number", demandOption: true, describe: "Question ID" })
                 .option("wait", { type: "boolean", describe: "Poll until finish, finish_stop, error, or timeout" })
                 .option("interval-ms", { type: "number", describe: "Polling interval in milliseconds" })
                 .option("timeout-ms", { type: "number", describe: "Polling timeout in milliseconds" })

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -4,7 +4,7 @@ import type { GlobalArgs } from "../cli.js"
 import { commandGroup } from "../command-group.js"
 import { readAgentEndpoint } from "../connection/profile-store.js"
 import { success, error, handledError, isHandledCliError } from "../output/index.js"
-import { getStudioContext } from "./studio-context.js"
+import { getStudioContext, type StudioContext } from "./studio-context.js"
 import { logOperation } from "../logger.js"
 
 const ROUTES = {
@@ -157,12 +157,12 @@ function responseRequestId(text: string): string | undefined {
   }
 }
 
-async function requestAnalytics(
-  argv: Record<string, unknown>,
-  route: AnalyticsRoute,
-  body: Record<string, unknown>,
-  query: Record<string, unknown> = {},
-): Promise<unknown> {
+interface ResolvedContext {
+  endpoint: string
+  studio: StudioContext
+}
+
+async function resolveAnalyticsContext(argv: Record<string, unknown>): Promise<ResolvedContext> {
   const format = typeof argv.format === "string" ? argv.format : "json"
   const endpoint = readAgentEndpoint(typeof argv.profile === "string" ? argv.profile : undefined)
   if (!endpoint) {
@@ -180,8 +180,18 @@ async function requestAnalytics(
       },
     )
   }
-
   const studio = await getStudioContext(argv)
+  return { endpoint: endpoint!, studio }
+}
+
+async function requestAnalytics(
+  argv: Record<string, unknown>,
+  route: AnalyticsRoute,
+  body: Record<string, unknown>,
+  query: Record<string, unknown> = {},
+  ctx?: ResolvedContext,
+): Promise<unknown> {
+  const { endpoint, studio } = ctx ?? await resolveAnalyticsContext(argv)
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     Accept: "application/json",
@@ -321,14 +331,14 @@ async function executeAnalyticsPollCommand(
   const intervalMs = typeof argv["interval-ms"] === "number" ? argv["interval-ms"] : 2_000
   const t0 = Date.now()
   try {
+    const ctx = await resolveAnalyticsContext(argv)
     const deadline = Date.now() + timeoutMs
-    const poll = async (): Promise<unknown> => {
-      const payload = await requestAnalytics(argv, route, body, query)
-      if (isTerminalResponse(payload) || Date.now() >= deadline) return payload
+    let payload: unknown
+    do {
+      payload = await requestAnalytics(argv, route, body, query, ctx)
+      if (isTerminalResponse(payload) || Date.now() >= deadline) break
       await Bun.sleep(intervalMs)
-      return poll()
-    }
-    const payload = await poll()
+    } while (true)
     logOperation(name, { ok: true, timeMs: Date.now() - t0 })
     success(unwrapResponse(payload), { format, timeMs: Date.now() - t0 })
   } catch (err) {

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -3,7 +3,8 @@ import { createTraceparent } from "@clickzetta/sdk"
 import type { GlobalArgs } from "../cli.js"
 import { commandGroup } from "../command-group.js"
 import { readAgentEndpoint } from "../connection/profile-store.js"
-import { success, error, handledError, isHandledCliError } from "../output/index.js"
+import { success, error, handledError, isHandledCliError, shouldColorize } from "../output/index.js"
+import { formatMarkdown } from "../output/formatter.js"
 import { getStudioContext, type StudioContext } from "./studio-context.js"
 import { logOperation } from "../logger.js"
 
@@ -290,12 +291,83 @@ function isTerminalResponse(payload: unknown): boolean {
   return ["finish", "finish_stop", "error"].includes(latestResponseDataType(payload))
 }
 
+function extractModelMessage(entry: unknown): string | undefined {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return undefined
+  const e = entry as Record<string, unknown>
+  const modelRes = e.modelRes
+  if (!modelRes || typeof modelRes !== "object" || Array.isArray(modelRes)) return undefined
+  const data = (modelRes as Record<string, unknown>).data
+  if (!data || typeof data !== "object" || Array.isArray(data)) return undefined
+  const message = (data as Record<string, unknown>).message
+  return typeof message === "string" ? message : undefined
+}
+
+/**
+ * Extract the final text summary from a completed session run response.
+ *
+ * Strategy:
+ * 1. Group responses by resGroupId, take the entries belonging to the latest group.
+ * 2. Within that group, prefer the last entry whose dataType is "summary".
+ *    Fall back to the last entry whose dataType is "message".
+ * 3. Return the modelRes.data.message string from that entry.
+ */
+function extractFinalSummary(payload: unknown): string | undefined {
+  const data = unwrapResponse(payload)
+  if (!data || typeof data !== "object" || Array.isArray(data)) return undefined
+  const responses = (data as Record<string, unknown>).responses
+  if (!Array.isArray(responses) || responses.length === 0) return undefined
+
+  // Find the latest resGroupId
+  let latestGroupId: unknown
+  for (const entry of responses) {
+    if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+      latestGroupId = (entry as Record<string, unknown>).resGroupId
+    }
+  }
+
+  // Filter to only entries in the latest group
+  const latestGroup = responses.filter(
+    (entry) =>
+      entry &&
+      typeof entry === "object" &&
+      !Array.isArray(entry) &&
+      (entry as Record<string, unknown>).resGroupId === latestGroupId,
+  )
+
+  // Prefer last "summary" entry, fall back to last "message" entry
+  let summaryEntry: unknown
+  let messageEntry: unknown
+  for (const entry of latestGroup) {
+    const dataType = (entry as Record<string, unknown>).dataType
+    if (dataType === "summary") summaryEntry = entry
+    if (dataType === "message") messageEntry = entry
+  }
+
+  const target = summaryEntry ?? messageEntry
+  return extractModelMessage(target)
+}
+
+/** Extract summary when the payload is simply {data: "<string>"}. */
+function extractSummaryString(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined
+  const data = (payload as Record<string, unknown>).data
+  return typeof data === "string" ? data : undefined
+}
+
+function renderSummary(summary: string): string {
+  // The backend encodes newlines as literal "\n" (two chars) inside the JSON string.
+  const text = summary.replace(/\\n/g, "\n")
+  if (shouldColorize()) return formatMarkdown(text)
+  // Non-TTY: strip markdown syntax, keep plain text
+  return text.replace(/\*\*(.+?)\*\*/g, "$1").replace(/__(.+?)__/g, "$1").replace(/^#{1,6}\s+/gm, "")
+}
+
 async function executeSessionRunCommand(
   name: string,
   argv: Record<string, unknown>,
   body: Record<string, unknown>,
 ): Promise<void> {
-  const format = typeof argv.format === "string" ? argv.format : "json"
+  const format = typeof argv.format === "string" ? argv.format : undefined
   const timeoutMs = typeof argv["timeout-ms"] === "number" ? argv["timeout-ms"] : 360_000
   const intervalMs = typeof argv["interval-ms"] === "number" ? argv["interval-ms"] : 2_000
   const t0 = Date.now()
@@ -324,7 +396,16 @@ async function executeSessionRunCommand(
       await Bun.sleep(intervalMs)
     } while (true)
     logOperation(name, { ok: true, timeMs: Date.now() - t0 })
-    success(unwrapResponse(payload), { format, timeMs: Date.now() - t0 })
+    const summary = extractSummaryString(payload) ?? extractFinalSummary(payload)
+    if (summary) {
+      if (format === "json") {
+        process.stdout.write(summary + "\n")
+      } else {
+        process.stdout.write(renderSummary(summary) + "\n")
+      }
+    } else {
+      success(null, { format, timeMs: Date.now() - t0 })
+    }
   } catch (err) {
     logOperation(name, { ok: false, timeMs: Date.now() - t0 })
     if (isHandledCliError(err)) return
@@ -371,7 +452,7 @@ async function executeAnalyticsPollCommand(
   body: Record<string, unknown>,
   query: Record<string, unknown> = {},
 ): Promise<void> {
-  const format = typeof argv.format === "string" ? argv.format : "json"
+  const format = typeof argv.format === "string" ? argv.format : undefined
   const timeoutMs = typeof argv["timeout-ms"] === "number" ? argv["timeout-ms"] : 360_000
   const intervalMs = typeof argv["interval-ms"] === "number" ? argv["interval-ms"] : 2_000
   const t0 = Date.now()
@@ -385,7 +466,16 @@ async function executeAnalyticsPollCommand(
       await Bun.sleep(intervalMs)
     } while (true)
     logOperation(name, { ok: true, timeMs: Date.now() - t0 })
-    success(unwrapResponse(payload), { format, timeMs: Date.now() - t0 })
+    const summary = extractSummaryString(payload) ?? extractFinalSummary(payload)
+    if (summary) {
+      if (format === "json") {
+        process.stdout.write(summary + "\n")
+      } else {
+        process.stdout.write(renderSummary(summary) + "\n")
+      }
+    } else {
+      success(null, { format, timeMs: Date.now() - t0 })
+    }
   } catch (err) {
     logOperation(name, { ok: false, timeMs: Date.now() - t0 })
     if (isHandledCliError(err)) return
@@ -745,28 +835,61 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
             },
           )
           .command(
-            "run [session-id]",
+            "run",
             "Start a text2insight query and wait for the result",
             (y) =>
               y
-                .positional("session-id", { type: "number", describe: "Session ID" })
-                .option("domain-id", { type: "number", describe: "Domain ID" })
+                .option("session-id", { type: "number", describe: "Session ID (creates a new session if omitted)" })
+                .option("domain-id", { type: "number", describe: "Domain ID (required when --session-id is omitted)" })
                 .option("msg", { type: "string", describe: "Question text" })
                 .option("model-name", { type: "string", describe: "Model name" })
                 .option("interval-ms", { type: "number", describe: "Polling interval in milliseconds" })
                 .option("timeout-ms", { type: "number", describe: "Polling timeout in milliseconds" })
-                .option("body", { type: "string", describe: "Full request body as JSON object" }),
+                .option("body", { type: "string", describe: "Full request body as JSON object" })
+                .check((argv) => {
+                  if (!argv["session-id"] && !argv["domain-id"]) {
+                    throw new Error("--domain-id is required when --session-id is not provided")
+                  }
+                  return true
+                }),
             async (argv) => {
+              const argvRec = argv as Record<string, unknown>
+              const format = typeof argv.format === "string" ? argv.format : undefined
               const modelSettings = undefinedIfEmpty(mergeBody({}, {
                 model_name: argv["model-name"],
               }))
+              let sessionId: number | undefined = argv["session-id"]
+              if (!sessionId) {
+                try {
+                  const createPayload = await requestAnalytics(argvRec, ROUTES.sessionCreate, { domainId: argv["domain-id"] })
+                  const bizErr = extractBusinessError(createPayload)
+                  if (bizErr) {
+                    error(bizErr.code, bizErr.message, { format })
+                    return
+                  }
+                  const rawData = unwrapResponse(createPayload)
+                  // session create returns {data: "<sessionId string>"}
+                  const id = typeof rawData === "string" || typeof rawData === "number"
+                    ? rawData
+                    : (rawData as Record<string, unknown>)?.sessionId ?? (rawData as Record<string, unknown>)?.id
+                  if (!id) {
+                    error("ANALYTICS_AGENT_ERROR", "session create did not return a sessionId", { format })
+                    return
+                  }
+                  sessionId = Number(id)
+                } catch (err) {
+                  if (isHandledCliError(err)) return
+                  error("ANALYTICS_AGENT_ERROR", err instanceof Error ? err.message : String(err), { format })
+                  return
+                }
+              }
               const body = mergeBody(parseJsonObject(argv.body, "--body"), {
                 domainId: argv["domain-id"],
-                sessionId: argv["session-id"],
+                sessionId,
                 msg: argv.msg,
                 modelSettings,
               })
-              await executeSessionRunCommand("analytics-agent session run", argv as Record<string, unknown>, body)
+              await executeSessionRunCommand("analytics-agent session run", argvRec, body)
             },
           )
           .command(

--- a/packages/cz-cli/src/commands/profile.ts
+++ b/packages/cz-cli/src/commands/profile.ts
@@ -59,6 +59,7 @@ function parseJdbcUrl(jdbc: string): JdbcConfig | undefined {
 const VALID_UPDATE_KEYS = [
   "pat", "username", "password", "service", "protocol",
   "instance", "workspace", "schema", "vcluster",
+  "analysis_agent_endpoint",
 ]
 
 function loadFullFile(): Record<string, unknown> {
@@ -108,6 +109,9 @@ export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
                 instance: String(p.instance ?? ""),
                 workspace: String(p.workspace ?? ""),
                 is_default: name === defaultProfile,
+              }
+              if (typeof p.analysis_agent_endpoint === "string") {
+                entry.analysis_agent_endpoint = p.analysis_agent_endpoint
               }
               if (argv["show-secret"] && !pat && p.password) {
                 entry.password = String(p.password)
@@ -181,6 +185,7 @@ export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
             .option("workspace", { type: "string", describe: "Workspace name" })
             .option("schema", { type: "string", describe: "Default schema" })
             .option("vcluster", { type: "string", describe: "Virtual cluster" })
+            .option("analysis-agent-endpoint", { type: "string", describe: "Analysis agent endpoint" })
             .option("header", { type: "string", array: true, describe: "Custom HTTP header KEY=VALUE (repeatable)" })
             .option("skip-verify", { type: "boolean", default: false, describe: "Skip connection verification" }),
         async (argv) => {
@@ -221,6 +226,7 @@ export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
               workspace: ws,
               schema: argv.schema ?? jdbcCfg?.schema ?? "public",
               vcluster: argv.vcluster ?? jdbcCfg?.vcluster ?? "default",
+              ...(argv["analysis-agent-endpoint"] ? { analysis_agent_endpoint: argv["analysis-agent-endpoint"] } : {}),
             }
             if (hasPat) {
               profileObj.pat = argv.pat!
@@ -284,11 +290,11 @@ export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
       )
       .command(
         "update <name> <key> <value>",
-        `Update a profile field. Valid keys: pat, username, password, service, protocol, instance, workspace, schema, vcluster, header.<NAME>`,
+        `Update a profile field. Valid keys: pat, username, password, service, protocol, instance, workspace, schema, vcluster, analysis_agent_endpoint, header.<NAME>`,
         (y) =>
           y
             .positional("name", { type: "string", demandOption: true, describe: "Profile name" })
-            .positional("key", { type: "string", demandOption: true, describe: "Field to update: pat | username | password | service | protocol | instance | workspace | schema | vcluster | header.<NAME>" })
+            .positional("key", { type: "string", demandOption: true, describe: "Field to update: pat | username | password | service | protocol | instance | workspace | schema | vcluster | analysis_agent_endpoint | header.<NAME>" })
             .positional("value", { type: "string", demandOption: true, describe: "New value" }),
         (argv) => {
           const format = argv.format

--- a/packages/cz-cli/src/commands/setup.ts
+++ b/packages/cz-cli/src/commands/setup.ts
@@ -235,6 +235,7 @@ function applyCredentialToProfiles(
         pat: String(cred.accessToken),
         service: String(cred.service ?? "dev-api.clickzetta.com"),
         protocol: String(cred.protocol ?? "https"),
+        ...(typeof cred.analysisAgentEndpoint === "string" ? { analysis_agent_endpoint: cred.analysisAgentEndpoint } : {}),
         ...(typeof cred.aimeshEndpointBaseUrl === "string" && { ai_gateway_url: String(cred.aimeshEndpointBaseUrl) }),
       },
     },
@@ -1727,6 +1728,7 @@ export function registerSetupCommand(cli: Argv<GlobalArgs>): void {
           pat: accessToken,
           service: (cred.service as string) ?? "dev-api.clickzetta.com",
           protocol: (cred.protocol as string) ?? "https",
+          ...(typeof cred.analysisAgentEndpoint === "string" ? { analysis_agent_endpoint: cred.analysisAgentEndpoint } : {}),
         }
         try {
           const data = loadFullFile()

--- a/packages/cz-cli/src/connection/profile-store.ts
+++ b/packages/cz-cli/src/connection/profile-store.ts
@@ -138,7 +138,12 @@ export function readAgentEndpoint(profileName?: string): string | undefined {
     const name = profileName ?? (data.default_profile as string | undefined) ?? Object.keys((data.profiles ?? {}) as Record<string, unknown>)[0]
     if (!name) return undefined
     const profiles = (data.profiles ?? {}) as Record<string, Record<string, unknown>>
-    const agent = profiles[name]?.agent as Record<string, unknown> | undefined
+    const profile = profiles[name]
+    if (!profile) return undefined
+    if (typeof profile.analysis_agent_endpoint === "string" && profile.analysis_agent_endpoint) {
+      return profile.analysis_agent_endpoint
+    }
+    const agent = profile.agent as Record<string, unknown> | undefined
     return (agent?.endpoint as string) || undefined
   } catch {
     return undefined

--- a/packages/cz-cli/src/output/formatter.ts
+++ b/packages/cz-cli/src/output/formatter.ts
@@ -1,3 +1,99 @@
+const ANSI_BOLD = "\x1b[1m"
+const ANSI_RESET = "\x1b[0m"
+const ANSI_DIM = "\x1b[2m"
+
+/**
+ * Render a markdown string to a human-readable terminal string.
+ * Handles: headings, bold, inline code, horizontal rules, and markdown tables.
+ * Falls back to plain text for anything else.
+ */
+export function formatMarkdown(text: string): string {
+  const lines = text.split("\n")
+  const out: string[] = []
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]
+
+    // Heading: ## Foo or ### Foo
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/)
+    if (headingMatch) {
+      out.push(ANSI_BOLD + renderInline(headingMatch[2]) + ANSI_RESET)
+      i++
+      continue
+    }
+
+    // Horizontal rule: --- or ===
+    if (/^(-{3,}|={3,})$/.test(line.trim())) {
+      out.push(ANSI_DIM + "─".repeat(60) + ANSI_RESET)
+      i++
+      continue
+    }
+
+    // Markdown table: collect header + separator + rows
+    if (line.trimStart().startsWith("|") && i + 1 < lines.length && /^\s*\|[-| :]+\|\s*$/.test(lines[i + 1])) {
+      const tableLines: string[] = [line]
+      i += 2 // skip separator
+      while (i < lines.length && lines[i].trimStart().startsWith("|")) {
+        tableLines.push(lines[i])
+        i++
+      }
+      out.push(renderMarkdownTable(tableLines))
+      continue
+    }
+
+    out.push(renderInline(line))
+    i++
+  }
+  return out.join("\n")
+}
+
+function renderInline(text: string): string {
+  // Bold: **text** or __text__
+  text = text.replace(/\*\*(.+?)\*\*/g, `${ANSI_BOLD}$1${ANSI_RESET}`)
+  text = text.replace(/__(.+?)__/g, `${ANSI_BOLD}$1${ANSI_RESET}`)
+  // Inline code: `code`
+  text = text.replace(/`([^`]+)`/g, `${ANSI_DIM}$1${ANSI_RESET}`)
+  return text
+}
+
+function splitTableRow(line: string): string[] {
+  return line
+    .replace(/^\s*\|/, "")
+    .replace(/\|\s*$/, "")
+    .split("|")
+    .map((c) => c.trim())
+}
+
+function renderMarkdownTable(tableLines: string[]): string {
+  if (tableLines.length === 0) return ""
+  const rows = tableLines.map(splitTableRow)
+  const colCount = Math.max(...rows.map((r) => r.length))
+  const colWidths: number[] = Array.from({ length: colCount }, () => 0)
+  for (const row of rows) {
+    for (let c = 0; c < colCount; c++) {
+      colWidths[c] = Math.max(colWidths[c], displayWidth(row[c] ?? ""))
+    }
+  }
+
+  const renderRow = (row: string[], bold: boolean): string => {
+    const cells = Array.from({ length: colCount }, (_, c) => {
+      const cell = row[c] ?? ""
+      const padded = padToWidth(cell, colWidths[c])
+      return bold ? `${ANSI_BOLD}${padded}${ANSI_RESET}` : padded
+    })
+    return "| " + cells.join(" | ") + " |"
+  }
+
+  const sep = "|-" + colWidths.map((w) => "-".repeat(w)).join("-+-") + "-|"
+  const result: string[] = []
+  result.push(renderRow(rows[0], true))
+  result.push(sep)
+  for (let r = 1; r < rows.length; r++) {
+    result.push(renderRow(rows[r], false))
+  }
+  return result.join("\n")
+}
+
 export function formatJson(data: unknown): string {
   return stringifyJson(data)
 }

--- a/packages/cz-cli/src/register-commands.ts
+++ b/packages/cz-cli/src/register-commands.ts
@@ -15,6 +15,7 @@ import { registerSetupCommand } from "./commands/setup.js"
 import { registerUpdateCommand } from "./commands/update.js"
 import { registerDatasourceCommand } from "./commands/datasource.js"
 import { registerGatewayCommand } from "./commands/ai-gateway.js"
+import { registerAnalyticsAgentCommand } from "./commands/analytics-agent.js"
 
 export function registerCommands(cli: Argv<GlobalArgs>): Argv<GlobalArgs> {
   registerSqlCommand(cli)
@@ -32,5 +33,6 @@ export function registerCommands(cli: Argv<GlobalArgs>): Argv<GlobalArgs> {
   registerUpdateCommand(cli)
   registerDatasourceCommand(cli)
   registerGatewayCommand(cli)
+  registerAnalyticsAgentCommand(cli)
   return cli
 }

--- a/packages/cz-cli/src/run-cli.ts
+++ b/packages/cz-cli/src/run-cli.ts
@@ -31,6 +31,7 @@ const PROFILE_REQUIRED_COMMANDS = new Set([
   "attempts",
   "job",
   "datasource",
+  "analytics-agent",
 ])
 
 const LLM_ONBOARDING = {

--- a/packages/cz-cli/test/e2e-command-surface.ts
+++ b/packages/cz-cli/test/e2e-command-surface.ts
@@ -5,7 +5,7 @@
  * Run: bun test/e2e-command-surface.ts
  */
 import { spawnSync } from "child_process"
-import { mkdirSync, rmSync } from "fs"
+import { mkdirSync, rmSync, writeFileSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
@@ -38,6 +38,26 @@ function withFakeHome() {
   const home = join(tmpdir(), `cz-surface-${Date.now()}-${Math.random().toString(36).slice(2)}`)
   mkdirSync(join(home, ".clickzetta"), { recursive: true })
   return { home, cleanup: () => rmSync(home, { recursive: true, force: true }) }
+}
+
+function withProfileButNoAnalysisEndpoint() {
+  const { home, cleanup } = withFakeHome()
+  writeFileSync(
+    join(home, ".clickzetta", "profiles.toml"),
+    [
+      'default_profile = "default"',
+      "",
+      "[profiles.default]",
+      'pat = "test-pat"',
+      'service = "cn-shanghai-alicloud.api.clickzetta.com"',
+      'instance = "test-instance"',
+      'workspace = "test-workspace"',
+      'schema = "public"',
+      'vcluster = "default"',
+      "",
+    ].join("\n"),
+  )
+  return { home, cleanup }
 }
 
 interface TestCase {
@@ -74,6 +94,12 @@ const noProfileCases = [
   ["job", "profile", "1"],
   ["datasource", "list"],
   ["datasource", "catalogs", "ds"],
+  ["analytics-agent", "datasource", "list"],
+  ["analytics-agent", "service", "enabled"],
+  ["analytics-agent", "session", "create"],
+  ["analytics-agent", "session", "run", "1"],
+  ["analytics-agent", "session", "result", "1"],
+  ["analytics-agent", "session", "stop", "1", "1"],
 ] as const
 
 const tests: TestCase[] = [
@@ -94,6 +120,23 @@ const tests: TestCase[] = [
           if (combined.includes("USAGE_ERROR") || combined.includes("INTERNAL_ERROR") || combined.includes("undefined is not an object")) {
             return { pass: false, detail: `${args.join(" ")} leaked internal/usage error` }
           }
+        }
+        return { pass: true }
+      } finally { cleanup() }
+    },
+  },
+  {
+    name: "ANALYTICS_AGENT: configured profile without analysis_agent_endpoint returns a dedicated config error",
+    run() {
+      const { home, cleanup } = withProfileButNoAnalysisEndpoint()
+      try {
+        const result = run(["analytics-agent", "service", "enabled"], { HOME: home, CLICKZETTA_TEST_HOME: home })
+        const combined = result.stdout + result.stderr
+        if (result.exitCode !== 1) {
+          return { pass: false, detail: `exit=${result.exitCode}` }
+        }
+        if (!expectCode(result.stdout, "NO_ANALYSIS_AGENT_ENDPOINT")) {
+          return { pass: false, detail: `unexpected output=${combined.slice(0, 200)}` }
         }
         return { pass: true }
       } finally { cleanup() }

--- a/packages/cz-cli/test/profile-store.test.ts
+++ b/packages/cz-cli/test/profile-store.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const previousHome = process.env.HOME
+const previousTestHome = process.env.CLICKZETTA_TEST_HOME
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.HOME
+  else process.env.HOME = previousHome
+  if (previousTestHome === undefined) delete process.env.CLICKZETTA_TEST_HOME
+  else process.env.CLICKZETTA_TEST_HOME = previousTestHome
+})
+
+function writeProfilesToml(content: string) {
+  const home = mkdtempSync(path.join(tmpdir(), "cz-cli-profile-store-"))
+  const clickzettaDir = path.join(home, ".clickzetta")
+  mkdirSync(clickzettaDir, { recursive: true })
+  writeFileSync(path.join(clickzettaDir, "profiles.toml"), content)
+  process.env.HOME = home
+  process.env.CLICKZETTA_TEST_HOME = home
+}
+
+describe("readAgentEndpoint", () => {
+  test("prefers profiles.<name>.analysis_agent_endpoint", async () => {
+    writeProfilesToml([
+      'default_profile = "default"',
+      "",
+      "[profiles.default]",
+      'analysis_agent_endpoint = "https://analysis-agent.clickzetta.com"',
+      "[profiles.default.agent]",
+      'endpoint = "https://legacy-agent.clickzetta.com"',
+      "",
+    ].join("\n"))
+
+    const { readAgentEndpoint } = await import(`../src/connection/profile-store.ts?${Date.now()}`)
+    expect(readAgentEndpoint()).toBe("https://analysis-agent.clickzetta.com")
+  })
+
+  test("falls back to profiles.<name>.agent.endpoint", async () => {
+    writeProfilesToml([
+      'default_profile = "default"',
+      "",
+      "[profiles.default]",
+      "[profiles.default.agent]",
+      'endpoint = "https://legacy-agent.clickzetta.com"',
+      "",
+    ].join("\n"))
+
+    const { readAgentEndpoint } = await import(`../src/connection/profile-store.ts?${Date.now()}`)
+    expect(readAgentEndpoint()).toBe("https://legacy-agent.clickzetta.com")
+  })
+})

--- a/packages/cz-cli/test/setup-credential-llm.test.ts
+++ b/packages/cz-cli/test/setup-credential-llm.test.ts
@@ -64,6 +64,7 @@ describe("setup --credential", () => {
       schema: "clickzetta_account",
       virtualCluster: "CXH_TEST_1",
       accessToken: "czt_test_pat",
+      analysisAgentEndpoint: "https://analysis-agent.clickzetta.com",
       apiKey: "ck_test_api_key",
       aimeshEndpointBaseUrl: "https://uat-aimesh.clickzetta.com/",
     })
@@ -88,6 +89,7 @@ describe("setup --credential", () => {
         pat: "czt_test_pat",
         service: "https://uat-api.clickzetta.com",
         protocol: "https",
+        analysis_agent_endpoint: "https://analysis-agent.clickzetta.com",
         ai_gateway_url: "https://uat-aimesh.clickzetta.com/",
       },
     })

--- a/packages/opencode/src/cli/cmd/setup.ts
+++ b/packages/opencode/src/cli/cmd/setup.ts
@@ -49,6 +49,7 @@ interface Credential {
   accessToken?: string
   apiKey?: string
   aimeshEndpointBaseUrl?: string
+  analysisAgentEndpoint?: string
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -78,6 +79,7 @@ export function applyCredentialToProfiles(
     ...(cred.service && { service: cred.service }),
     protocol: cred.service?.startsWith("http://") ? "http" : "https",
     ...(cred.username && { username: cred.username }),
+    ...(typeof cred.analysisAgentEndpoint === "string" && { analysis_agent_endpoint: cred.analysisAgentEndpoint }),
     ...(cred.aimeshEndpointBaseUrl && { ai_gateway_url: cred.aimeshEndpointBaseUrl }),
   }
 

--- a/packages/opencode/src/main.ts
+++ b/packages/opencode/src/main.ts
@@ -185,6 +185,7 @@ export async function main(args: string[], agentRuntime = false): Promise<number
     "job",
     "update",
     "datasource",
+    "analytics-agent",
   ])
   const PROFILE_REQUIRED_COMMANDS = new Set([
     "sql",
@@ -197,6 +198,7 @@ export async function main(args: string[], agentRuntime = false): Promise<number
     "attempts",
     "job",
     "datasource",
+    "analytics-agent",
   ])
   const isHelpOrEmpty = args.length === 0 || (args.length === 1 && ["--help", "-h"].includes(args[0]))
   const isForwardedCliCommand =


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change
- New feature

### What does this PR do?

Adds a new `analytics-agent` CLI command group that exposes the Analytics Agent (DataGPT) REST APIs via `cz-cli`.

The new command covers:

- **Datasource management** — list, create, update, delete datasources; browse schema, search/show tables, load data
- **Domain management** — list, create, update, delete domains; add/remove tables from a domain
- **Session operations** — list sessions, create a session (requires `--domain-id`), run a natural-language query (requires `--question-id`), poll for results, stop a query

Key implementation details:
- Session creation requires `domainId`; in-session queries require `questionId` — these constraints are enforced at the CLI argument level
- Session-related routes use a separate `openSessionAuth` token distinct from the standard API auth
- Route paths are constructed dynamically from CLI args with proper URL encoding
- Profile store extended to read `agentEndpoint` for routing analytics-agent requests separately from the main Lakehouse endpoint

### How did you verify your code works?

- Added e2e command surface test covering all new subcommands (`test/e2e-command-surface.ts`)
- Added `profile-store.test.ts` to cover `agentEndpoint` read logic
- Manually tested against a running Analytics Agent service

### Screenshots / recordings

N/A — CLI-only change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR