### PR TITLE
fix(task): 保存调度改为显式解析血缘

### DIFF
--- a/openspec/changes/archive/2026-06-16-add-task-dependency-output-parse-command/specs/task-dependency-output-parse/spec.md
+++ b/openspec/changes/archive/2026-06-16-add-task-dependency-output-parse-command/specs/task-dependency-output-parse/spec.md
@@ -34,23 +34,42 @@ The parse command MUST expose user-facing summaries for schedule dependencies an
 - **THEN** CLI MUST expose each output as a user-facing output summary
 - **AND** each output summary MUST include identifiers needed to understand the current task output, such as task ID, project ID, data file version, task name, output table name, referenced table name, and add method when present
 
-### Requirement: 保存调度配置时自动解析依赖和产出
-Save commands MUST automatically parse and save lineage for SQL and integration tasks without depending on `task lineage` command output.
+### Requirement: 保存调度配置时按配置解析依赖和产出
+Save commands MUST preserve existing lineage by default and MUST parse dependencies and output tables only when the user explicitly enables automatic lineage parsing.
 
-#### Scenario: 保存 cron 自动解析
+#### Scenario: 保存 cron 默认不自动解析
 - **WHEN** 用户执行 `cz-cli task save-cron <task>`
+- **AND** 用户没有传入 `--auto-lineage`
+- **THEN** CLI MUST NOT call `/ide-admin/v1/dataFileConfiguration/parseDataFileDependencyOut`
+- **AND** CLI MUST submit existing dependencies and output tables from saved configuration
+
+#### Scenario: 保存 cron 显式自动解析
+- **WHEN** 用户执行 `cz-cli task save-cron <task> --auto-lineage`
 - **AND** the task type is SQL or integration
 - **THEN** CLI MUST call `/ide-admin/v1/dataFileConfiguration/parseDataFileDependencyOut`
 - **AND** CLI MUST submit parsed dependencies as `dataFileInputListReqs`
 - **AND** CLI MUST submit parsed output tables as `dataFileOutputListReqs`
 - **AND** CLI MUST include top-level `ownerCnName` and `ownerEnName` when output tables are submitted
 
-#### Scenario: 保存非 cron 配置自动解析
+#### Scenario: 保存非 cron 配置默认不自动解析
 - **WHEN** 用户执行 `cz-cli task save-schedule <task>` 或 `cz-cli task save-config <task>`
+- **AND** 用户没有传入 `--auto-lineage`
+- **THEN** CLI MUST NOT call `/ide-admin/v1/dataFileConfiguration/parseDataFileDependencyOut`
+- **AND** CLI MUST submit existing dependencies and output tables from saved configuration unless the user explicitly overrides them
+
+#### Scenario: 保存非 cron 配置显式自动解析
+- **WHEN** 用户执行 `cz-cli task save-schedule <task> --auto-lineage` 或 `cz-cli task save-config <task> --auto-lineage`
 - **AND** the task type is SQL or integration
 - **THEN** CLI MUST call `/ide-admin/v1/dataFileConfiguration/parseDataFileDependencyOut`
 - **AND** CLI MUST submit parsed dependencies as `dataFileInputListReqs` unless the user explicitly passes `--deps clear` or `--deps replace`
 - **AND** CLI MUST submit parsed output tables as `dataFileOutputListReqs`
+
+#### Scenario: 手工设置任务产出
+- **WHEN** 用户执行 `cz-cli task save-cron <task> --outputs replace --output-tables <json>` 或 `cz-cli task save-config <task> --outputs replace --output-tables <json>`
+- **THEN** CLI MUST submit the provided output tables as `dataFileOutputListReqs`
+- **AND** CLI MUST mark the output table add method as manual when no add method is provided
+- **WHEN** 用户执行 `cz-cli task save-cron <task> --outputs clear` 或 `cz-cli task save-config <task> --outputs clear`
+- **THEN** CLI MUST submit an empty `dataFileOutputListReqs`
 
 #### Scenario: 保存调度配置时解析执行集群 ID
 - **WHEN** 用户保存调度配置 without `--vc-id`

--- a/openspec/specs/task-dependency-output-parse/spec.md
+++ b/openspec/specs/task-dependency-output-parse/spec.md
@@ -46,26 +46,48 @@ The parse command MUST expose user-facing summaries for schedule dependencies an
 - **THEN** CLI MUST expose each output as a user-facing output summary
 - **AND** each output summary MUST include identifiers needed to understand the current task output, such as task ID, project ID, data file version, task name, output table name, referenced table name, and add method when present
 
-### Requirement: 保存调度配置时自动解析依赖和产出
+### Requirement: 保存调度配置时按配置解析依赖和产出
 
-Save commands MUST automatically parse and save lineage for SQL and integration tasks without depending on `task lineage` command output.
+Save commands MUST preserve existing lineage by default and MUST parse dependencies and output tables only when the user explicitly enables automatic lineage parsing.
 
-#### Scenario: 保存 cron 自动解析
+#### Scenario: 保存 cron 默认不自动解析
 
 - **WHEN** 用户执行 `cz-cli task save-cron <task>`
+- **AND** 用户没有传入 `--auto-lineage`
+- **THEN** CLI MUST NOT call `/ide-admin/v1/dataFileConfiguration/parseDataFileDependencyOut`
+- **AND** CLI MUST submit existing dependencies and output tables from saved configuration
+
+#### Scenario: 保存 cron 显式自动解析
+
+- **WHEN** 用户执行 `cz-cli task save-cron <task> --auto-lineage`
 - **AND** the task type is SQL or integration
 - **THEN** CLI MUST call `/ide-admin/v1/dataFileConfiguration/parseDataFileDependencyOut`
 - **AND** CLI MUST submit parsed dependencies as `dataFileInputListReqs`
 - **AND** CLI MUST submit parsed output tables as `dataFileOutputListReqs`
 - **AND** CLI MUST include top-level `ownerCnName` and `ownerEnName` when output tables are submitted
 
-#### Scenario: 保存非 cron 配置自动解析
+#### Scenario: 保存非 cron 配置默认不自动解析
 
 - **WHEN** 用户执行 `cz-cli task save-schedule <task>` 或 `cz-cli task save-config <task>`
+- **AND** 用户没有传入 `--auto-lineage`
+- **THEN** CLI MUST NOT call `/ide-admin/v1/dataFileConfiguration/parseDataFileDependencyOut`
+- **AND** CLI MUST submit existing dependencies and output tables from saved configuration unless the user explicitly overrides them
+
+#### Scenario: 保存非 cron 配置显式自动解析
+
+- **WHEN** 用户执行 `cz-cli task save-schedule <task> --auto-lineage` 或 `cz-cli task save-config <task> --auto-lineage`
 - **AND** the task type is SQL or integration
 - **THEN** CLI MUST call `/ide-admin/v1/dataFileConfiguration/parseDataFileDependencyOut`
 - **AND** CLI MUST submit parsed dependencies as `dataFileInputListReqs` unless the user explicitly passes `--deps clear` or `--deps replace`
 - **AND** CLI MUST submit parsed output tables as `dataFileOutputListReqs`
+
+#### Scenario: 手工设置任务产出
+
+- **WHEN** 用户执行 `cz-cli task save-cron <task> --outputs replace --output-tables <json>` 或 `cz-cli task save-config <task> --outputs replace --output-tables <json>`
+- **THEN** CLI MUST submit the provided output tables as `dataFileOutputListReqs`
+- **AND** CLI MUST mark the output table add method as manual when no add method is provided
+- **WHEN** 用户执行 `cz-cli task save-cron <task> --outputs clear` 或 `cz-cli task save-config <task> --outputs clear`
+- **THEN** CLI MUST submit an empty `dataFileOutputListReqs`
 
 #### Scenario: 保存调度配置时解析执行集群 ID
 

--- a/packages/cz-cli/src/commands/task.ts
+++ b/packages/cz-cli/src/commands/task.ts
@@ -298,6 +298,44 @@ function parseDependencyTasks(raw: string, format: string | undefined, projectId
   })
 }
 
+function parseOutputTables(
+  raw: string,
+  format: string | undefined,
+  context: { projectId: number; fileId: number; taskName: string; ownerCnName?: unknown; ownerEnName?: unknown },
+): Record<string, unknown>[] {
+  const cleaned = raw.replace(/^'|'$/g, "")
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(cleaned)
+  } catch {
+    handledError("INVALID_ARGUMENTS", `--output-tables is not valid JSON: ${raw}`, { format })
+  }
+  if (!Array.isArray(parsed)) {
+    handledError("INVALID_ARGUMENTS", "--output-tables must be a JSON array", { format })
+  }
+  return parsed.map((item, index) => {
+    const record = isRecord(item) ? item : {}
+    const tableName = typeof item === "string"
+      ? item
+      : String(record.refTableName ?? record.ref_table_name ?? record.table ?? record.outputTableName ?? record.output_table_name ?? record.fileShowName ?? record.name ?? "")
+    const showName = typeof item === "string"
+      ? item
+      : String(record.outputTableName ?? record.output_table_name ?? record.fileShowName ?? record.name ?? tableName)
+    if (!tableName) handledError("INVALID_ARGUMENTS", `--output-tables[${index}]: output table name is required`, { format })
+    return {
+      projectId: Number(record.projectId ?? context.projectId),
+      dataFileId: Number(record.taskId ?? record.dataFileId ?? context.fileId),
+      dataFileVersion: Number(record.dataFileVersion ?? 0),
+      dataFileName: String(record.taskName ?? record.dataFileName ?? context.taskName),
+      ...(context.ownerCnName != null ? { ownerCnName: context.ownerCnName } : {}),
+      ...(context.ownerEnName != null ? { ownerEnName: context.ownerEnName } : {}),
+      fileShowName: showName,
+      refTableName: tableName,
+      parseType: Number(record.addMethod ?? record.add_method ?? record.parseType ?? 1),
+    }
+  })
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -317,18 +355,19 @@ function configList(value: unknown): Record<string, unknown>[] {
   return getObjectList(value).map((item) => ({ ...item }))
 }
 
-async function parseLineageForSave(sc: StudioConfig, fileId: number, schemaName: string, oldData: Record<string, unknown>) {
+async function parseLineageForSave(sc: StudioConfig, fileId: number, schemaName: string, oldData: Record<string, unknown>, autoLineage: boolean) {
   const detail = await getTaskDetail(sc, fileId)
   const detailData = isRecord(detail.data) ? detail.data : {}
   const detailObj = isRecord(detailData.taskDetail) ? detailData.taskDetail : detailData
   const fileType = Number(detailObj.fileType ?? detailData.fileType)
   const fallback = {
+    taskName: detailObj.dataFileName ?? detailObj.task_name ?? oldData.dataFileName ?? String(fileId),
     ownerCnName: detailObj.ownerCnName ?? detailData.ownerCnName,
     ownerEnName: detailObj.ownerEnName ?? detailData.ownerEnName,
     dataFileInputListReqs: configList(oldData.dataFileDependencyDTOS).map(normalizeDependencyStrategy),
     dataFileOutputListReqs: configList(oldData.fileOutputTableDTOS),
   }
-  if (!DEPENDENCY_OUTPUT_PARSE_TYPES.has(fileType)) return fallback
+  if (!autoLineage || !DEPENDENCY_OUTPUT_PARSE_TYPES.has(fileType)) return fallback
 
   const resp = await parseTaskDependencyOut(sc, {
     projectId: sc.projectId,
@@ -342,6 +381,7 @@ async function parseLineageForSave(sc: StudioConfig, fileId: number, schemaName:
   const dataFileOutputListReqs = configList(data.fileOutputTableDTOS)
   const firstOutput = dataFileOutputListReqs[0]
   return {
+    taskName: fallback.taskName,
     ownerCnName: firstOutput?.ownerCnName ?? fallback.ownerCnName,
     ownerEnName: firstOutput?.ownerEnName ?? fallback.ownerEnName,
     dataFileInputListReqs,
@@ -2676,7 +2716,10 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
             .option("cron", { type: "string", demandOption: true, describe: "Cron expression — ClickZetta uses 7-field format: second minute hour day month weekday year (e.g. '0 30 9 * * ? *' = daily 09:30)" })
             .option("vc", { type: "string", describe: "Virtual cluster code" })
             .option("vc-id", { type: "string", describe: "Virtual cluster ID" })
-            .option("schema", { type: "string", describe: "Schema name" }),
+            .option("schema", { type: "string", describe: "Schema name" })
+            .option("auto-lineage", { type: "boolean", describe: "Parse dependencies and output tables from task content before saving" })
+            .option("outputs", { type: "string", choices: ["keep", "replace", "clear"], describe: "Output table action" })
+            .option("output-tables", { type: "string", describe: "Output tables JSON array, e.g. '[{\"outputTableName\":\"ws.table\",\"refTableName\":\"ws.public.table\"}]'" }),
         async (argv) => {
           const format = argv.format
           try {
@@ -2703,7 +2746,19 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
             if (cronResult.uiParam.scheduleEndTime) oldConfigProps["scheduleEndTime"] = cronResult.uiParam.scheduleEndTime
 
             const schemaName = (argv.schema as string | undefined) ?? (oldData.schemaName as string | undefined) ?? "public"
-            const lineage = await parseLineageForSave(sc, fileId, schemaName, oldData)
+            const lineage = await parseLineageForSave(sc, fileId, schemaName, oldData, Boolean(argv["auto-lineage"]))
+            const outputsAction = (argv.outputs as string | undefined) ?? (argv["output-tables"] != null ? "replace" : undefined)
+            const outputTables = outputsAction === "clear"
+              ? []
+              : outputsAction === "replace"
+                ? parseOutputTables(String(argv["output-tables"] ?? "[]"), format, {
+                    projectId: sc.projectId,
+                    fileId,
+                    taskName: String(lineage.taskName),
+                    ownerCnName: lineage.ownerCnName,
+                    ownerEnName: lineage.ownerEnName,
+                  })
+                : lineage.dataFileOutputListReqs
             const vc = await resolveScheduleVc(sc, argv, oldData)
             const resp = await saveTaskConfig(sc, {
               dataFileId: fileId,
@@ -2726,7 +2781,7 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
               activeStartTime: formatIsoStartOfDay(oldData.activeStartTime as string | undefined),
               activeEndTime: formatIsoStartOfDay((oldData.activeEndTime as string | undefined) ?? "2099-01-01"),
               dataFileInputListReqs: lineage.dataFileInputListReqs,
-              dataFileOutputListReqs: lineage.dataFileOutputListReqs,
+              dataFileOutputListReqs: outputTables,
               configProperties: JSON.stringify(oldConfigProps),
             })
             logOperation("task save-cron", { ok: true })
@@ -2752,13 +2807,16 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
             .option("schema", { type: "string", describe: "Schema name" })
             .option("timeout", { type: "number", describe: "Execute timeout" })
             .option("timeout-unit", { type: "string", describe: "Timeout unit (m/s)" })
+            .option("auto-lineage", { type: "boolean", describe: "Parse dependencies and output tables from task content before saving" })
             .option("deps", { type: "string", choices: ["keep", "replace", "clear"], describe: "Dependency action" })
             .option("dep-tasks", { type: "string", describe: "Dependency tasks JSON array. Each item requires taskId (number) and taskName (string), e.g. '[{\"taskId\":123,\"taskName\":\"upstream_task\"}]'" })
+            .option("outputs", { type: "string", choices: ["keep", "replace", "clear"], describe: "Output table action" })
+            .option("output-tables", { type: "string", describe: "Output tables JSON array, e.g. '[{\"outputTableName\":\"ws.table\",\"refTableName\":\"ws.public.table\"}]'" })
             .option("param", { type: "array", string: true, describe: "Set task param: key=value (can repeat)" }),
         async (argv) => {
           const format = argv.format
           try {
-            const configOpts = ["retry-count", "retry-interval", "retry-unit", "rerun-property", "self-depends", "vc", "vcluster", "vc-id", "schema", "timeout", "timeout-unit", "deps", "param"] as const
+            const configOpts = ["retry-count", "retry-interval", "retry-unit", "rerun-property", "self-depends", "vc", "vcluster", "vc-id", "schema", "timeout", "timeout-unit", "auto-lineage", "deps", "outputs", "output-tables", "param"] as const
             if (!configOpts.some((k) => argv[k] != null)) {
               error("INVALID_ARGUMENTS", "At least one configuration option is required.", { format, exitCode: 2 })
               return
@@ -2779,9 +2837,21 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
                 explicitDeps = parseDependencyTasks(raw, format, sc.projectId)
               }
             }
-            const lineage = await parseLineageForSave(sc, fileId, schemaName || "public", oldData)
+            const lineage = await parseLineageForSave(sc, fileId, schemaName || "public", oldData, Boolean(argv["auto-lineage"]))
             const vc = await resolveScheduleVc(sc, argv, oldData)
             const deps = explicitDeps ?? lineage.dataFileInputListReqs
+            const outputsAction = (argv.outputs as string | undefined) ?? (argv["output-tables"] != null ? "replace" : undefined)
+            const outputTables = outputsAction === "clear"
+              ? []
+              : outputsAction === "replace"
+                ? parseOutputTables(String(argv["output-tables"] ?? "[]"), format, {
+                    projectId: sc.projectId,
+                    fileId,
+                    taskName: String(lineage.taskName),
+                    ownerCnName: lineage.ownerCnName,
+                    ownerEnName: lineage.ownerEnName,
+                  })
+                : lineage.dataFileOutputListReqs
 
             // Build paramValueList from --param, merging with existing
             const existingParams = (oldData.paramValueList as Record<string, unknown>[] | undefined) ?? []
@@ -2826,7 +2896,7 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
               executeTimeout: (argv.timeout as number | undefined) ?? (oldData.executeTimeout as number | undefined),
               executeTimeoutUnit: (argv["timeout-unit"] as string | undefined) ?? (oldData.executeTimeoutUnit as string | undefined) ?? "m",
               dataFileInputListReqs: deps,
-              dataFileOutputListReqs: lineage.dataFileOutputListReqs,
+              dataFileOutputListReqs: outputTables,
               configProperties: oldData.configProperties ?? "{}",
             })
             // Save params separately via saveTaskContent (paramValueList is stored with content, not config)

--- a/packages/cz-cli/test/e2e-help/runs-task-cases.ts
+++ b/packages/cz-cli/test/e2e-help/runs-task-cases.ts
@@ -108,7 +108,12 @@ export const runsTaskHelpCases: HelpCase[] = [
   {
     args: ["task", "save-config", "--help"],
     expectHeader: "cz-cli task save-config",
-    expectOptions: ["task", "--vc", "--retry-count"],
+    expectOptions: ["task", "--vc", "--retry-count", "--auto-lineage", "--outputs", "--output-tables"],
+  },
+  {
+    args: ["task", "save-cron", "--help"],
+    expectHeader: "cz-cli task save-cron",
+    expectOptions: ["task", "--cron", "--auto-lineage", "--outputs", "--output-tables"],
   },
   {
     args: ["task", "lineage", "--help"],

--- a/packages/cz-cli/test/task-save-config-validation.test.ts
+++ b/packages/cz-cli/test/task-save-config-validation.test.ts
@@ -20,6 +20,19 @@ const outputDtos = [
     parseType: 2,
   },
 ]
+const manualOutputDtos = [
+  {
+    projectId: 9,
+    dataFileId: 123,
+    dataFileVersion: 0,
+    dataFileName: "lineage_smoke",
+    ownerCnName: "owner-cn",
+    ownerEnName: "owner-en",
+    fileShowName: "ws.manual_output",
+    refTableName: "ws.public.manual_output",
+    parseType: 1,
+  },
+]
 const actualSdk = await import("@clickzetta/sdk")
 const actualResolver = await import("../src/resolver.ts")
 const actualDatasource = await import("../src/commands/datasource.ts")
@@ -144,6 +157,21 @@ afterAll(() => {
 })
 
 describe("task save-config dependency validation", () => {
+  test("requires at least one explicit save-config option", async () => {
+    const result = await execute("task save-config 123")
+    const json = firstJson(result.output)
+
+    expect(result.exitCode).toBe(2)
+    expect(json).toEqual({
+      error: {
+        code: "INVALID_ARGUMENTS",
+        message: "At least one configuration option is required.",
+      },
+    })
+    expect(saveCalls).toHaveLength(0)
+    expect(parseCalls).toHaveLength(0)
+  })
+
   test("fails fast when a dependency item is missing taskId", async () => {
     const result = await execute(`task save-config 123 --deps replace --dep-tasks '[{"taskName":"upstream"}]'`)
     const json = firstJson(result.output)
@@ -174,8 +202,24 @@ describe("task save-config dependency validation", () => {
     expect(parseCalls).toHaveLength(0)
   })
 
-  test("save-config automatically parses lineage and saves output table DTOs", async () => {
+  test("save-config keeps existing lineage unless auto-lineage is enabled", async () => {
     const result = await execute("task save-config 123 --retry-count 2")
+
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(parseCalls).toHaveLength(0)
+    expect(saveCalls[0]?.dataFileInputListReqs).toEqual([])
+    expect(saveCalls[0]?.dataFileOutputListReqs).toEqual(outputDtos)
+    expect(saveCalls[0]).toMatchObject({
+      ownerCnName: "owner-cn",
+      ownerEnName: "owner-en",
+      etlVcCode: "DEFAULT",
+      etlVcId: "vc-default-id",
+    })
+  })
+
+  test("save-config parses lineage only when auto-lineage is enabled", async () => {
+    const result = await execute("task save-config 123 --retry-count 2 --auto-lineage")
 
     if (result.exitCode !== 0) console.log(result.output)
     expect(result.exitCode).toBe(0)
@@ -202,8 +246,24 @@ describe("task save-config dependency validation", () => {
     })
   })
 
-  test("save-cron automatically parses lineage and resolves DEFAULT virtual cluster ID", async () => {
+  test("save-cron keeps existing lineage by default and resolves DEFAULT virtual cluster ID", async () => {
     const result = await execute('task save-cron 123 --cron "0 30 2 * * ? *"')
+
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(parseCalls).toHaveLength(0)
+    expect(saveCalls[0]?.dataFileInputListReqs).toEqual([])
+    expect(saveCalls[0]?.dataFileOutputListReqs).toEqual(outputDtos)
+    expect(saveCalls[0]).toMatchObject({
+      ownerCnName: "owner-cn",
+      ownerEnName: "owner-en",
+      etlVcCode: "DEFAULT",
+      etlVcId: "vc-default-id",
+    })
+  })
+
+  test("save-cron parses lineage only when auto-lineage is enabled", async () => {
+    const result = await execute('task save-cron 123 --cron "0 30 2 * * ? *" --auto-lineage')
 
     if (result.exitCode !== 0) console.log(result.output)
     expect(result.exitCode).toBe(0)
@@ -221,5 +281,23 @@ describe("task save-config dependency validation", () => {
       etlVcCode: "DEFAULT",
       etlVcId: "vc-default-id",
     })
+  })
+
+  test("save-config replaces output tables from manual output parameters", async () => {
+    const result = await execute(`task save-config 123 --outputs replace --output-tables '[{"outputTableName":"ws.manual_output","refTableName":"ws.public.manual_output"}]'`)
+
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(parseCalls).toHaveLength(0)
+    expect(saveCalls[0]?.dataFileOutputListReqs).toEqual(manualOutputDtos)
+  })
+
+  test("save-cron clears output tables from manual output action", async () => {
+    const result = await execute('task save-cron 123 --cron "0 30 2 * * ? *" --outputs clear')
+
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(parseCalls).toHaveLength(0)
+    expect(saveCalls[0]?.dataFileOutputListReqs).toEqual([])
   })
 })


### PR DESCRIPTION
## 摘要
- save-cron/save-config 默认保留已有依赖和任务产出，不再自动调用解析接口
- 新增 --auto-lineage，显式开启后才解析依赖和任务产出
- 新增 --outputs/--output-tables，支持手工替换或清空任务产出

## 验证
- cd packages/cz-cli && bun test test/task-save-config-validation.test.ts test/task-lineage.test.ts
- cd packages/cz-cli && bun test ./test/e2e-help.ts
- cd packages/cz-cli && bun typecheck
- openspec validate task-dependency-output-parse --strict
- openspec validate cli-command-routing --strict
- push hook: bun turbo typecheck 通过

## UAT 实测
- task: cluster_empty_repro_20260616173436
- save-cron 默认保存：parseDataFileDependencyOut 调用 0 次
- save-cron --auto-lineage：parseDataFileDependencyOut 调用 2 条 debug 记录（request + response）
- save-config --outputs replace：未调用解析接口，保存体 dataFileOutputListReqs[0].parseType=1
- restore：save-config --auto-lineage 后保存体 dataFileOutputListReqs[0].parseType=2