### PR TITLE
fix(llm): pin AIGW admin calls to Shanghai for alicloud regions

### DIFF
--- a/packages/cz-cli/src/commands/ai-gateway.ts
+++ b/packages/cz-cli/src/commands/ai-gateway.ts
@@ -9,6 +9,7 @@ import type { GlobalArgs } from "../cli.js"
 import { success, error, isHandledCliError } from "../output/index.js"
 import { logOperation } from "../logger.js"
 import { getGatewayContext, type GatewayContext } from "./studio-context.js"
+import { pinAlicloudAdminHost } from "../llm/clickzetta-rotation.js"
 
 // ── AIGW admin API paths ────────────────────────────────────────────────────
 // Portal-proxied endpoints (standard portal token auth):
@@ -46,9 +47,12 @@ export function setGatewayDebug(enabled: boolean) { _debug = enabled }
 
 /** Wrapper around studioRequest that logs roundtrip details when --debug is active. */
 async function gwRequest<T>(sc: StudioConfig, path: string, body: unknown): Promise<{ data: T; code: number | string; message?: string; count?: number }> {
+  // Admin virtual-key routes only exist on the Shanghai alicloud portal; pin
+  // the host there for alicloud regions while keeping the original token.
+  const adminSc = { ...sc, baseUrl: pinAlicloudAdminHost(sc.baseUrl) }
   if (_debug) process.stderr.write(`[debug] → POST ${path} ${JSON.stringify(body)}\n`)
   const t0 = Date.now()
-  const resp = await studioRequest<T>(sc, path, body)
+  const resp = await studioRequest<T>(adminSc, path, body)
   if (_debug) process.stderr.write(`[debug] ← ${Date.now() - t0}ms code=${resp.code} data=${JSON.stringify(resp.data)}\n`)
   return resp
 }

--- a/packages/cz-cli/src/llm/clickzetta-rotation.ts
+++ b/packages/cz-cli/src/llm/clickzetta-rotation.ts
@@ -85,6 +85,21 @@ export function inferAiGatewayUrl(profile: { service?: string; instance?: string
   return undefined
 }
 
+/**
+ * The AIGW virtual-key admin routes (`/llm-gateway-admin/*`) are only served
+ * by the Shanghai alicloud portal host — other alicloud regions (e.g. Beijing
+ * `cn-beijing-alicloud.api.clickzetta.com`) return 404 "Can not find suitable
+ * response". Virtual keys themselves are tenant-global, so for any
+ * `cn-<region>-alicloud.api.clickzetta.com` host we pin admin calls to the
+ * Shanghai host regardless of region. Non-alicloud hosts are left untouched.
+ */
+export function pinAlicloudAdminHost(baseUrl: string): string {
+  return baseUrl.replace(
+    /^(https?:\/\/)cn-[^.]+-alicloud\.api\.clickzetta\.com/,
+    "$1cn-shanghai-alicloud.api.clickzetta.com",
+  )
+}
+
 function randomAlias() {
   const bytes = crypto.getRandomValues(new Uint8Array(8))
   return AUTO_ALIAS_PREFIX + Array.from(bytes, (byte) => ALIAS_ALPHABET[byte % ALIAS_ALPHABET.length]).join("")
@@ -184,8 +199,11 @@ async function rotateEntry(input: {
   profile: string
 }) {
   const sc = await getGatewayContext({ profile: input.profile })
+  // Admin virtual-key routes only exist on the Shanghai alicloud portal; pin
+  // the host there for alicloud regions while keeping the original token.
+  const adminSc = { ...sc, baseUrl: pinAlicloudAdminHost(sc.baseUrl) }
   const alias = resolveRotationAlias(input.profile)
-  const listResp = await studioRequest<Array<Record<string, unknown>>>(sc, API.LIST, {
+  const listResp = await studioRequest<Array<Record<string, unknown>>>(adminSc, API.LIST, {
     pageIndex: 1,
     pageSize: 200,
     vApiKeyAlias: alias,
@@ -198,13 +216,13 @@ async function rotateEntry(input: {
       ? Number(existing.id)
       : Number(
           (
-            await studioRequest<number>(sc, API.SAVE, {
+            await studioRequest<number>(adminSc, API.SAVE, {
               vApiKeyAlias: alias,
               rateLimitConfigs: { quota_total: DEFAULT_QUOTA_TOTAL },
             })
           ).data,
         )
-  const keyResp = await studioRequest<string>(sc, `${API.GET}?id=${id}`, {})
+  const keyResp = await studioRequest<string>(adminSc, `${API.GET}?id=${id}`, {})
   const apiKey = String(keyResp.data)
   const entryName = writeRotatedKey({
     apiKey,

--- a/packages/cz-cli/test/clickzetta-rotation.test.ts
+++ b/packages/cz-cli/test/clickzetta-rotation.test.ts
@@ -65,6 +65,7 @@ mock.module("@clack/prompts", () => ({
 const {
   isClickzettaQuotaExhausted,
   maybeRotateExhaustedClickzettaLlm,
+  pinAlicloudAdminHost,
 } = await import("../src/llm/clickzetta-rotation.ts")
 
 beforeEach(() => {
@@ -272,5 +273,59 @@ describe("clickzetta key rotation", () => {
 
     expect(result).toBeUndefined()
     expect(studioCalls).toEqual([])
+  })
+
+  test("pins alicloud admin host to shanghai regardless of region", () => {
+    expect(pinAlicloudAdminHost("https://cn-beijing-alicloud.api.clickzetta.com")).toBe(
+      "https://cn-shanghai-alicloud.api.clickzetta.com",
+    )
+    expect(pinAlicloudAdminHost("https://cn-hangzhou-alicloud.api.clickzetta.com")).toBe(
+      "https://cn-shanghai-alicloud.api.clickzetta.com",
+    )
+    // already shanghai → unchanged
+    expect(pinAlicloudAdminHost("https://cn-shanghai-alicloud.api.clickzetta.com")).toBe(
+      "https://cn-shanghai-alicloud.api.clickzetta.com",
+    )
+    // non-alicloud hosts left untouched
+    expect(pinAlicloudAdminHost("https://ap-shanghai-tencentcloud.api.clickzetta.com")).toBe(
+      "https://ap-shanghai-tencentcloud.api.clickzetta.com",
+    )
+    expect(pinAlicloudAdminHost("https://uat-api.clickzetta.com")).toBe(
+      "https://uat-api.clickzetta.com",
+    )
+  })
+
+  test("routes admin calls to shanghai when profile service is a non-shanghai alicloud region", async () => {
+    writeFileSync(
+      profileFile,
+      [
+        'default_profile = "bj"',
+        "",
+        "[profiles.bj]",
+        'pat = "pat-bj"',
+        'instance = "inst-bj"',
+        'workspace = "ws-bj"',
+        'username = "BJ_TEST"',
+        'service = "cn-beijing-alicloud.api.clickzetta.com"',
+        'protocol = "https"',
+        'ai_gateway_url = "https://cn-shanghai-alicloud-aimesh.api.clickzetta.com/gateway/v1"',
+        "",
+      ].join("\n"),
+    )
+
+    const result = await maybeRotateExhaustedClickzettaLlm({
+      provider: "clickzetta",
+      status: 429,
+      detail:
+        "{\"code\":429,\"message\":\"Virtual key total quota exceeded: limit is 10000000 tokens for virtual key 'cz-code_auto_old', current usage: 10075371 tokens\"}",
+      approval: "auto",
+    })
+
+    expect(result?.rotated).toBe(true)
+    // every admin call must target the shanghai portal, not beijing
+    expect(studioCalls.length).toBeGreaterThan(0)
+    for (const call of studioCalls) {
+      expect(call.baseUrl).toBe("https://cn-shanghai-alicloud.api.clickzetta.com")
+    }
   })
 })


### PR DESCRIPTION
## Problem

The `/llm-gateway-admin/*` virtual-key routes are only served by the Shanghai alicloud portal. Non-Shanghai alicloud regions (e.g. `cn-beijing-alicloud.api.clickzetta.com`) return HTTP 404 `"Can not find suitable response"`, which broke runtime key rotation and the `ai-gateway` commands for those profiles.

## Fix

Add `pinAlicloudAdminHost()` to rewrite `cn-<region>-alicloud.api.clickzetta.com` → `cn-shanghai-alicloud.api.clickzetta.com`, applied to the admin `baseUrl` in `rotateEntry()` and `gwRequest()`.

Virtual keys are tenant-global, so the original token still authenticates; only the host the admin call targets changes. Token login, instance resolution, portal requests, and the `ai_gateway_url` / `base_url` derivation stay on the original region.
