### PR TITLE
fix(tui): keep copy-on-select toast visible and show char count

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -56,7 +56,11 @@ function init() {
 
   const toast = {
     show(options: ToastOptions) {
-      const { duration, ...currentToast } = options
+      // duration is optional on the type; the zod .default(5000) only applies on
+      // .parse(), not on direct show() calls. Without this fallback, callers that
+      // omit duration get setTimeout(fn, undefined) ≈ 0ms and the toast vanishes
+      // on the next tick (e.g. the copy-on-select "Copied" toast was never visible).
+      const { duration = 5000, ...currentToast } = options
       setStore("currentToast", currentToast)
       if (timeoutHandle) clearTimeout(timeoutHandle)
       timeoutHandle = setTimeout(() => {

--- a/packages/opencode/src/cli/cmd/tui/util/selection.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/selection.ts
@@ -14,8 +14,13 @@ export function copy(renderer: Renderer, toast: Toast): boolean {
   const text = renderer.getSelection()?.getSelectedText()
   if (!text) return false
 
+  // Report the character count so the user can tell the copy actually happened,
+  // and roughly how much was captured (matches the copy-on-select hint UX).
+  const count = [...text].length
+  const message = `Copied ${count} ${count === 1 ? "char" : "chars"} to clipboard`
+
   Clipboard.copy(text)
-    .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))
+    .then(() => toast.show({ message, variant: "info" }))
     .catch(toast.error)
 
   renderer.clearSelection()


### PR DESCRIPTION
## Problem

`copy-on-select` is enabled by default on macOS, so selecting text already copies it and calls `toast.show(...)`. But the "Copied" toast was never visible:

`toast.show()` destructured `duration` with no fallback, and the zod `.default(5000)` only applies on `.parse()`, not on direct `show()` calls. So `setTimeout(fn, undefined)` cleared the toast on the next tick — the user had no way to tell whether the copy happened.

## Fix

- **toast.tsx**: default `duration` to `5000` in the destructure, so the toast stays up for ~5s (also fixes every other toast that omits `duration`).
- **selection.ts**: report the character count — `Copied N chars to clipboard`. `[...text].length` counts by code point, so CJK/emoji are counted correctly.