### PR TITLE
feat(analytics-agent): session run 新增 --summary 输出推理过程

### DIFF
--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -3,7 +3,7 @@ import { createTraceparent } from "@clickzetta/sdk"
 import type { GlobalArgs } from "../cli.js"
 import { commandGroup } from "../command-group.js"
 import { readAgentEndpoint } from "../connection/profile-store.js"
-import { success, error, handledError, isHandledCliError, shouldColorize } from "../output/index.js"
+import { success, error, handledError, isHandledCliError, shouldColorize, renderOutput } from "../output/index.js"
 import { formatMarkdown } from "../output/formatter.js"
 import { getStudioContext, type StudioContext } from "./studio-context.js"
 import { logOperation } from "../logger.js"
@@ -362,6 +362,13 @@ function renderSummary(summary: string): string {
   return text.replace(/\*\*(.+?)\*\*/g, "$1").replace(/__(.+?)__/g, "$1").replace(/^#{1,6}\s+/gm, "")
 }
 
+function writeRenderedPayload(payload: unknown, format: string | undefined, field: string | undefined): void {
+  const output = renderOutput(payload, format, field)
+  if (output !== "") process.stdout.write(output + "\n")
+  ;(process as unknown as Record<string, unknown>).responseBytes = Buffer.byteLength(output, "utf-8")
+  process.exitCode = 0
+}
+
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
 function startSpinner(label: string): { stop: () => void } {
@@ -391,6 +398,8 @@ async function executeSessionRunCommand(
   body: Record<string, unknown>,
 ): Promise<void> {
   const format = typeof argv.format === "string" ? argv.format : undefined
+  const field = typeof argv.field === "string" ? argv.field : undefined
+  const formatted = argv.formatted === true
   const timeoutMs = typeof argv["timeout-ms"] === "number" ? argv["timeout-ms"] : 360_000
   const intervalMs = typeof argv["interval-ms"] === "number" ? argv["interval-ms"] : 2_000
   const t0 = Date.now()
@@ -423,7 +432,17 @@ async function executeSessionRunCommand(
     } finally {
       spinner.stop()
     }
+    const pollErr = extractBusinessError(payload)
+    if (pollErr) {
+      logOperation(name, { ok: false, timeMs: Date.now() - t0 })
+      error(pollErr.code, pollErr.message, { format })
+      return
+    }
     logOperation(name, { ok: true, timeMs: Date.now() - t0 })
+    if (!formatted) {
+      writeRenderedPayload(payload, format, field)
+      return
+    }
     const summary = extractSummaryString(payload) ?? extractFinalSummary(payload)
     if (summary) {
       if (format === "json") {
@@ -873,6 +892,7 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("model-name", { type: "string", describe: "Model name" })
                 .option("interval-ms", { type: "number", describe: "Polling interval in milliseconds" })
                 .option("timeout-ms", { type: "number", describe: "Polling timeout in milliseconds" })
+                .option("formatted", { type: "boolean", default: false, describe: "Show the formatted final answer instead of the full poll payload" })
                 .option("body", { type: "string", describe: "Full request body as JSON object" })
                 .check((argv) => {
                   if (!argv["session-id"] && !argv["domain-id"]) {

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -399,7 +399,7 @@ async function executeSessionRunCommand(
 ): Promise<void> {
   const format = typeof argv.format === "string" ? argv.format : undefined
   const field = typeof argv.field === "string" ? argv.field : undefined
-  const formatted = argv.formatted === true
+  const summaryOnly = argv.summary === true
   const timeoutMs = typeof argv["timeout-ms"] === "number" ? argv["timeout-ms"] : 360_000
   const intervalMs = typeof argv["interval-ms"] === "number" ? argv["interval-ms"] : 2_000
   const t0 = Date.now()
@@ -439,7 +439,7 @@ async function executeSessionRunCommand(
       return
     }
     logOperation(name, { ok: true, timeMs: Date.now() - t0 })
-    if (!formatted) {
+    if (!summaryOnly) {
       writeRenderedPayload(payload, format, field)
       return
     }
@@ -892,7 +892,7 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("model-name", { type: "string", describe: "Model name" })
                 .option("interval-ms", { type: "number", describe: "Polling interval in milliseconds" })
                 .option("timeout-ms", { type: "number", describe: "Polling timeout in milliseconds" })
-                .option("formatted", { type: "boolean", default: false, describe: "Show the formatted final answer instead of the full poll payload" })
+                .option("summary", { type: "boolean", default: false, describe: "Show the final answer instead of the full poll payload" })
                 .option("body", { type: "string", describe: "Full request body as JSON object" })
                 .check((argv) => {
                   if (!argv["session-id"] && !argv["domain-id"]) {

--- a/packages/cz-cli/test/analytics-agent-session-run.test.ts
+++ b/packages/cz-cli/test/analytics-agent-session-run.test.ts
@@ -132,7 +132,7 @@ describe("analytics-agent session run", () => {
     expect(JSON.parse(result.output.trim())).toEqual(pollPayload)
   })
 
-  test("shows the formatted final-summary output when --formatted is set", async () => {
+  test("shows the final-summary output when --summary is set", async () => {
     globalThis.fetch = mock(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url.includes("/open/text2insight/query")) {
@@ -169,7 +169,7 @@ describe("analytics-agent session run", () => {
       "7",
       "--msg",
       "hello",
-      "--formatted",
+      "--summary",
     ])
 
     expect(result.exitCode).toBe(0)

--- a/packages/cz-cli/test/analytics-agent-session-run.test.ts
+++ b/packages/cz-cli/test/analytics-agent-session-run.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+
+mock.module("../src/connection/profile-store.js", () => ({
+  readAgentEndpoint: () => "https://example.clickzetta.com",
+}))
+
+mock.module("../src/commands/studio-context.js", () => ({
+  getStudioContext: async () => ({
+    token: "studio-token",
+    instanceId: 11,
+    workspaceId: 22,
+    projectId: 33,
+    userId: 44,
+    tenantId: 55,
+    instanceName: "inst",
+    workspaceName: "ws",
+    env: "uat",
+    baseUrl: "https://example.clickzetta.com",
+    customHeaders: {},
+    userName: "tester",
+  }),
+}))
+
+mock.module("../src/logger.js", () => ({
+  logOperation: () => {},
+}))
+
+const { createCli } = await import("../src/cli.ts")
+const { registerAnalyticsAgentCommand } = await import("../src/commands/analytics-agent.ts")
+
+const originalFetch = globalThis.fetch
+const originalStdoutWrite = process.stdout.write.bind(process.stdout)
+const originalStderrWrite = process.stderr.write.bind(process.stderr)
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+async function runAnalyticsCli(args: string[]): Promise<{ exitCode: number; output: string }> {
+  const chunks: string[] = []
+  const savedExitCode = process.exitCode
+
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString())
+    return true
+  }) as typeof process.stdout.write
+
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString())
+    return true
+  }) as typeof process.stderr.write
+
+  process.exitCode = 0
+  try {
+    const cli = createCli(args)
+    registerAnalyticsAgentCommand(cli)
+    await cli.demandCommand(1, "").help().parseAsync()
+  } catch {
+    if (!process.exitCode) process.exitCode = 1
+  } finally {
+    process.stdout.write = originalStdoutWrite
+    process.stderr.write = originalStderrWrite
+  }
+
+  const exitCode = process.exitCode ?? 0
+  process.exitCode = savedExitCode ?? 0
+  return { exitCode, output: chunks.join("") }
+}
+
+describe("analytics-agent session run", () => {
+  beforeEach(() => {
+    process.exitCode = 0
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    process.stdout.write = originalStdoutWrite
+    process.stderr.write = originalStderrWrite
+    process.exitCode = 0
+  })
+
+  test("outputs the raw safe_question_poll payload by default", async () => {
+    const pollPayload = {
+      success: true,
+      data: {
+        questionId: 123,
+        responses: [
+          {
+            resGroupId: 1,
+            dataType: "thinking",
+            modelRes: { data: { message: "step 1" } },
+          },
+          {
+            resGroupId: 1,
+            dataType: "summary",
+            modelRes: { data: { message: "final answer" } },
+          },
+          {
+            resGroupId: 1,
+            dataType: "finish",
+            modelRes: { data: { message: "done" } },
+          },
+        ],
+      },
+    }
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/open/text2insight/query")) {
+        return jsonResponse({ data: { questionId: 123 } })
+      }
+      if (url.includes("/open/safe_question_poll")) {
+        return jsonResponse(pollPayload)
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "session",
+      "run",
+      "--session-id",
+      "7",
+      "--msg",
+      "hello",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(JSON.parse(result.output.trim())).toEqual(pollPayload)
+  })
+
+  test("shows the formatted final-summary output when --formatted is set", async () => {
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/open/text2insight/query")) {
+        return jsonResponse({ data: { questionId: 123 } })
+      }
+      if (url.includes("/open/safe_question_poll")) {
+        return jsonResponse({
+          success: true,
+          data: {
+            questionId: 123,
+            responses: [
+              {
+                resGroupId: 1,
+                dataType: "summary",
+                modelRes: { data: { message: "final answer" } },
+              },
+              {
+                resGroupId: 1,
+                dataType: "finish",
+                modelRes: { data: { message: "done" } },
+              },
+            ],
+          },
+        })
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "session",
+      "run",
+      "--session-id",
+      "7",
+      "--msg",
+      "hello",
+      "--formatted",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.output.trim()).toBe("final answer")
+  })
+})


### PR DESCRIPTION
 - 默认不传 --summary：直接输出 /open/safe_question_poll 的完整 JSON，包含推理过程和最终答案
  - 显式传 --summary：输出格式化后的最终答案，不含推理过程
  - --format 全局选项保留原有输出格式控制职责，两者不冲突
  - 新增 analytics-agent-session-run.test.ts 覆盖两条路径
  
  Issue for this PR
  Closes #

  Type of change
  - [x] New feature
  
  What does this PR do?
  session run 命令新增 --summary flag。默认输出 /open/safe_question_poll 的完整返回（含推理过程），显式传 --summary 时只输出格式化最终答案。

  How did you verify your code works?
  - bun test packages/cz-cli/test/analytics-agent-session-run.test.ts 2 pass
  - UAT: session run 默认输出完整 responses 数组（含推理过程）
  - UAT: session run --summary 只输出最终答案文本
  
  Checklist
  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR