### PR TITLE
fix: rename job performance tool to match MCP server

### DIFF
--- a/packages/cz-cli/src/commands/job-performance.ts
+++ b/packages/cz-cli/src/commands/job-performance.ts
@@ -132,7 +132,7 @@ export async function analyzeJobPerformance(options: AnalyzeJobOptions, debug?: 
   const client = new Client({ name: "cz-cli", version: VERSION })
   try {
     await client.connect(transport)
-    const result = await client.callTool({ name: "fetch_job_performance_data", arguments: args }, CallToolResultSchema, {
+    const result = await client.callTool({ name: "analyze_lakehouse_job", arguments: args }, CallToolResultSchema, {
       signal: options.signal,
       timeout: 120_000,
       resetTimeoutOnProgress: true,

--- a/packages/opencode/src/tool/job-performance.ts
+++ b/packages/opencode/src/tool/job-performance.ts
@@ -153,7 +153,7 @@ export async function callMcp(
   const client = new Client({ name: "cz-cli", version: InstallationVersion })
   try {
     await client.connect(transport)
-    const result = await client.callTool({ name: "fetch_job_performance_data", arguments: args }, CallToolResultSchema, {
+    const result = await client.callTool({ name: "analyze_lakehouse_job", arguments: args }, CallToolResultSchema, {
       signal,
       timeout: 120_000,
       resetTimeoutOnProgress: true,
@@ -170,7 +170,7 @@ export async function callMcp(
 }
 
 export const JobPerformanceTool = Tool.define(
-  "fetch_job_performance_data",
+  "analyze_lakehouse_job",
   Effect.gen(function* () {
     return {
       description: DESCRIPTION,
@@ -178,7 +178,7 @@ export const JobPerformanceTool = Tool.define(
       execute: (params: z.infer<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
           yield* ctx.ask({
-            permission: "fetch_job_performance_data",
+            permission: "analyze_lakehouse_job",
             patterns: [params.job_id ?? params.path ?? "*"],
             always: ["*"],
             metadata: { ...params },

--- a/packages/opencode/test/provider/copilot/convert-to-openai-responses-input.test.ts
+++ b/packages/opencode/test/provider/copilot/convert-to-openai-responses-input.test.ts
@@ -11,14 +11,14 @@ describe("convertToOpenAIResponsesInput", () => {
             {
               type: "tool-call",
               toolCallId: "call_jobperf",
-              toolName: "fetch_job_performance_data",
+              toolName: "analyze_lakehouse_job",
               input: { job_id: "2026012808001805432z9g3fx1sok" },
               providerExecuted: true,
             },
             {
               type: "tool-result",
               toolCallId: "call_jobperf",
-              toolName: "fetch_job_performance_data",
+              toolName: "analyze_lakehouse_job",
               output: { type: "text", value: "job profile summary" },
             },
           ],

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -584,7 +584,7 @@ it.live("job performance tool result is sent to the next model turn", () =>
           noReply: true,
           parts: [{ type: "text", text: "analyze job" }],
         })
-        yield* llm.tool("fetch_job_performance_data", { job_id: "2026012808001805432z9g3fx1sok" })
+        yield* llm.tool("analyze_lakehouse_job", { job_id: "2026012808001805432z9g3fx1sok" })
         yield* llm.text("second")
 
         const result = yield* prompt.loop({ sessionID: session.id })
@@ -926,7 +926,7 @@ it.live(
 )
 
 it.live(
-  "includes fetch_job_performance_data in prompt tool payload",
+  "includes analyze_lakehouse_job in prompt tool payload",
   () =>
     provideTmpdirServer(
       ({ llm }) =>
@@ -945,7 +945,7 @@ it.live(
 
           const inputs = yield* llm.inputs
           const tools = inputs[0]?.tools as Array<{ function?: { name?: string } }> | undefined
-          expect(tools?.some((item) => item.function?.name === "fetch_job_performance_data")).toBe(true)
+          expect(tools?.some((item) => item.function?.name === "analyze_lakehouse_job")).toBe(true)
         }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -17,12 +17,12 @@ afterEach(async () => {
 })
 
 describe("tool.registry", () => {
-  it.live("registers fetch_job_performance_data as a builtin tool", () =>
+  it.live("registers analyze_lakehouse_job as a builtin tool", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const registry = yield* ToolRegistry.Service
         const ids = yield* registry.ids()
-        expect(ids).toContain("fetch_job_performance_data")
+        expect(ids).toContain("analyze_lakehouse_job")
       }),
     ),
   )


### PR DESCRIPTION
MCP server (commit 4895be6) renamed `fetch_job_performance_data` → `analyze_lakehouse_job`.

cz-cli was still calling the old name, which would cause tool-not-found errors when connecting to the updated MCP server.

**Changes:**
- Renamed tool ID in `packages/opencode/src/tool/job-performance.ts`
- Renamed MCP callTool name in `packages/cz-cli/src/commands/job-performance.ts`
- Updated all test references