### PR TITLE
fix(profile): use shared JDBC parser in profile create

### DIFF
--- a/packages/cz-cli/src/commands/profile.ts
+++ b/packages/cz-cli/src/commands/profile.ts
@@ -9,52 +9,13 @@ import type { GlobalArgs } from "../cli.js"
 import { success, error } from "../output/index.js"
 import { logOperation } from "../logger.js"
 import { loadProfiles, saveProfiles, getDefaultProfileName, type ProfileEntry } from "../connection/profile-store.js"
+import { parseJdbcUrl } from "../connection/jdbc.js"
 import { registerBootstrapCommands } from "./profile-bootstrap.js"
 import { getExecContext, execSql, isQueryResult } from "./exec.js"
 import { VERSION } from "../version.js"
 
 const PROFILES_DIR = join(homedir(), ".clickzetta")
 const PROFILES_FILE = join(PROFILES_DIR, "profiles.toml")
-
-interface JdbcConfig {
-  instance: string
-  service: string
-  workspace: string
-  username?: string
-  password?: string
-  schema?: string
-  vcluster?: string
-  protocol?: string
-}
-
-function parseJdbcUrl(jdbc: string): JdbcConfig | undefined {
-  if (!jdbc.startsWith("jdbc:clickzetta://")) return undefined
-  try {
-    const url = new URL(jdbc.slice(5))
-    const host = url.hostname
-    if (!host) return undefined
-    const parts = host.split(".")
-    if (parts.length < 4) return undefined
-    const params = url.searchParams
-    const ws = url.pathname.replace(/^\//, "") || params.get("workspace") || ""
-    const cfg: JdbcConfig = {
-      instance: parts[0],
-      service: parts.slice(1).join("."),
-      workspace: ws,
-    }
-    if (params.has("username")) cfg.username = params.get("username")!
-    if (params.has("password")) cfg.password = params.get("password")!
-    if (params.has("schema")) cfg.schema = params.get("schema")!
-    if (params.has("virtualCluster")) cfg.vcluster = params.get("virtualCluster")!
-    if (params.has("protocol")) {
-      const p = params.get("protocol")!.toLowerCase()
-      cfg.protocol = p === "http" ? "http" : "https"
-    }
-    return cfg
-  } catch {
-    return undefined
-  }
-}
 
 const VALID_UPDATE_KEYS = [
   "pat", "username", "password", "service", "protocol",
@@ -197,7 +158,7 @@ export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
             if (profiles[name]) {
               return error("PROFILE_EXISTS", `Profile '${name}' already exists`, { format })
             }
-            let jdbcCfg: JdbcConfig | undefined
+            let jdbcCfg: Partial<import("@clickzetta/sdk").ConnectionConfig> | undefined
             if (argv.jdbc) {
               jdbcCfg = parseJdbcUrl(argv.jdbc)
               if (!jdbcCfg) {

--- a/packages/cz-cli/test/profile-jdbc.test.ts
+++ b/packages/cz-cli/test/profile-jdbc.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import { spawnSync } from "child_process"
+import { mkdtempSync, mkdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+function run(args: string[], home: string) {
+  const result = spawnSync("bun", ["./src/main.ts", ...args, "--format", "json"], {
+    cwd: import.meta.dir + "/..",
+    encoding: "utf-8",
+    env: { ...process.env, HOME: home, CLICKZETTA_TEST_HOME: home },
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  return { stdout: result.stdout ?? "", exitCode: result.status ?? 1 }
+}
+
+function firstJson(out: string) {
+  return JSON.parse(out.trim().split("\n")[0] ?? "{}") as Record<string, any>
+}
+
+test("profile create preserves port and vcluster from --jdbc (bug-38)", () => {
+  const home = mkdtempSync(join(tmpdir(), "cz-profile-jdbc-"))
+  mkdirSync(join(home, ".clickzetta"), { recursive: true })
+
+  const create = run([
+    "profile", "create", "prod",
+    "--jdbc", "jdbc:clickzetta://1923808b.10.155.2.214:8033/ab_test?username=ks_bjadmin&password=Ks20241228%23&schema=public&vcluster=DEFAULT&use_http=true",
+    "--protocol", "http",
+    "--skip-verify",
+  ], home)
+  expect(create.exitCode).toBe(0)
+
+  const detail = run(["profile", "detail", "prod"], home)
+  const d = firstJson(detail.stdout).data
+  // service must carry the port so the request hits :8033 (bug-37/bug-38)
+  expect(d.service).toBe("10.155.2.214:8033")
+  expect(d.vcluster).toBe("DEFAULT")
+  expect(d.instance).toBe("1923808b")
+  expect(d.workspace).toBe("ab_test")
+  expect(d.protocol).toBe("http")
+})


### PR DESCRIPTION
Reuse the shared parseJdbcUrl in profile create so the port, all vcluster aliases, and use_http are preserved.