### PR TITLE
feat(cli): support cookie-based authentication for profiles

### DIFF
--- a/packages/cz-cli/src/commands/exec.ts
+++ b/packages/cz-cli/src/commands/exec.ts
@@ -25,18 +25,90 @@ export interface ExecContext {
   clientOpts: ClientOptions
 }
 
+function getHeader(headers: Record<string, string> | undefined, name: string): string | undefined {
+  return Object.entries(headers ?? {}).find(([key]) => key.toLowerCase() === name.toLowerCase())?.[1]
+}
+
+function cookieValue(cookie: string, name: string): string | undefined {
+  const lowerName = name.toLowerCase()
+  const match = cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.slice(0, part.indexOf("=")).toLowerCase() === lowerName)
+  return match?.slice(match.indexOf("=") + 1)
+}
+
+function parseJwtPayload(token: string): Record<string, unknown> {
+  const payload = token.split(".")[1]
+  if (!payload) return {}
+  try {
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf-8")) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+function numeric(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value !== "string") return 0
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+async function resolveInstanceId(
+  baseUrl: string,
+  token: string,
+  accountId: number,
+  instanceName: string,
+  customHeaders?: Record<string, string>,
+): Promise<number> {
+  const response = await fetch(`${baseUrl}/clickzetta-portal/service/serviceInstanceList?accountId=${accountId}`, {
+    headers: { ...customHeaders, "x-clickzetta-token": token, Accept: "application/json" },
+  })
+  if (!response.ok) return 0
+  const payload = await response.json() as { data?: Array<Record<string, unknown>> }
+  const match = (payload.data ?? []).find((row) =>
+    String(row.name ?? row.instanceName ?? "") === instanceName
+    && numeric(row.serviceId ?? 1) === 1,
+  )
+  return numeric(match?.id ?? match?.instanceId)
+}
+
+async function getCookieToken(config: ConnectionConfig): Promise<AuthToken | undefined> {
+  const cookie = getHeader(config.customHeaders, "Cookie") ?? ""
+  const token = cookieValue(cookie, "X-ClickZetta-Token")
+  if (!token) return undefined
+  const payload = parseJwtPayload(token)
+  const userId = numeric(payload.userId ?? payload.user_id)
+  const accountId = numeric(payload.accountId ?? payload.tenantId ?? payload.tenant_id)
+  const exp = numeric(payload.exp)
+  const instanceId = numeric(payload.instanceId ?? payload.instance_id)
+    || numeric(getHeader(config.customHeaders, "Instanceid"))
+    || await resolveInstanceId(toServiceUrl(config.service, config.protocol), token, accountId, config.instance, config.customHeaders)
+  if (!instanceId) throw new Error(`Unable to resolve instance id for '${config.instance}' from cookie auth.`)
+  return {
+    token,
+    instanceId,
+    userId,
+    expireTimeMs: exp ? Math.max(0, exp * 1000 - Date.now()) : 0,
+    obtainedAt: Date.now(),
+  }
+}
+
 export async function getExecContext(args: Partial<CliArgs>): Promise<ExecContext> {
   const config = resolveConnectionConfig(args)
-  if (!config.pat && !(config.username && config.password)) {
-    throw new Error("Authentication required. Provide --pat or --username/--password, or run `cz-cli setup` to configure a connection profile.")
-  }
   if (!config.instance) {
     throw new Error("Instance is required. Provide --instance or configure it in your profile.")
   }
   if (!config.workspace) {
     throw new Error("Workspace is required. Provide --workspace or configure it in your profile.")
   }
-  const token = await getToken(config)
+  const token = await getCookieToken(config) ?? await (async () => {
+    if (!config.pat && !(config.username && config.password)) {
+      throw new Error("Authentication required. Provide --pat, --username/--password, or profile header.Cookie.")
+    }
+    return getToken(config)
+  })()
   // Persist userId to profile for telemetry (enduser.id). Fire-and-forget.
   if (token.userId) patchProfileUserId(args.profile, token.userId)
   const clientOpts: ClientOptions = {

--- a/packages/cz-cli/src/commands/profile.ts
+++ b/packages/cz-cli/src/commands/profile.ts
@@ -45,6 +45,37 @@ function maskSecret(val: string, prefixLen = 8): string {
   return val.length > prefixLen ? val.slice(0, prefixLen) + "****" : "****"
 }
 
+function maskProfileSecrets(profile: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...profile }
+  if (result.pat) result.pat = maskSecret(String(result.pat))
+  if (result.password) result.password = "******"
+  if (result.header && typeof result.header === "object" && !Array.isArray(result.header)) {
+    result.header = Object.fromEntries(
+      Object.entries(result.header as Record<string, unknown>).map(([key, value]) =>
+        key.toLowerCase() === "cookie" ? [key, maskSecret(String(value), 16)] : [key, value],
+      ),
+    )
+  }
+  return result
+}
+
+function hasCookieTokenHeader(headers: string[] | undefined): boolean {
+  return headers?.some((header) => {
+    const separator = header.indexOf("=")
+    if (separator <= 0) return false
+    if (header.slice(0, separator).trim().toLowerCase() !== "cookie") return false
+    return header
+      .slice(separator + 1)
+      .split(";")
+      .some((cookie) => {
+        const cookieSeparator = cookie.indexOf("=")
+        return cookieSeparator > 0
+          && cookie.slice(0, cookieSeparator).trim().toLowerCase() === "x-clickzetta-token"
+          && cookie.slice(cookieSeparator + 1).trim().length > 0
+      })
+  }) ?? false
+}
+
 export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
   cli.command("profile", "Manage connection profiles", (yargs) => {
     yargs
@@ -119,10 +150,7 @@ export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
               is_default: argv.name === defaultProfile,
               ...profile,
             }
-            if (!argv["show-secret"]) {
-              if (result.pat) result.pat = maskSecret(String(result.pat))
-              if (result.password) result.password = "******"
-            }
+            if (!argv["show-secret"]) Object.assign(result, maskProfileSecrets(result))
             logOperation("profile detail", { ok: true })
             success(result, { format })
           } catch (err) {
@@ -169,11 +197,12 @@ export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
             const resolvedPassword = argv.password ?? jdbcCfg?.password
             const hasPat = Boolean(argv.pat)
             const hasUserPwd = Boolean(resolvedUsername && resolvedPassword)
+            const headerAuth = hasCookieTokenHeader(argv.header as string[] | undefined)
             if (hasPat && (resolvedUsername || resolvedPassword)) {
               return error("INVALID_ARGUMENTS", "Cannot specify both --pat and --username/--password.", { format, exitCode: 2 })
             }
-            if (!hasPat && !hasUserPwd) {
-              return error("INVALID_ARGUMENTS", "Provide either --pat or both --username and --password.", { format, exitCode: 2 })
+            if (!hasPat && !hasUserPwd && !headerAuth) {
+              return error("INVALID_ARGUMENTS", "Provide either --pat, both --username and --password, or --header Cookie=...", { format, exitCode: 2 })
             }
             const inst = argv.instance ?? jdbcCfg?.instance ?? ""
             const ws = argv.workspace ?? jdbcCfg?.workspace ?? ""
@@ -191,7 +220,7 @@ export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
             }
             if (hasPat) {
               profileObj.pat = argv.pat!
-            } else {
+            } else if (hasUserPwd) {
               profileObj.username = resolvedUsername!
               profileObj.password = resolvedPassword!
             }
@@ -207,7 +236,7 @@ export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
                 profileObj.header = headerDict
               }
             }
-            if (!argv["skip-verify"]) {
+            if (!argv["skip-verify"] && !headerAuth) {
               try {
                 const verifyCfg: import("@clickzetta/sdk").ConnectionConfig = {
                   pat: String(profileObj.pat ?? ""),

--- a/packages/cz-cli/test/profile-cookie-auth.test.ts
+++ b/packages/cz-cli/test/profile-cookie-auth.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+function firstJson(output: string) {
+  return JSON.parse(output.trim().split("\n")[0] ?? "{}") as Record<string, unknown>
+}
+
+function data(output: string) {
+  return firstJson(output).data as Record<string, unknown>
+}
+
+function errorPayload(output: string) {
+  return firstJson(output).error as Record<string, unknown>
+}
+
+function jwt(payload: Record<string, unknown>) {
+  return [
+    "header",
+    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    "signature",
+  ].join(".")
+}
+
+function run(args: string[], home: string) {
+  const result = spawnSync("bun", ["./src/main.ts", ...args, "--format", "json"], {
+    cwd: import.meta.dir + "/..",
+    encoding: "utf-8",
+    env: { ...process.env, HOME: home, CLICKZETTA_TEST_HOME: home },
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  return { output: result.stdout ?? "", exitCode: result.status ?? 1 }
+}
+
+async function withHome<T>(name: string, run: (home: string) => Promise<T>) {
+  const previousHome = process.env.HOME
+  const previousTestHome = process.env.CLICKZETTA_TEST_HOME
+  const home = mkdtempSync(join(tmpdir(), name))
+  mkdirSync(join(home, ".clickzetta"), { recursive: true })
+  process.env.HOME = home
+  process.env.CLICKZETTA_TEST_HOME = home
+  try {
+    return await run(home)
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME
+    else process.env.HOME = previousHome
+    if (previousTestHome === undefined) delete process.env.CLICKZETTA_TEST_HOME
+    else process.env.CLICKZETTA_TEST_HOME = previousTestHome
+    await Bun.$`rm -rf ${home}`
+  }
+}
+
+test("profile create accepts Cookie header auth and masks it in profile detail", async () => {
+  await withHome("cz-profile-cookie-create-", async (home) => {
+    const token = jwt({ userId: 7, accountId: 3, instanceId: 86, exp: 4_102_444_800 })
+    const cookie = `X-ClickZetta-Token=${token}; other=value`
+
+    const create = run(["profile", "create", "cookie", "--service", "api.example.com", "--instance", "inst", "--workspace", "ws", "--header", `Cookie=${cookie}`], home)
+    expect(create.exitCode).toBe(0)
+
+    const detail = run(["profile", "detail", "cookie"], home)
+    expect(detail.exitCode).toBe(0)
+    expect(JSON.stringify(data(detail.output).header)).toContain("****")
+    expect(JSON.stringify(data(detail.output).header)).not.toContain(token)
+
+    const unmasked = run(["profile", "detail", "cookie", "--show-secret"], home)
+    expect(unmasked.exitCode).toBe(0)
+    expect(JSON.stringify(data(unmasked.output).header)).toContain(token)
+  })
+})
+
+test("profile create rejects Cookie header auth without X-ClickZetta-Token", async () => {
+  await withHome("cz-profile-cookie-missing-token-", async (home) => {
+    const create = run(["profile", "create", "cookie", "--service", "api.example.com", "--instance", "inst", "--workspace", "ws", "--header", "Cookie=theme=light"], home)
+
+    expect(create.exitCode).toBe(2)
+    expect(errorPayload(create.output).code).toBe("INVALID_ARGUMENTS")
+  })
+})
+
+test("getExecContext uses X-ClickZetta-Token from profile Cookie header", async () => {
+  await withHome("cz-profile-cookie-exec-", async (home) => {
+    const token = jwt({ userId: 7, accountId: 3, instanceId: 86, exp: 4_102_444_800 })
+    writeFileSync(
+      join(home, ".clickzetta", "profiles.toml"),
+      [
+        'default_profile = "cookie"',
+        "",
+        "[profiles.cookie]",
+        'service = "api.example.com"',
+        'protocol = "https"',
+        'instance = "inst"',
+        'workspace = "ws"',
+        "",
+        "[profiles.cookie.header]",
+        `"Cookie" = "theme=light; X-ClickZetta-Token=${token}"`,
+        "",
+      ].join("\n"),
+    )
+
+    const { getExecContext } = await import(`../src/commands/exec.ts?cookie-auth-${Date.now()}`)
+    const ctx = await getExecContext({})
+
+    expect(ctx.token.token).toBe(token)
+    expect(ctx.token.instanceId).toBe(86)
+    expect(ctx.token.userId).toBe(7)
+    expect(ctx.clientOpts.token).toBe(token)
+    expect(ctx.clientOpts.customHeaders.Cookie).toContain(token)
+    expect(ctx.clientOpts.customHeaders.instanceName).toBe("inst")
+  })
+})


### PR DESCRIPTION
Add cookie-based authentication as a third profile auth method, alongside PAT and username/password. A profile can carry an `X-ClickZetta-Token` inside a Cookie header, which is used directly to obtain an exec context.