### PR TITLE
fix(release): pin ghostty-web git dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
         "diff": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "catalog:",
-        "ghostty-web": "github:anomalyco/ghostty-web#main",
+        "ghostty-web": "github:anomalyco/ghostty-web#20bd3613f59dfc0f088a9aec498db2fa1a08b768",
         "luxon": "catalog:",
         "marked": "catalog:",
         "marked-shiki": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,7 +62,7 @@
     "diff": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
-    "ghostty-web": "github:anomalyco/ghostty-web#main",
+    "ghostty-web": "github:anomalyco/ghostty-web#20bd3613f59dfc0f088a9aec498db2fa1a08b768",
     "luxon": "catalog:",
     "marked": "catalog:",
     "marked-shiki": "catalog:",


### PR DESCRIPTION
- Pin `ghostty-web` to the commit already resolved in `bun.lock`
- Sync the lockfile dependency spec so frozen installs are reproducible
- Prevent release builds from resolving a moving Git branch during `bun install --frozen-lockfile`