### PR TITLE
fix: create-setup --description, schedule-info errors, REALTIME deploy guard

### DIFF
--- a/packages/cz-cli/src/commands/task.ts
+++ b/packages/cz-cli/src/commands/task.ts
@@ -1323,7 +1323,8 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
             .option("vc", { type: "string", describe: "Virtual cluster code, e.g. CZCODE_DI. Use 'cz-cli --vcluster <vc>' to set globally for the session." })
             .option("params", { type: "string", describe: 'Runtime parameters JSON. Values matching system param names (bizdate, sys_biz_day, sys_plan_day) are auto-detected. e.g. \'{"city":"beijing","dt":"bizdate"}\' — "beijing"=literal, "bizdate"=system param.' })
             .option("datasource", { type: "string", describe: "JDBC datasource name or ID to bind (JDBC tasks only)" })
-            .option("database", { type: "string", describe: "JDBC database/schema name (JDBC tasks only)" }),
+            .option("database", { type: "string", describe: "JDBC database/schema name (JDBC tasks only)" })
+            .option("description", { type: "string", describe: "Task description" }),
         async (argv) => {
           const format = argv.format
           try {

--- a/packages/cz-cli/src/commands/task.ts
+++ b/packages/cz-cli/src/commands/task.ts
@@ -2294,7 +2294,10 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
               } else if (fileType === 1) {
                 // INTEGRATION: check both fileContent (field mapping) and hasConfig (schedule)
                 const content = String(taskDetailInner?.fileContent ?? taskDetailData?.fileContent ?? "").trim()
-                if (!content || content.length < 10) {
+                // A valid INTEGRATION field-mapping JSON contains at least "jobs" key.
+                // Treat empty string, "null", "{}", "[]" or very short strings as unconfigured.
+                const hasContent = content.length > 10 && content !== "null" && content !== "[]" && content !== "{}"
+                if (!hasContent) {
                   error("NO_INTEGRATION_CONFIG",
                     `INTEGRATION task has no field mapping configured. Run:\n` +
                     `  cz-cli task integration setup ${fileId} --sync-type single --source-datasource <ds> --source-schema <db> --source-table <table> --sink-datasource <lh_ds>\n` +
@@ -2311,7 +2314,10 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
               } else if (fileType === 14) {
                 // REALTIME: use create-stream-sync which sets up source/target/schema in one step
                 const content = String(taskDetailInner?.fileContent ?? taskDetailData?.fileContent ?? "").trim()
-                if (!content || content.length < 10) {
+                // A valid INTEGRATION field-mapping JSON contains at least "jobs" key.
+                // Treat empty string, "null", "{}", "[]" or very short strings as unconfigured.
+                const hasContent = content.length > 10 && content !== "null" && content !== "[]" && content !== "{}"
+                if (!hasContent) {
                   error("NO_SYNC_CONFIG",
                     `REALTIME task not configured. Use 'cz-cli task create-stream-sync' to create and configure in one step, or open Studio to configure source/target manually: ${studioUrl(sc, fileId)}`,
                     { format, exitCode: 2 }); return

--- a/packages/cz-cli/src/commands/task.ts
+++ b/packages/cz-cli/src/commands/task.ts
@@ -2308,6 +2308,16 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
                     `Run: cz-cli task save-cron ${fileId} --cron '0 2 * * *' --vc <vc_name>`,
                     { format, exitCode: 2 }); return
                 }
+              } else if (fileType === 14) {
+                // REALTIME: use create-stream-sync which sets up source/target/schema in one step
+                const content = String(taskDetailInner?.fileContent ?? taskDetailData?.fileContent ?? "").trim()
+                if (!content || content.length < 10) {
+                  error("NO_SYNC_CONFIG",
+                    `REALTIME task not configured. Use 'cz-cli task create-stream-sync' to create and configure in one step, or open Studio to configure source/target manually: ${studioUrl(sc, fileId)}`,
+                    { format, exitCode: 2 }); return
+                }
+                // Warn if no schedule config
+                process.stderr.write(`Warning: REALTIME task — verifying source/target configuration before deploy. Open Studio if deploy fails: ${studioUrl(sc, fileId)}\n`)
               } else {
                 // All other sync types require Studio UI configuration
                 process.stderr.write(`Warning: ${typeName} task — source/target/field-mapping must be configured in Studio UI before deploying. Open: ${studioUrl(sc, fileId)}\n`)
@@ -3296,12 +3306,41 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
           try {
             const sc = await ctx(argv)
             const fileId = await resolveTaskId(sc, argv.task as string, format)
+
+            // Pre-check: FLOW tasks (type=500 internal, actual fileType=500 from API) don't create
+            // scheduleTask entries — the API throws IDE-SYSTEM_EXCEPTION instead of returning empty.
+            // Also handle tasks deployed without cron by catching and returning friendly message.
+            const detailResp = await getTaskDetail(sc, fileId)
+            const detailData = (detailResp.data && typeof detailResp.data === "object" ? detailResp.data : {}) as Record<string, unknown>
+            const detailObj = (typeof detailData.taskDetail === "object" && detailData.taskDetail !== null
+              ? detailData.taskDetail : detailData) as Record<string, unknown>
+            const fileType = Number(detailObj.fileType ?? 0)
+            if (fileType === 500) { // FLOW
+              success({ task_id: fileId, task_name: detailObj.dataFileName, note: "FLOW tasks do not have standalone schedule entries. Use 'cz-cli task flow instances <task>' to see run history." }, {
+                format, aiMessage: `FLOW task: use 'cz-cli task flow instances ${argv.task}' for run history.`
+              })
+              return
+            }
+
             // getScheduleDetail uses scheduleTaskId = fileId (same id as draft task)
-            const resp = await studioRequest(sc,
-              "/ide-admin/v1/scheduleTask/getDetail",
-              { scheduleTaskId: fileId, projectId: sc.projectId },
-              { env: "prod" },
-            )
+            let resp: Awaited<ReturnType<typeof studioRequest>>
+            try {
+              resp = await studioRequest(sc,
+                "/ide-admin/v1/scheduleTask/getDetail",
+                { scheduleTaskId: fileId, projectId: sc.projectId },
+                { env: "prod" },
+              )
+            } catch (apiErr) {
+              // Backend throws IDE-SYSTEM_EXCEPTION for tasks deployed without cron schedule.
+              // Return friendly message instead of raw error.
+              logOperation("task schedule-info", { ok: false })
+              success({
+                task_id: fileId,
+                task_name: detailObj.dataFileName,
+                note: "This task has no active schedule entry (no cron configured, or not yet deployed to the schedule engine). Use 'cz-cli task content <task>' to check draft config.",
+              }, { format, aiMessage: "No schedule entry found. Check 'cz-cli task content <task>' for draft cron config." })
+              return
+            }
             logOperation("task schedule-info", { ok: true })
             success(convertScheduleInfoFields(resp.data as Record<string, unknown>), { format, aiMessage: "This is the deployed (published) schedule state. For draft config use: cz-cli task content <task>" })
           } catch (err) {

--- a/packages/cz-cli/test/task-pr14.test.ts
+++ b/packages/cz-cli/test/task-pr14.test.ts
@@ -11,7 +11,10 @@ import { spawnSync } from "child_process"
 import { resolve } from "path"
 
 function json(r: ExecuteResult): Record<string, unknown> {
-  const parsed = JSON.parse(r.output.trim().split("\n")[0]) as Record<string, unknown>
+  const lines = r.output.trim().split("\n")
+  const jsonLine = lines.find(l => l.trim().startsWith("{") || l.trim().startsWith("["))
+  if (!jsonLine) throw new Error(`no JSON in output: ${r.output.slice(0, 100)}`)
+  const parsed = JSON.parse(jsonLine) as Record<string, unknown>
   console.log(">>> output:", JSON.stringify(parsed).slice(0, 200))
   return parsed
 }
@@ -497,5 +500,153 @@ describe("flow dag", () => {
     const dag = j.data
     // DAG returns array (may be empty if no nodes created)
     expect(Array.isArray(dag)).toBe(true)
+  })
+})
+
+// ── 15. schedule-info — friendly errors (issues 2 & 4) ──────────────────
+
+describe("schedule-info friendly errors", () => {
+  test("returns friendly note for task deployed without cron (no IDE-SYSTEM_EXCEPTION)", async () => {
+    // Find a deployed SQL/Python task that has no cron configured
+    const listR = await execute("task list --page-size 20")
+    const listJ = json(listR)
+    const data = (listJ.data as Record<string, unknown>[]) ?? []
+    const SQL_TYPES = new Set([4, 5, 7]) // SQL(4→23), SHELL(5→24), PYTHON(7→26)
+    const deployed = data.filter(t => t.task_edit_state === 20 && !SQL_TYPES.has(t.task_type as number))
+    // Try all deployed tasks and find one without cron
+    for (const t of deployed.slice(0, 5)) {
+      const taskId = t.task_id as number
+      const r = await execute(`task schedule-info ${taskId}`)
+      expect(r.exitCode).toBe(0) // must NOT return error exit code
+      const j = json(r)
+      expect(j.error).toBeUndefined() // must NOT propagate IDE-SYSTEM_EXCEPTION
+      const d = j.data as Record<string, unknown>
+      // Either real data (cron set) or friendly note (no cron)
+      if (d.note) {
+        expect(typeof d.note).toBe("string")
+        expect(d.note.length).toBeGreaterThan(0)
+      } else {
+        expect(d.task_id).toBeDefined()
+      }
+    }
+  })
+
+  test("returns FLOW-specific note for FLOW tasks instead of exception", async () => {
+    // Find a deployed FLOW task (fileType=500 stored internally)
+    // Task status shows these as having cdc_status=None and draft.task_content=''
+    const listR = await execute("task list --page-size 20")
+    const listJ = json(listR)
+    const data = (listJ.data as Record<string, unknown>[]) ?? []
+    // FLOW tasks have no content but are deployed
+    const deployed = data.filter(t => t.task_edit_state === 20)
+    let tested = false
+    for (const t of deployed.slice(0, 5)) {
+      const taskId = t.task_id as number
+      // Check if this is a FLOW task via task content (empty task_content = potential FLOW)
+      const r = await execute(`task schedule-info ${taskId}`)
+      expect(r.exitCode).toBe(0)
+      const j = json(r)
+      expect(j.error).toBeUndefined()
+      const d = j.data as Record<string, unknown>
+      if (d.note && String(d.note).includes("flow instances")) {
+        // Found a FLOW task — verify the note is correct
+        expect(d.note).toMatch(/flow instances/)
+        tested = true
+        break
+      }
+    }
+    if (!tested) console.log("⊘ note: no FLOW task found in first 5 deployed tasks")
+  })
+
+  test("returns cron info for properly scheduled tasks (still works)", async () => {
+    // Find a deployed task that has cron — schedule-info should return full data
+    const listR = await execute("task list --page-size 20")
+    const listJ = json(listR)
+    const data = (listJ.data as Record<string, unknown>[]) ?? []
+    const deployed = data.filter(t => t.task_edit_state === 20)
+    let found = false
+    for (const t of deployed.slice(0, 5)) {
+      const taskId = t.task_id as number
+      const r = await execute(`task schedule-info ${taskId}`)
+      expect(r.exitCode).toBe(0)
+      const j = json(r)
+      expect(j.error).toBeUndefined()
+      const d = j.data as Record<string, unknown>
+      if (d.cron_expression && d.task_id) {
+        expect(d.task_name).toBeDefined()
+        expect(d.vc_code).toBeDefined()
+        expect(typeof d.cron_expression).toBe("string")
+        found = true
+        break
+      }
+    }
+    if (!found) console.log("⊘ note: no deployed task with cron found")
+  })
+})
+
+// ── 16. REALTIME deploy guard (issue 4) ─────────────────────────────────
+
+describe("REALTIME deploy guard", () => {
+  test("bare REALTIME task (no content) → NO_SYNC_CONFIG before deploy", async () => {
+    // Find a folder
+    const folderR = await execute("task list-folders --page-size 1")
+    const folderJ = json(folderR)
+    const folders = (folderJ.data as Record<string, unknown>[]) ?? []
+    if (folders.length === 0) { console.log("⊘ skip: no folders"); return }
+    const folderId = folders[0].id as number
+
+    const ts = Date.now() % 99999
+    const name = `test_rt_guard_${ts}`
+
+    // Create bare REALTIME task
+    const createR = await execute(`task create "${name}" --folder ${folderId} --type REALTIME`)
+    if (createR.exitCode !== 0) {
+      console.log("⊘ skip: could not create REALTIME task")
+      return
+    }
+    const createJ = json(createR)
+    const taskId = (createJ.data as Record<string, unknown>)?.id
+    if (!taskId) { console.log("⊘ skip: no task id"); return }
+
+    // Deploy should return NO_SYNC_CONFIG, not backend error
+    const deployR = await execute(`task deploy ${taskId} -y`)
+    expect(deployR.exitCode).not.toBe(0)
+    const deployJ = json(deployR)
+    expect(deployJ.error).toBeDefined()
+    const errCode = (deployJ.error as Record<string, unknown>).code as string
+    // Must be caught at CLI level (NO_SYNC_CONFIG), not backend (TASK_ERROR/文件参数不匹配)
+    expect(errCode).toBe("NO_SYNC_CONFIG")
+  })
+
+  test("create-stream-sync task deploys successfully", async () => {
+    // Get a kafka datasource
+    const listR = await execute("datasource list --type kafka --page-size 1")
+    const listJ = json(listR)
+    const datasources = (listJ.data as Record<string, unknown>[]) ?? []
+    if (datasources.length === 0) { console.log("⊘ skip: no Kafka datasource"); return }
+    const dsName = datasources[0].name as string
+
+    // Get a folder
+    const folderR = await execute("task list-folders --page-size 1")
+    const folderJ = json(folderR)
+    const folders = (folderJ.data as Record<string, unknown>[]) ?? []
+    if (folders.length === 0) { console.log("⊘ skip: no folders"); return }
+    const folderId = folders[0].id as number
+
+    const ts = Date.now() % 99999
+    const name = `test_stream_deploy_${ts}`
+
+    // create-stream-sync (configured)
+    const createR = await execute(`task create-stream-sync "${name}" --folder ${folderId} --source "${dsName}" --topic test --target LAKEHOUSE_quick_start`)
+    const createJ = json(createR)
+    const taskId = (createJ.data as Record<string, unknown>)?.task_id
+    if (!taskId) { console.log("⊘ skip: create-stream-sync failed"); return }
+
+    // Deploy should succeed
+    const deployR = await execute(`task deploy ${taskId} -y`)
+    expect(deployR.exitCode).toBe(0)
+    const deployJ = json(deployR)
+    expect(deployJ.error).toBeUndefined()
+    expect((deployJ.data as Record<string, unknown>)?.status).toBe("online")
   })
 })


### PR DESCRIPTION
## Summary

Three fixes found during double-check of reported issues.

### Issue 5 — `create-setup --description` option missing
- `create-setup` handler already reads `argv.description` and saves it as `fileDescription`, but the yargs option was never declared
- Added `.option("description", { type: "string", ... })` — one line, no logic change

### Issue 2 — `schedule-info` throws `外部调用异常` for 3/4 tasks
Root cause: `scheduleTask/getDetail` API throws `IDE-SYSTEM_EXCEPTION` for:
- **FLOW tasks** (fileType=500): never create schedule entries
- **SQL/other tasks deployed without cron**: schedule engine has no entry

CLI fixes:
- FLOW tasks: detected by `fileType === 500` before API call → friendly note: "Use 'task flow instances'"
- No-cron tasks: API exception caught → friendly "no active schedule entry" message with hint to use `task content`
- Tasks with valid cron: unchanged, still returns full schedule info

### Issue 4 — bare `REALTIME` deploy fails with `文件参数不匹配`
Root cause: `task create --type REALTIME` creates a bare task. Deploying without configuring source/target causes a backend error.

CLI fix:
- Added fileType=14 (REALTIME) check in `task deploy`
- If no content configured: returns `NO_SYNC_CONFIG` error with guidance to use `create-stream-sync`
- Configured REALTIME tasks (via `create-stream-sync`) still deploy normally ✅

## Verification

```bash
# Issue 2 — no cron task (was: 外部调用异常)
cz-cli task schedule-info <sql-no-cron>
# → ✅ "no active schedule entry" note

# Issue 2 — FLOW task (was: 外部调用异常)  
cz-cli task schedule-info <flow-task>
# → ✅ "FLOW tasks: use task flow instances" note

# Issue 4 — bare REALTIME (was: 文件参数不匹配)
cz-cli task create foo --type REALTIME --folder <id>
cz-cli task deploy foo -y
# → ✅ NO_SYNC_CONFIG: use create-stream-sync instead

# Issue 4 — configured REALTIME still works
cz-cli task create-stream-sync ... → cz-cli task deploy ...
# → ✅ status=online
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)