### PR TITLE
  fix(task): rename flow instances --instance to --run_id

### DIFF
--- a/packages/cz-cli/src/commands/task.ts
+++ b/packages/cz-cli/src/commands/task.ts
@@ -3221,7 +3221,7 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
             (y) =>
               y
                 .positional("task", { type: "string", demandOption: true })
-                .option("instance", { type: "number", demandOption: true, describe: "Flow instance ID" })
+                .option("run_id", { type: "number", demandOption: true, describe: "Flow instance ID" })
                 .option("node-id", { type: "number", describe: "Flow node ID" })
                 .option("node-instance-id", { type: "number", describe: "Flow node instance ID" }),
             async (argv) => {
@@ -3231,7 +3231,7 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
                 const fileId = await resolveTaskId(sc, argv.task as string, format)
                 const resp = await listFlowInstances(sc, {
                   flowId: fileId,
-                  flowInstanceId: argv.instance as number | undefined,
+                  flowInstanceId: argv.run_id as number | undefined,
                   flowNodeId: argv["node-id"] as number | undefined,
                   flowNodeInstanceId: argv["node-instance-id"] as number | undefined,
                 })


### PR DESCRIPTION
  ## Summary
  - `task flow instances` 的 `--instance` 选项和 profile 里的字段冲突,改名为 `--run_id` 规避冲突。
  - 仅改了选项名和读取处,行为不变。
## Test plan
  - [ ] 构建后运行 `cz-cli task flow instances <task> --run_id <id>` 验证可正常取到 flow 实例
  - [ ] 确认不再与 profile 字段冲突