### PR TITLE
fix: support Volkswagen UAT and guard merge SQL

### DIFF
--- a/openspec/specs/setup/spec.md
+++ b/openspec/specs/setup/spec.md
@@ -22,3 +22,24 @@
 - **WHEN** 系统浏览器打开命令不存在或启动失败
 - **THEN** `cz-cli setup` 不应抛出未处理异常
 - **且** 用户仍然可以根据终端中显示的 URL 手动打开页面并粘贴 credential
+
+### Requirement: Volkswagen UAT endpoint 可用于 setup/profile bootstrap
+
+本需求 MUST 按以下场景执行。
+
+`cz-cli setup` MUST 将 Volkswagen UAT Studio API endpoint 作为显式 service endpoint 提供给用户选择；profile bootstrap MUST 在按 region key 渲染 profile 命令时识别 `uat-cn-shanghai-alicloud` 对应的 Volkswagen UAT Studio API endpoint。
+
+#### Scenario: setup 提供 Volkswagen UAT service endpoint
+
+- **WHEN** `cz-cli setup` 需要用户选择 service endpoint
+- **THEN** service endpoint 选项 MUST 包含 `lakehouse-studio.uat.cn-vw.volkswagen-cea.com/api`
+
+#### Scenario: 通过 region key 推导 Volkswagen UAT service
+
+- **WHEN** profile bootstrap 使用 region key `uat-cn-shanghai-alicloud`
+- **THEN** service MUST 解析为 `lakehouse-studio.uat.cn-vw.volkswagen-cea.com/api`
+
+#### Scenario: 未知 UAT region 仍按通用规则推导
+
+- **WHEN** profile bootstrap 使用未显式配置的 region key
+- **THEN** service MAY 按 `{region}.api.clickzetta.com` 通用规则推导

--- a/openspec/specs/sql-execution/spec.md
+++ b/openspec/specs/sql-execution/spec.md
@@ -58,6 +58,12 @@
 - **THEN** 系统拒绝执行
 - **AND** 返回 write-protection 错误
 
+#### Scenario: MERGE SQL 未授权
+
+- **WHEN** 用户执行 `cz-cli sql "MERGE INTO t USING s ON t.id=s.id WHEN MATCHED THEN UPDATE SET v=s.v"` 且没有 `--write`
+- **THEN** 系统拒绝执行
+- **AND** 不提交 SQL job
+
 #### Scenario: 危险 DELETE/UPDATE
 
 - **WHEN** 用户执行没有 WHERE 或被 guardrail 判定危险的 DELETE/UPDATE

--- a/packages/cz-cli/src/commands/job-performance.ts
+++ b/packages/cz-cli/src/commands/job-performance.ts
@@ -18,6 +18,8 @@ type Profile = {
   vcluster?: string
 }
 
+const VW_UAT_HOST = "lakehouse-studio.uat.cn-vw.volkswagen-cea.com"
+
 function centralApiUrl(host: string): string {
   if (host.startsWith("uat-")) return "https://uat-api.clickzetta.com"
   if (host.startsWith("dev-") || host.startsWith("localhost") || host.startsWith("0.0.0.0")) return "https://dev-api.clickzetta.com"
@@ -43,7 +45,9 @@ function normalizeHost(serviceUrl: string): string {
 }
 
 export function serviceUrlToMcpUrl(serviceUrl: string): string {
-  const apiHost = normalizeHost(centralApiUrl(normalizeHost(serviceUrl)))
+  const host = normalizeHost(serviceUrl)
+  if (host === VW_UAT_HOST) return `http://${VW_UAT_HOST}/mcp`
+  const apiHost = normalizeHost(centralApiUrl(host))
   if (!apiHost.includes("api")) return `https://${apiHost}/mcp`
   return `https://${apiHost.replace(/([.-])api(?=\.)/, "-mcp$1api")}/mcp`
 }

--- a/packages/cz-cli/src/commands/profile-bootstrap.ts
+++ b/packages/cz-cli/src/commands/profile-bootstrap.ts
@@ -105,6 +105,7 @@ function getRegionByAlias(alias: string): string {
     sit: "sit",
     uat: "uat",
     prod: "cn-shanghai-alicloud",
+    "uat-cn-shanghai-alicloud": "uat-cn-shanghai-alicloud",
   }
   return map[alias.toLowerCase()] || ""
 }
@@ -525,13 +526,14 @@ async function listWorkspacesForInstance(
     .sort((a, b) => a.workspace_name.localeCompare(b.workspace_name))
 }
 
-function resolveServiceHost(serviceHost: string, regionKey: string): string {
+export function resolveServiceHost(serviceHost: string, regionKey: string): string {
   if (serviceHost) return serviceHost.replace(/^https?:\/\//, "")
   // Fallback: derive service URL from region key (matching Python's read_url from config.ini)
   const REGION_URL_MAP: Record<string, string> = {
     dev: "dev-api.clickzetta.com",
     sit: "sit-api.clickzetta.com",
     uat: "uat-api.clickzetta.com",
+    "uat-cn-shanghai-alicloud": "lakehouse-studio.uat.cn-vw.volkswagen-cea.com/api",
     "cn-shanghai-alicloud": "cn-shanghai-alicloud.api.clickzetta.com",
     "ap-southeast-1-alicloud": "ap-southeast-1-alicloud.api.singdata.com",
     "ap-shanghai-tencentcloud": "ap-shanghai-tencentcloud.api.clickzetta.com",

--- a/packages/cz-cli/src/commands/setup.ts
+++ b/packages/cz-cli/src/commands/setup.ts
@@ -77,7 +77,8 @@ const LOGIN_METHOD_URLS = {
   singdata: "https://accounts.singdata.com/login",
 } as const
 
-const SERVICE_ENDPOINTS = [
+export const SERVICE_ENDPOINTS = [
+  "lakehouse-studio.uat.cn-vw.volkswagen-cea.com/api",
   "cn-shanghai-alicloud.api.clickzetta.com",
   "cn-beijing-alicloud.api.clickzetta.com",
   "cn-hangzhou-alicloud.api.clickzetta.com",

--- a/packages/cz-cli/src/commands/sql.ts
+++ b/packages/cz-cli/src/commands/sql.ts
@@ -8,7 +8,7 @@ import { logOperation } from "../logger.js"
 import { getExecContext, execSql, execSqlWithRetry, isQueryResult, validateIdentifier, classifyExecError, type ExecContext } from "./exec.js"
 import { formatBillingError } from "./billing-error.js"
 
-const WRITE_RE = /^\s*(INSERT|UPDATE|DELETE|REPLACE|ALTER|CREATE|DROP|TRUNCATE|RENAME|FORK)\b/i
+const WRITE_RE = /^\s*(INSERT|UPDATE|DELETE|REPLACE|ALTER|CREATE|DROP|TRUNCATE|RENAME|FORK|MERGE)\b/i
 const SELECT_RE = /^\s*(SELECT\b|WITH\b[\s\S]*?\bSELECT\b|SHOW\b)/i
 const LIMIT_RE = /\bLIMIT\s+\d+/i
 const SHOW_RE = /^\s*SHOW\b/i

--- a/packages/cz-cli/test/job-performance.test.ts
+++ b/packages/cz-cli/test/job-performance.test.ts
@@ -4,6 +4,9 @@ import { buildAuthHeaders, pruneUndefined, serviceUrlToMcpUrl } from "../src/com
 describe("job performance MCP parity helpers", () => {
   test("maps service URLs to the same central MCP endpoint as the built-in tool", () => {
     expect(serviceUrlToMcpUrl("uat-api.clickzetta.com")).toBe("https://uat-mcp-api.clickzetta.com/mcp")
+    expect(serviceUrlToMcpUrl("http://lakehouse-studio.uat.cn-vw.volkswagen-cea.com/api")).toBe(
+      "http://lakehouse-studio.uat.cn-vw.volkswagen-cea.com/mcp",
+    )
     expect(serviceUrlToMcpUrl("dev-api.clickzetta.com")).toBe("https://dev-mcp-api.clickzetta.com/mcp")
     expect(serviceUrlToMcpUrl("cn-beijing-alicloud.api.clickzetta.com")).toBe(
       "https://cn-shanghai-alicloud-mcp.api.clickzetta.com/mcp",

--- a/packages/cz-cli/test/profile-bootstrap.test.ts
+++ b/packages/cz-cli/test/profile-bootstrap.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+import { resolveServiceHost } from "../src/commands/profile-bootstrap"
+import { SERVICE_ENDPOINTS } from "../src/commands/setup"
+
+describe("profile bootstrap region service mapping", () => {
+  test("maps Volkswagen UAT region to its Studio API endpoint", () => {
+    expect(resolveServiceHost("", "uat-cn-shanghai-alicloud")).toBe(
+      "lakehouse-studio.uat.cn-vw.volkswagen-cea.com/api",
+    )
+    expect(SERVICE_ENDPOINTS).toContain("lakehouse-studio.uat.cn-vw.volkswagen-cea.com/api")
+  })
+
+  test("keeps generic fallback for unknown region keys", () => {
+    expect(resolveServiceHost("", "unknown-region")).toBe("unknown-region.api.clickzetta.com")
+  })
+})

--- a/packages/cz-cli/test/sql-use-validation.test.ts
+++ b/packages/cz-cli/test/sql-use-validation.test.ts
@@ -160,4 +160,19 @@ describe("sql USE validation", () => {
     })
     expect(execCalls).toEqual(["DESC SCHEMA analytics", "SELECT 1 LIMIT 101"])
   })
+
+  test("MERGE is treated as a write operation and requires --write", async () => {
+    const result = await execute('sql "MERGE INTO target USING source ON target.id=source.id WHEN MATCHED THEN UPDATE SET v=source.v" --sync')
+    const json = firstJson(result.output)
+
+    expect(result.exitCode).toBe(1)
+    expect(json).toEqual({
+      ai_message: "Add --write flag to execute write operations: cz-cli sql \"<SQL>\" --write",
+      error: {
+        code: "WRITE_NOT_ALLOWED",
+        message: "Write operation detected. Pass --write to confirm.",
+      },
+    })
+    expect(execCalls).toEqual([])
+  })
 })

--- a/packages/opencode/src/tool/job-performance.ts
+++ b/packages/opencode/src/tool/job-performance.ts
@@ -77,7 +77,9 @@ function normalizeHost(serviceUrl: string): string {
  * 再在 `api` 标签前插入 `-mcp`、路径设为 `/mcp`。
  */
 export function serviceUrlToMcpUrl(serviceUrl: string): string {
-  const apiHost = normalizeHost(centralApiUrl(normalizeHost(serviceUrl)))
+  const host = normalizeHost(serviceUrl)
+  if (host === VW_UAT_HOST) return `http://${VW_UAT_HOST}/mcp`
+  const apiHost = normalizeHost(centralApiUrl(host))
   // OP domains without "api" in hostname: use directly with /mcp path
   if (!apiHost.includes("api")) return `https://${apiHost}/mcp`
   return `https://${apiHost.replace(/([.-])api(?=\.)/, "-mcp$1api")}/mcp`
@@ -93,6 +95,8 @@ type Profile = {
   schema?: string
   vcluster?: string
 }
+
+const VW_UAT_HOST = "lakehouse-studio.uat.cn-vw.volkswagen-cea.com"
 
 /** 取活跃连接：优先 CZ_* 环境变量，否则读 ~/.clickzetta/profiles.toml 的 CZ_PROFILE / default_profile。 */
 function loadProfile(): Profile {

--- a/packages/opencode/test/tool/job-performance.test.ts
+++ b/packages/opencode/test/tool/job-performance.test.ts
@@ -5,6 +5,11 @@ describe("serviceUrlToMcpUrl (central-region only)", () => {
   test("uat- prefix -> uat central", () => {
     expect(serviceUrlToMcpUrl("uat-api.clickzetta.com")).toBe("https://uat-mcp-api.clickzetta.com/mcp")
   })
+  test("Volkswagen UAT host -> Volkswagen UAT MCP endpoint", () => {
+    expect(serviceUrlToMcpUrl("http://lakehouse-studio.uat.cn-vw.volkswagen-cea.com/api")).toBe(
+      "http://lakehouse-studio.uat.cn-vw.volkswagen-cea.com/mcp",
+    )
+  })
   test("dev- / localhost / 0.0.0.0 -> dev central", () => {
     expect(serviceUrlToMcpUrl("dev-api.clickzetta.com")).toBe("https://dev-mcp-api.clickzetta.com/mcp")
     expect(serviceUrlToMcpUrl("http://localhost:8080")).toBe("https://dev-mcp-api.clickzetta.com/mcp")


### PR DESCRIPTION
## Summary
- add Volkswagen UAT service endpoint mapping for setup/profile bootstrap
- route Volkswagen UAT job-performance MCP endpoint consistently
- require --write for MERGE SQL execution

## Verification
- bun test test/job-performance.test.ts test/sql-use-validation.test.ts test/profile-bootstrap.test.ts (packages/cz-cli)
- bun test test/tool/job-performance.test.ts (packages/opencode)
- bun typecheck (packages/cz-cli)
- bun typecheck (packages/opencode)
- pre-push: bun turbo typecheck