### PR TITLE
fix(release): detect musl/old-glibc in bootstrap installer platform()

### DIFF
--- a/scripts/cos-release.mjs
+++ b/scripts/cos-release.mjs
@@ -429,7 +429,34 @@ platform() {
     aarch64|arm64) ARCH="arm64" ;;
   esac
 
-  echo "$OS-$ARCH"
+  SUFFIX=""
+  if [ "$OS" = "linux" ]; then
+    # baseline: x64 CPUs without AVX2 need the non-AVX2 build.
+    if [ "$ARCH" = "x64" ] && ! grep -qwi avx2 /proc/cpuinfo 2>/dev/null; then
+      SUFFIX="-baseline"
+    fi
+    # libc: use the statically-linked musl build on musl distros, when forced
+    # via CZ_LIBC=musl, or when the host glibc is older than the glibc binary's
+    # minimum (GLIBC_2.25, e.g. CentOS/RHEL 7 at 2.17).
+    CZ_LIBC="\${CZ_LIBC:-auto}"
+    if [ "$CZ_LIBC" = "musl" ]; then
+      SUFFIX="$SUFFIX-musl"
+    elif [ "$CZ_LIBC" = "auto" ]; then
+      if [ -f /etc/alpine-release ] || ldd --version 2>&1 | grep -qi musl; then
+        SUFFIX="$SUFFIX-musl"
+      else
+        # \`|| true\`: a failing pipeline (ldd absent / no match) must not abort
+        # under set -e; leave GLIBC empty and keep the glibc build.
+        GLIBC=$(ldd --version 2>&1 | grep -oE '[0-9]+\\.[0-9]+' | tail -n1 || true)
+        GMAJ=\${GLIBC%%.*}; GMIN=\${GLIBC##*.}
+        if [ -n "$GLIBC" ] && { [ "$GMAJ" -lt 2 ] || { [ "$GMAJ" -eq 2 ] && [ "$GMIN" -lt 25 ]; }; }; then
+          SUFFIX="$SUFFIX-musl"
+        fi
+      fi
+    fi
+  fi
+
+  echo "$OS-$ARCH$SUFFIX"
 }
 
 main() {


### PR DESCRIPTION
The served install.sh (curl | sh) is the bootstrap generated by renderBootstrapSh(), whose platform() only emitted OS-ARCH. Its musl and baseline archive branches were therefore unreachable, so hosts with old glibc (e.g. CentOS/RHEL 7, glibc 2.17 < the binary's GLIBC_2.25 floor) always received the glibc build and could not run it.

Detect libc and AVX2 in platform(): fall back to the statically-linked musl build on musl distros, when CZ_LIBC=musl is set, or when host glibc is older than 2.25; append -baseline for x64 CPUs without AVX2. The matching archive entries already exist in the bootstrap case table.

Verified: rendered bootstrap passes sh -n; platform() matrix 15/15 (modern/old glibc, 2.25 boundary, alpine, CZ_LIBC override, arm64, ldd-absent fallback, darwin/win skip); existing cos-release-logging + release-dev-format tests green (15/15).