### PR TITLE
fix(cli): show group help instead of usage error on missing subcommand

### DIFF
--- a/openspec/specs/cli-command-routing/spec.md
+++ b/openspec/specs/cli-command-routing/spec.md
@@ -97,6 +97,47 @@
 - **THEN** CLI MUST NOT silently apply a generic global row limit or field truncation through the shared output formatter
 - **且** 若该命令需要限制或截断行为，MUST 在该命令自身实现并在帮助信息中声明
 
+### Requirement: 分组命令缺子命令时返回帮助而非报错
+
+本需求 MUST 按以下场景执行。
+
+当用户调用一个"分组命令"（即本身没有可执行动作、只承载子命令的命令，如 `cz-cli ai-gateway`、`cz-cli ai-gateway key`、`cz-cli task`、`cz-cli task flow`、`cz-cli analytics-agent domain`、`cz-cli agent llm`）却未提供子命令时，CLI MUST 输出该分组的帮助信息（等同 `--help`）并以退出码 0 结束，而不是返回 `USAGE_ERROR`。此行为仅适用于缺少子命令的分组命令；不适用于叶子命令缺少必填位置参数或选项的情形。
+
+分组命令缺子命令 MUST NOT 要求已配置 ClickZetta profile 或 active LLM —— 帮助信息 MUST 在无任何 profile/LLM 的机器上照常输出，不得被 `NO_PROFILE` 或 `NO_ACTIVE_LLM` 掩盖。
+
+#### Scenario: 顶层分组命令缺子命令返回帮助
+
+- **WHEN** 用户执行 `cz-cli ai-gateway`（无子命令）
+- **THEN** CLI MUST 输出 `cz-cli ai-gateway` 的帮助信息，包含其子命令（`key`、`model`）
+- **且** 退出码 MUST 为 0
+- **且** 输出 MUST NOT 包含 `USAGE_ERROR`
+
+#### Scenario: 嵌套分组命令缺子命令返回帮助
+
+- **WHEN** 用户执行 `cz-cli ai-gateway key`（无子命令）
+- **THEN** CLI MUST 输出 `cz-cli ai-gateway key` 的帮助信息（而非父级 `ai-gateway` 的帮助）
+- **且** 退出码 MUST 为 0
+
+#### Scenario: profile-gated 分组命令缺子命令不要求 profile
+
+- **WHEN** 用户在未配置 profile 的机器上执行 `cz-cli task`（无子命令）
+- **THEN** CLI MUST 输出 `cz-cli task` 的帮助信息
+- **且** 退出码 MUST 为 0
+- **且** 输出 MUST NOT 包含 `NO_PROFILE`
+
+#### Scenario: 未知子命令仍然报错
+
+- **WHEN** 用户执行 `cz-cli ai-gateway bogus`（未知子命令）
+- **THEN** CLI MUST 返回 `USAGE_ERROR`
+- **且** 退出码 MUST 为 2
+- **且** 若存在相近子命令，SHOULD 在 `did_you_mean` 中给出建议
+
+#### Scenario: 叶子命令缺必填参数仍然报错
+
+- **WHEN** 用户执行 `cz-cli ai-gateway key get`（缺少必填位置参数 `<ref>`）
+- **THEN** CLI MUST 返回 `USAGE_ERROR`
+- **且** 退出码 MUST 为 2
+
 ### Requirement: task 依赖产出解析命令可发现
 
 本需求 MUST 按以下场景执行。

--- a/packages/cz-cli/src/cli.ts
+++ b/packages/cz-cli/src/cli.ts
@@ -3,6 +3,7 @@ import { VERSION } from "./version.js"
 import { defaultFormat, outputState, parseOutputArgs, renderOutput } from "./output/index.js"
 import { withClickZettaProfileOption } from "./clickzetta-profile-option.js"
 import { suggestClosest } from "./suggest.js"
+import { SubcommandHelpShown } from "./subcommand-help.js"
 
 export interface GlobalArgs {
   profile?: string
@@ -156,8 +157,19 @@ export function createCli(args: string[]) {
       outputState.field = argv.field as string | undefined
     }, /* applyBeforeValidation */ true)
     .strict()
-    .fail((msg, err, yargs) => {
+    .fail((msg, err, failYargs) => {
       if (err) throw err
+      // Defensive net: a group built with raw `.demandCommand()` (no commandGroup
+      // fail handler of its own, e.g. some agent.ts subtrees) bubbles its
+      // "Missing subcommand for 'X'" failure straight up here. Resolve it like
+      // commandGroup does: render that group's help from the failing instance
+      // (yargs hands it in as the 3rd arg) and throw SubcommandHelpShown so the
+      // parse boundary exits 0. Groups built via commandGroup handle this in
+      // their own fail handler and never reach here. See subcommand-help.ts.
+      if (msg && msg.startsWith("Missing subcommand for '")) {
+        failYargs.showHelp((help: string) => process.stdout.write(help + "\n"))
+        throw new SubcommandHelpShown()
+      }
       const KNOWN_FLAGS = KNOWN_GLOBAL_FLAGS
       const KNOWN_COMMANDS = KNOWN_TOP_COMMANDS
       const knownFlagSet = new Set(KNOWN_FLAGS)

--- a/packages/cz-cli/src/command-group.ts
+++ b/packages/cz-cli/src/command-group.ts
@@ -2,8 +2,14 @@ import type { Argv } from "yargs"
 import { suggestClosest } from "./suggest.js"
 import { parseOutputArgs, renderOutput } from "./output/index.js"
 import { KNOWN_GLOBAL_FLAGS, INVOCATION_ARGS_KEY } from "./cli.js"
+import { SubcommandHelpShown } from "./subcommand-help.js"
 
-export function commandGroup(yargs: Argv, commandName: string): Argv {
+// Re-exported so the opencode agent runtime (which imports commandGroup from
+// this module) can catch the sentinel at its own parse boundaries. See
+// subcommand-help.ts.
+export { SubcommandHelpShown } from "./subcommand-help.js"
+
+export function commandGroup<T>(yargs: Argv<T>, commandName: string): Argv<T> {
   const commands = getRegisteredCommands(yargs)
   const localOptions = getRegisteredOptions(yargs)
   const available = commands.length > 0 ? commands.join(", ") : "see --help"
@@ -25,8 +31,26 @@ export function commandGroup(yargs: Argv, commandName: string): Argv {
   return yargs
     .strictCommands()
     .strictOptions()
-    .fail((msg, err) => {
+    .fail((msg, err, failYargs) => {
       if (err) throw err
+
+      // A bare group invocation (`cz-cli ai-gateway`, `cz-cli ai-gateway key`)
+      // is not a user error — the caller has not yet chosen a subcommand. Treat
+      // it like `--help`: render this group's help and throw the sentinel, so
+      // incomplete branch commands are self-documenting instead of returning
+      // USAGE_ERROR.
+      //
+      // yargs hands the failing instance to the fail handler as its 3rd arg, so
+      // failYargs.showHelp() renders THIS group's help (correct even for a
+      // nested group). Throwing (not returning) stops the failure from bubbling
+      // up to ancestor fail handlers — which would reset exitCode to 2 and
+      // re-emit USAGE_ERROR — and aborts the parse before the post-validation
+      // profile middleware runs, so a bare group prints help, never NO_PROFILE.
+      // The parse boundary catches SubcommandHelpShown and exits 0.
+      if (msg && msg.startsWith("Missing subcommand for '")) {
+        failYargs.showHelp((help: string) => process.stdout.write(help + "\n"))
+        throw new SubcommandHelpShown()
+      }
 
       // Distinguish the two yargs failure shapes so we suggest the right thing:
       //   "Unknown command: X"  -> X is a bad SUBCOMMAND  -> match subcommand names

--- a/packages/cz-cli/src/commands/task.ts
+++ b/packages/cz-cli/src/commands/task.ts
@@ -420,7 +420,7 @@ function registerCdcCommands(cdcYargs: Argv<GlobalArgs>): Argv<GlobalArgs> {
       .positional("task", { type: "string", demandOption: true, describe: "Multi-table CDC pipeline task name or ID (fileType 281)" })
       .option("table-ids", { type: "string", demandOption: true, describe: "Comma-separated pipeline table ids (from 'task cdc tables <task>')" })
 
-  return cdcYargs
+  const cdcGroup = cdcYargs
     .command(
       "list",
       "List multi-table CDC pipeline tasks (MULTI_REALTIME, fileType 281)",
@@ -502,7 +502,9 @@ function registerCdcCommands(cdcYargs: Argv<GlobalArgs>): Argv<GlobalArgs> {
     .command("resync-table <task>", "Re-sync (re-snapshot) specific CDC pipeline tables", tableOpBuilder, tableOp(resyncCdcTables, "resync-table"))
     .command("pause-table <task>", "Pause incremental sync for specific CDC pipeline tables", tableOpBuilder, tableOp(pauseCdcTables, "pause-table"))
     .command("recover-table <task>", "Recover (resume) incremental sync for specific CDC pipeline tables", tableOpBuilder, tableOp(recoverCdcTables, "recover-table"))
-    .demandCommand(1, "Missing subcommand for 'task cdc'. Available: list, tables, offline, start-table, stop-table, resync-table, pause-table, recover-table")
+  // Wrap in commandGroup so a bare `cz-cli task cdc` renders help instead of
+  // USAGE_ERROR. See subcommand-help.ts.
+  return commandGroup(cdcGroup, "task cdc")
 }
 
 function parseDependencyTasks(raw: string, format: string | undefined, projectId: number): Record<string, unknown>[] {
@@ -3219,7 +3221,9 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
         },
       )
       .command("flow", "Flow (composite) task operations. Workflow: task create --type FLOW → flow create-node (repeat) → flow node-save (each) → flow node-save-config (each) → flow bind → flow submit", (flowYargs) =>
-        flowYargs
+        // commandGroup registers this group so a bare `cz-cli task flow` renders
+        // help (via the parse boundary) instead of USAGE_ERROR.
+        commandGroup(flowYargs
           .command(
             "dag <task>",
             "Get flow DAG",
@@ -3880,9 +3884,7 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
               }
             },
           )
-          .strictCommands()
-          .strictOptions()
-          .demandCommand(1, "Missing subcommand for 'task flow'. Available: dag, create-node, remove-node, bind, unbind, node-detail, node-save, node-save-config, submit, run, instances"),
+          , "task flow"),
       )
       .command(
         "delete-folder <folder>",

--- a/packages/cz-cli/src/execute.ts
+++ b/packages/cz-cli/src/execute.ts
@@ -6,6 +6,7 @@ import { defaultFormat, outputState } from "./output/index.js"
 import { createCli } from "./cli.js"
 import { registerCommands } from "./register-commands.js"
 import { classifyCliArgs, emitNoProfile } from "./run-cli.js"
+import { SubcommandHelpShown } from "./subcommand-help.js"
 import { trackCommand } from "./telemetry.js"
 
 export interface ExecuteResult {
@@ -82,6 +83,12 @@ async function executeInternal(command: string, extraArgs?: string[]): Promise<E
   } catch (e) {
     if (e instanceof ControlledExit) {
       process.exitCode = e.code
+    } else if (e instanceof SubcommandHelpShown) {
+      // A bare command group already rendered its help via its fail handler,
+      // which wrote into the hijacked stdout (captured in chunks) during
+      // parseAsync. Treat it as a successful help request (exit 0), not an
+      // error. See subcommand-help.ts.
+      process.exitCode = 0
     } else {
       if (!process.exitCode) process.exitCode = 1
       if (!chunks.length) {

--- a/packages/cz-cli/src/run-cli.ts
+++ b/packages/cz-cli/src/run-cli.ts
@@ -6,6 +6,7 @@ import { createCli } from "./cli.js"
 import { CLICKZETTA_PROFILE_OPTION_NAMES } from "./clickzetta-profile-option.js"
 import { parseOutputArgs, renderOutput } from "./output/index.js"
 import { registerCommands } from "./register-commands.js"
+import { SubcommandHelpShown } from "./subcommand-help.js"
 import { trackCommand, parseTrackingArgs } from "./telemetry.js"
 
 interface CliRuntime {
@@ -299,7 +300,14 @@ async function parseRegisteredCommands(args: string[], onValidated?: () => void)
   // This way a mistyped command or unknown option surfaces a USAGE_ERROR instead
   // of being masked by NO_PROFILE on a machine without a configured profile.
   if (onValidated) cli.middleware(() => onValidated(), false)
-  await cli.parseAsync()
+  try {
+    await cli.parseAsync()
+  } catch (err) {
+    // A bare command group already rendered its help in its fail handler and
+    // threw this sentinel (before the profile middleware ran). Not an error —
+    // exit stays 0. See subcommand-help.ts.
+    if (!(err instanceof SubcommandHelpShown)) throw err
+  }
 }
 
 function agentSubcommand(args: string[], commandIndex: number) {

--- a/packages/cz-cli/src/subcommand-help.ts
+++ b/packages/cz-cli/src/subcommand-help.ts
@@ -1,0 +1,24 @@
+// Sentinel thrown by a command group's fail handler after it has already
+// rendered that group's help for a bare (missing-subcommand) invocation.
+//
+// Why throw at all: yargs marks the parse as failed on a demandCommand miss. If
+// the fail handler merely returns, yargs bubbles the same failure up to every
+// ancestor fail handler (which would re-emit USAGE_ERROR) and then runs the
+// post-validation middleware (which would emit NO_PROFILE). Throwing a sentinel
+// stops the bubble immediately and aborts the pipeline before that middleware —
+// so a bare group prints help, never USAGE_ERROR or NO_PROFILE.
+//
+// The help itself is rendered inline in the fail handler from the failing yargs
+// instance (yargs hands it to the handler as the 3rd argument), so the sentinel
+// carries no data. Each parse boundary (run-cli, execute, opencode main /
+// config-llm) simply catches it and exits 0 — help is already on stdout.
+//
+// Kept in its own leaf module (no imports) so command-group.ts, cli.ts,
+// run-cli.ts and execute.ts can all import it without an import cycle, and so
+// command-group.ts can re-export it for the opencode agent runtime.
+export class SubcommandHelpShown extends Error {
+  constructor() {
+    super("subcommand help shown")
+    this.name = "SubcommandHelpShown"
+  }
+}

--- a/packages/cz-cli/test/group-help-fallback.test.ts
+++ b/packages/cz-cli/test/group-help-fallback.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Locks the "bare command group renders help, not an error" behavior
+ * (openspec/specs/cli-command-routing/spec.md — "分组命令缺子命令时返回帮助而非报错").
+ *
+ * A group command (one that only carries subcommands, e.g. `cz-cli ai-gateway`)
+ * invoked WITHOUT a subcommand must print that group's help and exit 0, on a
+ * machine with no configured profile/LLM — never USAGE_ERROR or NO_PROFILE.
+ * Unknown subcommands and missing leaf positionals still error (exit 2).
+ *
+ * Runs the TypeScript source entry (never a stale compiled binary) under a
+ * throwaway HOME so profile-gated groups can't leak a developer profile.
+ * Run: bun test test/group-help-fallback.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { mkdirSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { execute } from "../src/execute.ts"
+
+const RUNTIME = process.execPath // bun
+const ENTRY = ["./src/main.ts"]
+
+let fakeHome: string
+
+beforeAll(() => {
+  fakeHome = join(tmpdir(), `cz-grouphelp-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(join(fakeHome, ".clickzetta"), { recursive: true })
+})
+
+afterAll(() => {
+  if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
+})
+
+interface Result { stdout: string; stderr: string; exitCode: number }
+
+function run(args: string[]): Result {
+  const r = spawnSync(RUNTIME, [...ENTRY, ...args], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, HOME: fakeHome, CLICKZETTA_TEST_HOME: fakeHome },
+    timeout: 40_000,
+  })
+  return { stdout: r.stdout ?? "", stderr: r.stderr ?? "", exitCode: r.status ?? 1 }
+}
+
+// Command groups that funnel through commandGroup() and are reachable on the
+// plain cz-cli path (no agent-runtime delegation). Not exhaustive of the deep
+// analytics-agent tree, but covers top-level, one- and two-level nesting, and
+// both raw-demandCommand conversions (task cdc/flow). Each, invoked bare, must
+// print its own help header and exit 0.
+const BARE_GROUPS: string[][] = [
+  ["ai-gateway"],
+  ["ai-gateway", "key"],
+  ["ai-gateway", "model"],
+  ["task"],
+  ["task", "cdc"],
+  ["task", "flow"],
+  ["task", "integration"],
+  ["schema"],
+  ["workspace"],
+  ["workspace-param"],
+  ["profile"],
+  ["job"],
+  ["runs"],
+  ["attempts"],
+  ["datasource"],
+  ["analytics-agent"],
+  ["analytics-agent", "domain"],
+  ["analytics-agent", "datasource"],
+  ["analytics-agent", "knowledge"],
+  ["analytics-agent", "table"],
+  ["analytics-agent", "column"],
+  ["analytics-agent", "metric"],
+  ["analytics-agent", "service"],
+  ["analytics-agent", "session"],
+  ["analytics-agent", "answer-builder"],
+  ["table"],
+]
+
+describe("bare command group renders help (exit 0), not USAGE_ERROR", () => {
+  for (const args of BARE_GROUPS) {
+    const label = args.join(" ")
+    test(`cz-cli ${label} prints its OWN help header + Commands and exits 0`, () => {
+      const r = run(args)
+      expect(r.exitCode).toBe(0)
+      // The FIRST line must be exactly this group's header — not a prefix. A
+      // loose startsWith() would also accept a mistakenly-rendered child header
+      // ("cz-cli task cdc" starts with "cz-cli task"); requiring the exact line
+      // proves the group rendered its OWN help.
+      const firstLine = r.stdout.split("\n").find((l) => l.trim().length > 0)?.trim()
+      expect(firstLine).toBe(`cz-cli ${label}`)
+      // A group help always lists its subcommands under a Commands: section.
+      expect(r.stdout).toContain("Commands:")
+      expect(r.stdout).not.toContain("USAGE_ERROR")
+      expect(r.stdout).not.toContain("NO_PROFILE")
+    })
+  }
+
+  test("cz-cli ai-gateway help actually lists its subcommands (key, model)", () => {
+    // Spec scenario "顶层分组命令缺子命令返回帮助" requires the subcommands to appear.
+    const r = run(["ai-gateway"])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain("key")
+    expect(r.stdout).toContain("model")
+  })
+})
+
+describe("nested bare group shows its OWN help, not the parent's", () => {
+  test("cz-cli ai-gateway key lists key subcommands", () => {
+    const r = run(["ai-gateway", "key"])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout.trimStart().startsWith("cz-cli ai-gateway key")).toBe(true)
+    // A key-specific subcommand must appear (proves it isn't the parent help).
+    expect(r.stdout).toContain("set-quota")
+  })
+})
+
+describe("profile-gated bare group does not require a profile", () => {
+  // `task` is in PROFILE_REQUIRED_COMMANDS; a bare invocation must still show
+  // help rather than being masked by NO_PROFILE.
+  test("cz-cli task shows help without NO_PROFILE", () => {
+    const r = run(["task"])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout.trimStart().startsWith("cz-cli task")).toBe(true)
+    expect(r.stdout).not.toContain("NO_PROFILE")
+  })
+})
+
+describe("genuine errors still surface (not masked by help fallback)", () => {
+  test("unknown subcommand -> USAGE_ERROR exit 2", () => {
+    const r = run(["ai-gateway", "bogus"])
+    expect(r.exitCode).toBe(2)
+    expect(r.stdout).toContain("USAGE_ERROR")
+  })
+
+  test("unknown nested subcommand -> USAGE_ERROR exit 2", () => {
+    const r = run(["task", "flow", "bogus"])
+    expect(r.exitCode).toBe(2)
+    expect(r.stdout).toContain("USAGE_ERROR")
+  })
+
+  test("leaf command missing required positional -> USAGE_ERROR exit 2", () => {
+    const r = run(["ai-gateway", "key", "get"])
+    expect(r.exitCode).toBe(2)
+    expect(r.stdout).toContain("USAGE_ERROR")
+  })
+})
+
+describe("programmatic execute() boundary renders bare-group help", () => {
+  // The in-process execute() path (used by the TUI / MCP server) has its own
+  // sentinel catch, distinct from the spawned-binary run-cli path: the fail
+  // handler's showHelp() writes into a hijacked stdout captured in `output`.
+  test("execute('ai-gateway') returns help text and exit 0", async () => {
+    const { exitCode, output } = await execute("ai-gateway")
+    expect(exitCode).toBe(0)
+    expect(output).toContain("cz-cli ai-gateway")
+    expect(output).toContain("Commands:")
+    expect(output).not.toContain("USAGE_ERROR")
+  })
+
+  test("execute('ai-gateway bogus') still returns USAGE_ERROR exit 2", async () => {
+    const { exitCode, output } = await execute("ai-gateway bogus")
+    expect(exitCode).toBe(2)
+    expect(output).toContain("USAGE_ERROR")
+  })
+})
+
+describe("agent runtime boundary renders bare-group help", () => {
+  // `agent llm` is delegated to the opencode agent runtime (a separate parse
+  // boundary that also catches the sentinel). A bare invocation must render
+  // help and exit 0 without requiring a configured LLM/profile.
+  test("cz-cli agent llm (bare) shows help and exits 0", () => {
+    const r = run(["agent", "llm"])
+    expect(r.exitCode).toBe(0)
+    const firstLine = r.stdout.split("\n").find((l) => l.trim().length > 0)?.trim()
+    expect(firstLine).toBe("cz-cli agent llm")
+    expect(r.stdout).not.toContain("USAGE_ERROR")
+  })
+
+  test("cz-cli agent llm bogus (unknown) still errors", () => {
+    const r = run(["agent", "llm", "bogus"])
+    expect(r.exitCode).not.toBe(0)
+    expect(r.stdout).toContain("USAGE_ERROR")
+  })
+})

--- a/packages/cz-cli/test/robustness.test.ts
+++ b/packages/cz-cli/test/robustness.test.ts
@@ -68,7 +68,10 @@ describe("#1 profile gate runs after yargs syntax validation", () => {
   })
 
   test("unknown subcommand surfaces USAGE_ERROR, not NO_PROFILE", () => {
-    const r = run(["task", "flow"])
+    // Note: a BARE group (`task flow`) now renders help, not an error — see the
+    // "bare command group renders help" suite below. An UNKNOWN subcommand is
+    // still a genuine syntax error and must surface USAGE_ERROR before the gate.
+    const r = run(["task", "bogus"])
     expect(errorOf(r.stdout).code).toBe("USAGE_ERROR")
   })
 
@@ -117,7 +120,9 @@ describe("#3 did-you-mean suggestions", () => {
 
 describe("#2 commandGroup errors honor --format / --field", () => {
   test("--format pretty produces multi-line JSON", () => {
-    const r = run(["task", "flow", "--format", "pretty"])
+    // Use an unknown subcommand (a genuine error) — a bare group now renders
+    // help instead of a structured error.
+    const r = run(["task", "bogus", "--format", "pretty"])
     expect(r.stdout.trimStart().startsWith("{\n")).toBe(true)
   })
 

--- a/packages/opencode/src/cli/cmd/config-llm.ts
+++ b/packages/opencode/src/cli/cmd/config-llm.ts
@@ -4,7 +4,7 @@ import path from "path"
 import type { Argv } from "yargs"
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml"
 import { migrateLegacyClickzettaConfig, normalizeLlmBaseUrl, buildLlmProbeRequest } from "../../config/profiles-llm"
-import { commandGroup } from "@clickzetta/cli/command-group"
+import { commandGroup, SubcommandHelpShown } from "@clickzetta/cli/command-group"
 import { maybeRotateExhaustedClickzettaLlm } from "@clickzetta/cli/llm/clickzetta-rotation"
 import { cmd } from "./cmd"
 
@@ -785,14 +785,21 @@ export const AgentLlmCommand = cmd({
 
 export async function runLlm(args: readonly string[]): Promise<never> {
   const { default: yargs } = await import("yargs")
-  await yargs(args)
-    .scriptName("cz-cli agent")
-    .command(AgentLlmCommand)
-    .demandCommand(1, "")
-    .strictCommands()
-    .strict(false)
-    .help("help", "show help")
-    .alias("help", "h")
-    .parseAsync()
+  try {
+    await yargs(args)
+      .scriptName("cz-cli agent")
+      .command(AgentLlmCommand)
+      .demandCommand(1, "")
+      .strictCommands()
+      .strict(false)
+      .help("help", "show help")
+      .alias("help", "h")
+      .parseAsync()
+  } catch (err) {
+    // A bare `cz-cli agent llm` already rendered its help in its commandGroup
+    // fail handler and threw this sentinel; it just unwinds the parse. Not an
+    // error — exit 0. See @clickzetta/cli subcommand-help. Re-throw anything else.
+    if (!(err instanceof SubcommandHelpShown)) throw err
+  }
   process.exit(0)
 }

--- a/packages/opencode/src/main.ts
+++ b/packages/opencode/src/main.ts
@@ -251,7 +251,7 @@ export async function main(args: string[], agentRuntime = false): Promise<number
   const { PluginCommand } = await import("./cli/cmd/plug")
   const { SetupCommand } = await import("./cli/cmd/setup")
   const { AgentLlmCommand } = await import("./cli/cmd/config-llm")
-  const { commandGroup } = await import("@clickzetta/cli/command-group")
+  const { commandGroup, SubcommandHelpShown } = await import("@clickzetta/cli/command-group")
 
   const agentArgs = isAgentSubcommand ? args.slice(1) : args
 
@@ -403,7 +403,12 @@ export async function main(args: string[], agentRuntime = false): Promise<number
       await cli.parse()
     }
   } catch (e) {
-    if (process.exitCode) {
+    if (e instanceof SubcommandHelpShown) {
+      // A bare agent command group (`cz-cli agent`, `cz-cli agent session`)
+      // already rendered its help in its commandGroup fail handler; the sentinel
+      // just unwinds the parse. Not an error — leave exitCode 0. See
+      // @clickzetta/cli subcommand-help.
+    } else if (process.exitCode) {
       // commandGroup already emitted structured output and set exitCode
     } else {
       let data: Record<string, any> = {}


### PR DESCRIPTION
Invoking a command group without a subcommand (e.g. `cz-cli ai-gateway`, `cz-cli task flow`) now prints that group's help and exits 0, instead of returning a USAGE_ERROR.