### PR TITLE
fix(analytics-agent): allow missing workspace for tenant-scoped calls

### DIFF
--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -678,7 +678,7 @@ async function resolveAnalyticsContext(argv: Record<string, unknown>): Promise<R
       },
     )
   }
-  const studio = getProfileAgentContext(argv) ?? await getStudioContext(argv)
+  const studio = getProfileAgentContext(argv) ?? await getStudioContext(argv, { allowMissingWorkspace: true })
   return { endpoint: endpoint!, studio }
 }
 

--- a/packages/cz-cli/src/commands/studio-context.ts
+++ b/packages/cz-cli/src/commands/studio-context.ts
@@ -79,7 +79,20 @@ export async function getGatewayContext(args: Partial<CliArgs> & { format?: stri
   }
 }
 
-export async function getStudioContext(args: Partial<CliArgs> & { format?: string; debug?: boolean }): Promise<StudioContext> {
+export interface StudioContextOptions {
+  /**
+   * When true, a missing workspace (empty listUserWorkspaces / name not found)
+   * is non-fatal: workspaceId/projectId fall back to 0 instead of erroring.
+   * Used by tenant-scoped features (e.g. Analytics Agent) whose resources are
+   * not gated on Studio workspace membership.
+   */
+  allowMissingWorkspace?: boolean
+}
+
+export async function getStudioContext(
+  args: Partial<CliArgs> & { format?: string; debug?: boolean },
+  opts: StudioContextOptions = {},
+): Promise<StudioContext> {
   const format = args.format ?? "json"
   const debug = !!args.debug
   const config = resolveConnectionConfig(args)
@@ -93,38 +106,42 @@ export async function getStudioContext(args: Partial<CliArgs> & { format?: strin
 
   const instanceId = await resolveInstanceId(baseUrl, token.token, tenantId, config.instance, token.instanceId, debug)
 
-  if (!config.workspace) {
+  if (!config.workspace && !opts.allowMissingWorkspace) {
     handledError("NO_WORKSPACE", "Workspace is required for studio commands. Use --workspace or set it in your profile.", { format })
   }
 
-  const ws = await getWorkspaceByName(
-    baseUrl,
-    token.token,
-    token.userId,
-    tenantId,
-    instanceId,
-    config.instance,
-    config.workspace,
-    debug,
-  )
+  const ws = config.workspace
+    ? await getWorkspaceByName(
+        baseUrl,
+        token.token,
+        token.userId,
+        tenantId,
+        instanceId,
+        config.instance,
+        config.workspace,
+        debug,
+      )
+    : undefined
 
-  if (!ws) {
+  if (!ws && !opts.allowMissingWorkspace) {
     handledError("WORKSPACE_NOT_FOUND", `Workspace '${config.workspace}' not found.`, { format })
   }
 
-  if (!ws.projectId) {
+  if (ws && !ws.projectId && !opts.allowMissingWorkspace) {
     handledError("PROJECT_NOT_FOUND", `Workspace '${config.workspace}' has no associated project.`, { format })
   }
+
+  if (!ws && debug) process.stderr.write(`[debug] studio-context: workspace '${config.workspace}' unresolved, falling back to workspaceId=0 projectId=0 (allowMissingWorkspace)\n`)
 
   return {
     token: token.token,
     instanceId,
-    workspaceId: ws.workspaceId,
-    projectId: ws.projectId,
+    workspaceId: ws?.workspaceId ?? 0,
+    projectId: ws?.projectId ?? 0,
     userId: token.userId,
     tenantId,
     instanceName: config.instance,
-    workspaceName: config.workspace,
+    workspaceName: config.workspace ?? "",
     env: detectEnv(config.service),
     baseUrl,
     customHeaders: config.customHeaders,


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Analytics Agent commands failed with NO_WORKSPACE / WORKSPACE_NOT_FOUND when the
profile had no workspace or the workspace name could not be resolved. But
Analytics Agent resources are tenant-scoped and do not depend on Studio
workspace membership, so requiring a workspace was wrong for these commands.

This adds an optional `allowMissingWorkspace` option to `getStudioContext`.
When set, an empty `listUserWorkspaces` result or an unresolved workspace name
is non-fatal: `workspaceId` / `projectId` fall back to `0` (and `workspaceName`
to `""`) instead of raising a handled error. `resolveAnalyticsContext` passes
the flag; all other studio commands keep the strict behavior and still error on
a missing/unresolved workspace.

A debug-only stderr line notes when the fallback path is taken.

### How did you verify your code works?

From `packages/cz-cli`:

- `bun run typecheck` — passes, no errors
- `bun test test/analytics-agent-*.test.ts` — 114 pass / 0 fail (373 expect calls, 10 files)

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR