### PR TITLE
fix(cz-cli): precheck task submits and poll flow publish status

### DIFF
--- a/openspec/specs/task-flow-management/spec.md
+++ b/openspec/specs/task-flow-management/spec.md
@@ -82,6 +82,24 @@ flow 节点内容、cron、VC、schema 与参数配置 MUST 以父 flow task 为
 - **THEN** 系统保存父 flow 调度配置并提交/发布 flow
 - **AND** 缺失或非法 cron 时返回可诊断错误
 
+#### Scenario: 提交 draft flow 时走 flow 发布接口
+
+- **WHEN** 用户执行 `cz-cli task flow submit FLOW_TASK` 且该任务是已配置节点的 draft flow
+- **THEN** CLI MUST 使用 flow 发布接口语义提交 `fileId`
+- **AND** MUST NOT 误走通用 task 发布接口导致 `文件参数不匹配`
+
+#### Scenario: 提交 flow 前先检查 workspace 参数
+
+- **WHEN** 用户执行 `cz-cli task flow submit FLOW_TASK`
+- **THEN** CLI MUST 在真正提交前调用 workspace 参数预检查
+- **AND** 若存在未发布、已停用或不存在的项目参数，CLI MUST 返回可诊断错误且不调用 flow 发布接口
+
+#### Scenario: flow 提交后轮询异步提交状态
+
+- **WHEN** flow 发布接口返回 `submitTraceId`
+- **THEN** CLI MUST 轮询 flow 提交状态直到成功、失败或超时
+- **AND** 当状态为失败时，CLI MUST 返回业务错误而不是误报提交成功
+
 #### Scenario: 手动执行流程
 
 - **WHEN** 用户执行 `cz-cli task flow run FLOW_TASK --vc DEFAULT --param ds=2026-01-01`

--- a/openspec/specs/task-management/spec.md
+++ b/openspec/specs/task-management/spec.md
@@ -207,6 +207,12 @@ CLI task 类型、状态、调度频率等 Studio 后端契约 MUST 通过集中
 - **THEN** 系统发布任务
 - **AND** 返回发布版本或状态信息
 
+#### Scenario: deploy 前先检查 workspace 参数
+
+- **WHEN** 用户执行 `cz-cli task deploy TASK -y`
+- **THEN** CLI MUST 在调用发布接口前执行 workspace 参数预检查
+- **AND** 若任务引用了未发布、已停用或不存在的项目参数，CLI MUST 返回可诊断错误且不调用发布接口
+
 #### Scenario: undeploy 需要确认
 
 - **WHEN** 用户执行 `cz-cli task undeploy TASK` 且未提供 `-y`

--- a/packages/clickzetta-sdk/src/studio/flow.ts
+++ b/packages/clickzetta-sdk/src/studio/flow.ts
@@ -45,6 +45,18 @@ export interface ExecuteFlowParams {
   nodeParams?: { id: number; name: string; paramValueList?: unknown[] }[]
 }
 
+export interface SubmitFlowParams {
+  fileId: number
+  projectId: number
+  env?: string
+  commitMsg?: string
+  approvers?: number[]
+}
+
+export interface CheckFlowSubmitStatusParams {
+  submitTraceId: string
+}
+
 export interface ListFlowInstancesParams {
   flowId: number
   flowInstanceId?: number
@@ -229,6 +241,38 @@ export function executeFlow(config: StudioConfig, params: ExecuteFlowParams) {
       updateBy: params.updateBy,
       dataFileId: params.dataFileId,
       instanceName: params.instanceName,
+    },
+  )
+}
+
+export function submitFlow(config: StudioConfig, params: SubmitFlowParams) {
+  return studioRequest(
+    config,
+    "/ide-admin/v1/flow/submit",
+    {
+      fileId: params.fileId,
+      projectId: params.projectId,
+      env: params.env ?? config.env,
+      ...(params.commitMsg !== undefined && { commitMsg: params.commitMsg }),
+      ...(params.approvers !== undefined && { approvers: params.approvers }),
+    },
+    {
+      tenantId: String(config.tenantId),
+      userId: String(config.userId),
+      env: config.env,
+      openApi: "false",
+    },
+  )
+}
+
+export function checkFlowSubmitStatus(config: StudioConfig, params: CheckFlowSubmitStatusParams) {
+  return studioRequest<number>(
+    config,
+    `/ide-admin/v1/flow/checkSubmitStatus?submitTraceId=${encodeURIComponent(params.submitTraceId)}`,
+    {},
+    {
+      tenantId: String(config.tenantId),
+      openApi: "false",
     },
   )
 }

--- a/packages/clickzetta-sdk/src/studio/task.ts
+++ b/packages/clickzetta-sdk/src/studio/task.ts
@@ -101,6 +101,27 @@ export interface SubmitTaskParams {
   updatedBy: string
 }
 
+export interface WorkspaceParamInvalidParam {
+  paramKey?: string
+  reason?: string
+}
+
+export interface TaskPreCheckDetail {
+  fileId?: number
+  fileName?: string
+  invalidParams?: WorkspaceParamInvalidParam[]
+}
+
+export interface TaskPreCheckParams {
+  projectId: number
+  fileIds: number[]
+}
+
+export interface TaskPreCheckResult {
+  pass?: boolean
+  details?: TaskPreCheckDetail[]
+}
+
 export interface GetTaskDependenciesParams {
   currentId: number
   fileIds: number[]
@@ -251,6 +272,17 @@ export function submitTask(config: StudioConfig, params: SubmitTaskParams) {
     projectId: params.projectId,
     updatedBy: params.updatedBy,
   })
+}
+
+export function taskPreCheck(config: StudioConfig, params: TaskPreCheckParams) {
+  return studioRequest<TaskPreCheckResult>(
+    config,
+    "/ide-admin/v1/workspaceParams/task/preCheck",
+    {
+      projectId: params.projectId,
+      fileIds: params.fileIds,
+    },
+  )
 }
 
 export function onlineTask(config: StudioConfig, taskId: number, projectId: number) {

--- a/packages/cz-cli/src/commands/task.ts
+++ b/packages/cz-cli/src/commands/task.ts
@@ -8,7 +8,7 @@ import {
   listFolders, createFolder,
   executeAdhoc, getRunDetail,
   getFlowDag, createFlowNode, bindFlowNode, unbindFlowNode,
-  removeFlowNode, executeFlow, getFlowParams, listFlowInstances,
+  removeFlowNode, executeFlow, getFlowParams, listFlowInstances, submitFlow, checkFlowSubmitStatus,
   saveFlowNodeContent, getFlowNodeDetail, saveFlowNodeConfig,
   getInstanceStats, getTaskRunStats,
   getAllDownstream, previewScheduleInstanceTimes,
@@ -29,6 +29,7 @@ import {
   stopRealtimeTask,
   listPgSlots,
   listPgPublications,
+  taskPreCheck,
   resolveVclusterId,
   studioRequest,
   type StudioConfig,
@@ -358,6 +359,44 @@ async function ctx(argv: Record<string, unknown>): Promise<StudioConfig> {
 function reportTaskError(err: unknown, format: string | undefined): void {
   if (isHandledCliError(err)) return
   error("TASK_ERROR", err instanceof Error ? err.message : String(err), { format })
+}
+
+function summarizeWorkspaceParamFailure(detail: Record<string, unknown>): string {
+  const label = String(detail.fileName ?? detail.fileId ?? "unknown task")
+  const invalidParams = getObjectList(detail.invalidParams)
+  if (!invalidParams.length) return label
+  return `${label}: ${invalidParams.map((item) => `${String(item.paramKey ?? "unknown")}(${String(item.reason ?? "invalid")})`).join(", ")}`
+}
+
+async function ensureTaskPreCheck(sc: StudioConfig, fileIds: number[], format: string | undefined): Promise<void> {
+  const resp = await taskPreCheck(sc, { projectId: sc.projectId, fileIds })
+  const data = isRecord(resp.data) ? resp.data : {}
+  const details = getObjectList(data.details)
+  const invalidDetails = details.filter((detail) => getObjectList(detail.invalidParams).length > 0)
+  if (data.pass === true && invalidDetails.length === 0) return
+  const message = invalidDetails.length > 0
+    ? `Workspace param pre-check failed: ${invalidDetails.map(summarizeWorkspaceParamFailure).join("; ")}`
+    : `Workspace param pre-check failed for task ${fileIds.join(", ")}.`
+  handledError("WORKSPACE_PARAM_PRECHECK_FAILED", message, {
+    format,
+    extra: { details: invalidDetails.length > 0 ? invalidDetails : details },
+  })
+}
+
+async function waitForFlowSubmit(sc: StudioConfig, submitTraceId: string, format: string | undefined): Promise<number | undefined> {
+  for (let i = 0; i < 20; i++) {
+    if (i > 0) await new Promise((r) => setTimeout(r, 1500))
+    const resp = await checkFlowSubmitStatus(sc, { submitTraceId })
+    const status = typeof resp.data === "number" ? resp.data : Number(resp.data)
+    if (status === 2) return status
+    if (status === 3) {
+      handledError("FLOW_SUBMIT_FAILED", `Flow submit failed (submitTraceId=${submitTraceId}).`, {
+        format,
+        extra: { submit_trace_id: submitTraceId, submit_status: status },
+      })
+    }
+  }
+  return undefined
 }
 
 // Multi-table CDC pipeline lifecycle subcommands (fileType 281 = MULTI_REALTIME).
@@ -2803,6 +2842,7 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
                 return
               }
             }
+            await ensureTaskPreCheck(sc, [fileId], format)
             const resp = await submitTask(sc, {
               commitMsg: "Published via cz-cli",
               dataFileId: fileId,
@@ -3757,12 +3797,15 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
                     ...(nodeParams !== undefined && { paramValueList: nodeParams }),
                   })
                 }))
-                await submitTask(sc, {
+                await ensureTaskPreCheck(sc, [fileId], format)
+                const submitResp = await submitFlow(sc, {
                   commitMsg: "Published flow via cz-cli",
-                  dataFileId: fileId,
+                  fileId,
                   projectId: sc.projectId,
-                  updatedBy: String(sc.userId),
+                  env: sc.env,
                 })
+                const submitTraceId = typeof submitResp.data === "string" ? submitResp.data : String(submitResp.data ?? "")
+                if (submitTraceId) await waitForFlowSubmit(sc, submitTraceId, format)
                 let published = false
                 for (let i = 0; i < 10; i++) {
                   if (i > 0) await new Promise((r) => setTimeout(r, 1500))

--- a/packages/cz-cli/test/task-condition-flow.test.ts
+++ b/packages/cz-cli/test/task-condition-flow.test.ts
@@ -21,9 +21,13 @@ const conditionContent = JSON.stringify({
 const saveTaskConfigCalls: Array<Record<string, unknown>> = []
 const saveFlowNodeConfigCalls: Array<Record<string, unknown>> = []
 const saveFlowNodeContentCalls: Array<Record<string, unknown>> = []
-const submitTaskCalls: Array<Record<string, unknown>> = []
+const submitFlowCalls: Array<Record<string, unknown>> = []
+const taskPreCheckCalls: Array<Record<string, unknown>> = []
+const checkFlowSubmitStatusCalls: Array<Record<string, unknown>> = []
 const bindFlowNodeCalls: Array<Record<string, unknown>> = []
 let failNodeConfigDetail = false
+let flowPreCheckPass = true
+let flowSubmitStatus = 2
 
 const actualSdk = await import("@clickzetta/sdk")
 const actualResolver = await import("../src/resolver.ts")
@@ -82,9 +86,21 @@ mock.module("@clickzetta/sdk", () => ({
     saveTaskConfigCalls.push(params)
     return { data: { ok: true } }
   },
-  submitTask: async (_config: Record<string, unknown>, params: Record<string, unknown>) => {
-    submitTaskCalls.push(params)
-    return { data: { ok: true } }
+  submitFlow: async (_config: Record<string, unknown>, params: Record<string, unknown>) => {
+    submitFlowCalls.push(params)
+    return { data: "trace-flow-001" }
+  },
+  taskPreCheck: async (_config: Record<string, unknown>, params: Record<string, unknown>) => {
+    taskPreCheckCalls.push(params)
+    return {
+      data: flowPreCheckPass
+        ? { pass: true, details: [{ fileId: 13412004, fileName: "condition_flow", invalidParams: [] }] }
+        : { pass: false, details: [{ fileId: 13412004, fileName: "condition_flow", invalidParams: [{ paramKey: "tenant", reason: "参数未上线(当前状态:未发布)" }] }] },
+    }
+  },
+  checkFlowSubmitStatus: async (_config: Record<string, unknown>, params: Record<string, unknown>) => {
+    checkFlowSubmitStatusCalls.push(params)
+    return { data: flowSubmitStatus }
   },
   saveTaskContent: async () => ({ data: { ok: true } }),
   getFlowDag: async () => ({
@@ -171,6 +187,7 @@ mock.module("../src/commands/studio-context.js", () => ({
     env: "prod",
     userName: "studi_test_1",
   }),
+  getProfileAgentContext: () => undefined,
 }))
 
 mock.module("../src/resolver.js", () => ({
@@ -196,9 +213,13 @@ beforeEach(() => {
   saveTaskConfigCalls.length = 0
   saveFlowNodeConfigCalls.length = 0
   saveFlowNodeContentCalls.length = 0
-  submitTaskCalls.length = 0
+  submitFlowCalls.length = 0
+  taskPreCheckCalls.length = 0
+  checkFlowSubmitStatusCalls.length = 0
   bindFlowNodeCalls.length = 0
   failNodeConfigDetail = false
+  flowPreCheckPass = true
+  flowSubmitStatus = 2
   mkdirSync(profileDir, { recursive: true })
   writeFileSync(profileFile, "[profiles.test]\npat = 'pat'\nworkspace = 'ws'\ninstance = 'inst'\n")
   process.env.CLICKZETTA_TEST_HOME = home
@@ -325,13 +346,22 @@ describe("condition task contracts", () => {
       vcCode: "NODE_SQL_VC",
       vcId: "node-sql-vc-id",
     })
-    expect(submitTaskCalls).toEqual([
+    expect(submitFlowCalls).toEqual([
       {
         commitMsg: "Published flow via cz-cli",
-        dataFileId: 13412004,
+        fileId: 13412004,
         projectId: 60001,
-        updatedBy: "12365",
+        env: "prod",
       },
+    ])
+    expect(taskPreCheckCalls).toEqual([
+      {
+        fileIds: [13412004],
+        projectId: 60001,
+      },
+    ])
+    expect(checkFlowSubmitStatusCalls).toEqual([
+      { submitTraceId: "trace-flow-001" },
     ])
   })
 
@@ -341,7 +371,29 @@ describe("condition task contracts", () => {
     const result = await execute("task flow submit 13412004 --vc AUTO_STOP_TEST_01")
 
     expect(result.exitCode).toBe(1)
-    expect(submitTaskCalls).toHaveLength(0)
+    expect(submitFlowCalls).toHaveLength(0)
     expect(saveFlowNodeContentCalls.some((call) => call.nodeId === 13412006)).toBe(false)
+  })
+
+  test("flow submit stops when workspace param pre-check fails", async () => {
+    flowPreCheckPass = false
+
+    const result = await execute("task flow submit 13412004 --vc AUTO_STOP_TEST_01")
+
+    expect(result.exitCode).toBe(1)
+    expect(submitFlowCalls).toHaveLength(0)
+    expect(checkFlowSubmitStatusCalls).toHaveLength(0)
+  })
+
+  test("flow submit returns error when async submit status becomes failed", async () => {
+    flowSubmitStatus = 3
+
+    const result = await execute("task flow submit 13412004 --vc AUTO_STOP_TEST_01")
+
+    expect(result.exitCode).toBe(1)
+    expect(submitFlowCalls).toHaveLength(1)
+    expect(checkFlowSubmitStatusCalls).toEqual([
+      { submitTraceId: "trace-flow-001" },
+    ])
   })
 })

--- a/packages/cz-cli/test/task-merge.test.ts
+++ b/packages/cz-cli/test/task-merge.test.ts
@@ -11,7 +11,9 @@ const createCalls: Array<Record<string, unknown>> = []
 const saveContentCalls: Array<Record<string, unknown>> = []
 const saveConfigCalls: Array<Record<string, unknown>> = []
 const submitTaskCalls: Array<Record<string, unknown>> = []
+const taskPreCheckCalls: Array<Record<string, unknown>> = []
 let mergeHasConfig = true
+let taskPreCheckPass = true
 
 const actualSdk = await import("@clickzetta/sdk")
 const actualResolver = await import("../src/resolver.ts")
@@ -75,6 +77,14 @@ mock.module("@clickzetta/sdk", () => ({
     submitTaskCalls.push(params)
     return { data: true }
   },
+  taskPreCheck: async (_config: Record<string, unknown>, params: Record<string, unknown>) => {
+    taskPreCheckCalls.push(params)
+    return {
+      data: taskPreCheckPass
+        ? { pass: true, details: [{ fileId: 13535004, fileName: "merge_task", invalidParams: [] }] }
+        : { pass: false, details: [{ fileId: 13535004, fileName: "merge_task", invalidParams: [{ paramKey: "tenant", reason: "参数不存在" }] }] },
+    }
+  },
 }))
 
 mock.module("../src/commands/studio-context.js", () => ({
@@ -86,6 +96,7 @@ mock.module("../src/commands/studio-context.js", () => ({
     workspaceName: "quick_start",
     baseUrl: "https://api.example.com",
   }),
+  getProfileAgentContext: () => undefined,
   getGatewayContext: async () => ({
     projectId: 1417759,
     workspaceId: 1,
@@ -131,7 +142,9 @@ beforeEach(() => {
   saveContentCalls.length = 0
   saveConfigCalls.length = 0
   submitTaskCalls.length = 0
+  taskPreCheckCalls.length = 0
   mergeHasConfig = true
+  taskPreCheckPass = true
   mkdirSync(profileDir, { recursive: true })
   writeFileSync(profileFile, "[profiles.test]\npat = 'pat'\nworkspace = 'quick_start'\ninstance = 'tmwmzxzs'\n")
   process.env.CLICKZETTA_TEST_HOME = home
@@ -257,5 +270,24 @@ describe("task merge", () => {
         updatedBy: "studi_test_1",
       },
     ])
+    expect(taskPreCheckCalls).toEqual([
+      {
+        fileIds: [13535004],
+        projectId: 1417759,
+      },
+    ])
+  })
+
+  test("deploy blocks submit when workspace param pre-check fails", async () => {
+    taskPreCheckPass = false
+
+    const result = await execute("task deploy merge_task -y")
+    const json = firstJson(result.output)
+
+    expect(result.exitCode).toBe(1)
+    expect(json.error).toMatchObject({
+      code: "WORKSPACE_PARAM_PRECHECK_FAILED",
+    })
+    expect(submitTaskCalls).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
- add workspace param pre-check before `task deploy` and `task flow submit`
- switch flow publish to the flow-specific submit API and poll async flow submit status
- add specs and regression tests for pre-check and failed async flow submit handling

## Testing
- `bun test test/task-condition-flow.test.ts`
- `bun test test/task-merge.test.ts`
- `bun typecheck` in `packages/clickzetta-sdk`
- `bun typecheck` in `packages/cz-cli`
- `bun src/main.ts --debug task flow submit 13585004 --workspace wanxin-test-ws-03 --format json`
