### PR TITLE
feat(analytics-agent): batch enable/disable, table columns alias, richer help

### DIFF
--- a/openspec/specs/analytics-agent-answer-builder/spec.md
+++ b/openspec/specs/analytics-agent-answer-builder/spec.md
@@ -26,6 +26,42 @@
 - **WHEN** 用户执行 `cz-cli analytics-agent answer-builder create --help`
 - **THEN** help 中不包含 `--body`
 
+#### Scenario: create help 提供可复制的使用示例
+
+- **WHEN** 用户执行 `cz-cli analytics-agent answer-builder create --help`
+- **THEN** help 输出包含 `Examples:` 段
+- **且** 示例提示先用 `validate` 校验 `--content` DSL
+
+### Requirement: answer-builder 命令组帮助说明与 metric 的关系
+
+`cz-cli analytics-agent answer-builder --help` MUST 在 epilogue 中说明 answer-builder 是 complex_metric（多步/多表 DSL 分析），单表单聚合应使用 `metric`（simple_metric），且两者都计入 `domain detail` 的 targetCounts，并提示可用 `--domain-id` 把 `answer-builder list` 限定到单个 domain。
+
+#### Scenario: answer-builder 组帮助解释 complex/simple metric 关系
+
+- **WHEN** 用户执行 `cz-cli analytics-agent answer-builder`（缺子命令，渲染组帮助）
+- **THEN** 帮助输出包含 `complex_metric`
+- **且** 帮助输出包含 `simple_metric`
+- **且** 帮助输出提到 `targetCounts`
+
+### Requirement: answer-builder enable/disable 支持按 domain 批量操作
+
+`cz-cli analytics-agent answer-builder enable` 与 `disable` MUST 同时支持单条模式（positional `analysis-id`）与批量模式（`--all --domain-id <id>`）。两种模式互斥且至少提供其一。批量模式 MUST 先列出该 domain 下的 answer-builder，跳过已处于目标状态的项，对其余逐个调用单条 enable/disable，并汇总 `total`、`succeeded`、`failed`、`skipped` 与逐项 `results`。批量 disable MUST 复用单条 disable 的 detail+update 回退逻辑。
+
+#### Scenario: 批量 disable 跳过已禁用项并禁用其余
+
+- **WHEN** 用户执行 `cz-cli analytics-agent answer-builder disable --all --domain-id 27`
+- **AND** 该 domain 下有 2 个 answer-builder，其中 1 个已是 `DISABLE`
+- **THEN** CLI 先调用 answer-builder list
+- **且** 对已 `DISABLE` 的项标记为 `skipped`，不再调用 disable
+- **且** 对其余 1 项执行禁用
+- **且** 输出包含 `total=2`、`succeeded=1`、`skipped=1`、`failed=0`
+
+#### Scenario: 同时传 id 与 --all 时本地拒绝
+
+- **WHEN** 用户执行 `cz-cli analytics-agent answer-builder enable 9 --all`
+- **THEN** CLI MUST 在发请求前直接返回 `USAGE_ERROR`
+- **且** 错误信息 MUST 说明二者互斥
+
 ### Requirement: answer-builder list 使用扁平过滤参数
 
 `cz-cli analytics-agent answer-builder list` MUST 使用显式过滤参数构造请求体，不把 `--body` 暴露为普通用户主路径。

--- a/openspec/specs/analytics-agent-metric/spec.md
+++ b/openspec/specs/analytics-agent-metric/spec.md
@@ -73,7 +73,7 @@
 
 ### Requirement: metric enable/disable 支持按 domain 批量操作
 
-`cz-cli analytics-agent metric enable` 与 `disable` MUST 同时支持单条模式（positional `metric-id`）与批量模式（`--all --domain-id <id>`）。两种模式互斥且至少提供其一。批量模式 MUST 先列出该 domain 下的 metric，跳过已处于目标状态的项，对其余逐个调用单条 enable/disable，并汇总 `total`、`succeeded`、`failed`、`skipped` 与逐项 `results`。批量 disable MUST 复用单条 disable 的 detail+update 回退逻辑。
+`cz-cli analytics-agent metric enable` 与 `disable` MUST 同时支持单条模式（positional `metric-id`）与批量模式（`--all --domain-id <id>`）。两种模式互斥且至少提供其一。批量模式 MUST 先列出该 domain 下的 metric，跳过已处于目标状态的项，对其余逐个调用单条 enable/disable，并汇总 `total`、`succeeded`、`failed`、`skipped` 与逐项 `results`。批量列表 MUST 翻页覆盖 domain 下的全部 metric，不得只处理服务端默认第一页。批量 disable MUST 复用单条 disable 的 detail+update 回退逻辑。
 
 #### Scenario: 批量 enable 跳过已启用项并启用其余
 
@@ -83,6 +83,13 @@
 - **且** 对已 `ENABLE` 的项标记为 `skipped`，不再调用 enable
 - **且** 对其余 2 项调用 `/metrics/enable`
 - **且** 输出包含 `total=3`、`succeeded=2`、`skipped=1`、`failed=0`
+
+#### Scenario: 批量操作翻页覆盖首页之外的项
+
+- **WHEN** 用户执行 `cz-cli analytics-agent metric enable --all --domain-id 27`
+- **AND** 该 domain 下的 metric 数量超过服务端单页默认条数
+- **THEN** CLI MUST 按页请求 metric list 直到取回全部项
+- **且** 汇总的 `total` 等于 domain 下 metric 的真实总数，而非单页条数
 
 #### Scenario: 批量操作部分失败时返回非零退出码
 

--- a/openspec/specs/analytics-agent-metric/spec.md
+++ b/openspec/specs/analytics-agent-metric/spec.md
@@ -49,6 +49,66 @@
 - **THEN** help 中不包含 `--body`
 - **且** help 中保留 `--alias`
 
+### Requirement: metric create help 提供可复制的使用示例
+
+`cz-cli analytics-agent metric create --help` MUST 提供至少一个可直接复制的完整示例，帮助用户推断 `--table-name` 全限定格式与 `--expression` 聚合写法，降低首次调用的重试率。示例 MUST 引导用户用虚拟列封装字符串条件，而非在 `--expression` 中直接写字符串字面量（后端 SQL 校验层拒绝字符串字面量）。
+
+#### Scenario: create help 展示全限定表名与聚合示例
+
+- **WHEN** 用户执行 `cz-cli analytics-agent metric create --help`
+- **THEN** help 输出包含 `Examples:` 段
+- **且** 示例中包含全限定表名格式提示 `catalog.schema.table`
+- **且** 示例引导用虚拟列（如 `win_flag`）封装条件，而非 SQL 字符串字面量
+
+### Requirement: metric 命令组帮助说明与 answer-builder 的关系
+
+`cz-cli analytics-agent metric --help` MUST 在 epilogue 中说明 metric 是 simple_metric（单表单聚合），多步/多表分析应使用 `answer-builder`（complex_metric），且两者都计入 `domain detail` 的 targetCounts，避免用户混淆两个命令组的定位。
+
+#### Scenario: metric 组帮助解释 simple/complex metric 关系
+
+- **WHEN** 用户执行 `cz-cli analytics-agent metric`（缺子命令，渲染组帮助）
+- **THEN** 帮助输出包含 `simple_metric`
+- **且** 帮助输出提示改用 `answer-builder`
+- **且** 帮助输出提到 `targetCounts`
+
+### Requirement: metric enable/disable 支持按 domain 批量操作
+
+`cz-cli analytics-agent metric enable` 与 `disable` MUST 同时支持单条模式（positional `metric-id`）与批量模式（`--all --domain-id <id>`）。两种模式互斥且至少提供其一。批量模式 MUST 先列出该 domain 下的 metric，跳过已处于目标状态的项，对其余逐个调用单条 enable/disable，并汇总 `total`、`succeeded`、`failed`、`skipped` 与逐项 `results`。批量 disable MUST 复用单条 disable 的 detail+update 回退逻辑。
+
+#### Scenario: 批量 enable 跳过已启用项并启用其余
+
+- **WHEN** 用户执行 `cz-cli analytics-agent metric enable --all --domain-id 27`
+- **AND** 该 domain 下有 3 个 metric，其中 1 个已是 `ENABLE`
+- **THEN** CLI 先调用 metric list
+- **且** 对已 `ENABLE` 的项标记为 `skipped`，不再调用 enable
+- **且** 对其余 2 项调用 `/metrics/enable`
+- **且** 输出包含 `total=3`、`succeeded=2`、`skipped=1`、`failed=0`
+
+#### Scenario: 批量操作部分失败时返回非零退出码
+
+- **WHEN** 用户执行 `cz-cli analytics-agent metric enable --all --domain-id 27`
+- **AND** 其中一项调用 enable 时后端返回业务错误
+- **THEN** CLI 继续处理其余项，不中断
+- **且** 输出中该项 `result=failed` 并带 `error`
+- **且** 命令退出码为非零
+
+#### Scenario: 同时传 id 与 --all 时本地拒绝
+
+- **WHEN** 用户执行 `cz-cli analytics-agent metric enable 197 --all`
+- **THEN** CLI MUST 在发请求前直接返回 `USAGE_ERROR`
+- **且** 错误信息 MUST 说明二者互斥
+
+#### Scenario: --all 缺少 --domain-id 时本地拒绝
+
+- **WHEN** 用户执行 `cz-cli analytics-agent metric enable --all`
+- **THEN** CLI MUST 在发请求前直接返回 `USAGE_ERROR`
+- **且** 错误信息 MUST 提示需要 `--domain-id`
+
+#### Scenario: 既无 id 也无 --all 时本地拒绝
+
+- **WHEN** 用户执行 `cz-cli analytics-agent metric enable`
+- **THEN** CLI MUST 在发请求前直接返回 `USAGE_ERROR`
+
 ### Requirement: metric disable 兼容旧状态接口异常并回退到 detail + update
 
 当服务端直接 `disable` 路径返回“对象不存在”这类旧兼容异常时，`cz-cli analytics-agent metric disable` MUST 优先尝试读取 detail，再用完整 update 请求把 `status` 改为 `DISABLE`，避免用户因为旧状态路由异常而无法禁用 metric。
@@ -61,3 +121,14 @@
 - **且** 再调用 `metric update`
 - **且** update 请求体包含 detail 中的核心字段与 `status=DISABLE`
 - **且** 最终命令返回成功
+
+#### Scenario: disable 遇到非 not-found 的后端错误时如实上报
+
+- **WHEN** 用户执行 `cz-cli analytics-agent metric disable 184`
+- **AND** 后端返回非 not-found 业务错误（例如 `CZD-99999` 约束违反）
+- **THEN** CLI MUST NOT 触发 detail+update 回退（回退仅针对 not-found 类异常）
+- **且** CLI 如实上报该后端错误码与信息
+- **且** 命令退出码为非零
+- **且** metric 本地状态保持不变（不产生部分写入）
+
+> 已知后端限制：在部分环境，metric disable 会触发后端 `CZD-99999`（`common_reference_relationship.source_id` 非空约束违反），单条与批量 disable 均会命中。此为后端缺陷，CLI 侧仅保证如实透传错误、退出码非零、不改本地状态。

--- a/openspec/specs/analytics-agent-table-semantics/spec.md
+++ b/openspec/specs/analytics-agent-table-semantics/spec.md
@@ -16,6 +16,17 @@
 - **且** 请求包含 open token 鉴权和 `tenantId` query
 - **且** 输出包含每个字段的 `attrId`、`attrCode`、`semanticType`、`description`、`hidden`
 
+### Requirement: table columns 作为 semantics list 的扁平别名
+
+`cz-cli analytics-agent table columns <dataset-id>` MUST 作为 `table semantics list <dataset-id>` 的扁平别名，调用同一个 dataset 语义 open API 并返回相同结果，用于缩短查看数据集列语义的命令层级。
+
+#### Scenario: columns 别名命中与 semantics list 相同的端点
+
+- **WHEN** 用户执行 `cz-cli analytics-agent table columns 195`
+- **THEN** CLI 调用 `GET /open/api/v1/analytics-agent/datasets/195/semantics`
+- **且** 输出包含每个字段的 `attrId`、`attrCode`、`semanticType`、`description`、`hidden`
+- **且** 输出与 `cz-cli analytics-agent table semantics list 195` 一致
+
 ### Requirement: table semantics get 查看单个字段语义详情
 
 `cz-cli analytics-agent table semantics get` MUST 支持按 `datasetId + attrId` 查看单个字段的语义详情。

--- a/openspec/specs/analytics-agent/spec.md
+++ b/openspec/specs/analytics-agent/spec.md
@@ -22,6 +22,34 @@
 - **THEN** CLI 返回 usage error
 - **AND** 不调用远端服务
 
+### Requirement: id 参数本地校验为正整数
+
+`analytics-agent` 命令族的资源 id 参数（如 `domain-id`、`dataset-id`、`attr-id`、`metric-id`、`analysis-id`、`node-id`、`space-id`、`join-id`、`table-id`、`datasource-id`、`question-id`、`session-id` 等）MUST 在发请求前本地校验为正整数（安全整数范围内、> 0）。非数字、小数、0、负数、超出安全整数范围的输入 MUST 直接返回 `USAGE_ERROR`，不得把非法值发给后端而暴露为 HTTP 500 或后端 NPE。表示根节点的 `parent-id`（允许为 0）不受此约束。
+
+#### Scenario: 非数字 id 本地拒绝
+
+- **WHEN** 用户执行 `cz-cli analytics-agent domain detail abc`
+- **THEN** CLI MUST 在发请求前直接返回 `USAGE_ERROR`
+- **且** 错误信息 MUST 说明该 id 必须是正整数
+- **AND** 不调用远端服务
+
+#### Scenario: 小数 / 0 / 负数 / 溢出 id 本地拒绝
+
+- **WHEN** 用户对任一资源 id 传入 `27.5`、`0`、`-1` 或超出安全整数范围的值（如 `99999999999999999999`）
+- **THEN** CLI MUST 在发请求前直接返回 `USAGE_ERROR`
+- **AND** 不调用远端服务
+
+#### Scenario: 合法 id 正常放行
+
+- **WHEN** 用户传入正整数 id
+- **THEN** 校验通过并正常调用远端服务
+
+#### Scenario: parent-id 允许为 0（根节点）
+
+- **WHEN** 用户执行 `cz-cli analytics-agent knowledge file list <space-id> --parent-id 0`
+- **THEN** CLI MUST NOT 因 `parent-id=0` 报 `USAGE_ERROR`
+- **且** 正常按根节点查询
+
 ### Requirement: 输出字段面向用户和 agent
 
 本需求 MUST 按以下场景执行。

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -5,7 +5,7 @@ import { createTraceparent } from "@clickzetta/sdk"
 import type { GlobalArgs } from "../cli.js"
 import { commandGroup } from "../command-group.js"
 import { readAgentEndpoint } from "../connection/profile-store.js"
-import { success, error, handledError, isHandledCliError, shouldColorize, renderOutput } from "../output/index.js"
+import { success, error, handledError, isHandledCliError, shouldColorize, renderOutput, EXIT_BIZ_ERROR } from "../output/index.js"
 import { formatMarkdown } from "../output/formatter.js"
 import { getProfileAgentContext, getStudioContext, type StudioContext } from "./studio-context.js"
 import { logOperation } from "../logger.js"
@@ -299,6 +299,24 @@ function pickTableSemanticsFields(value: unknown): Record<string, unknown> {
   }
 }
 
+async function runTableSemanticsList(argv: Record<string, unknown>): Promise<void> {
+  const format = typeof argv.format === "string" ? argv.format : "json"
+  const t0 = Date.now()
+  try {
+    const payload = await requestAnalytics(argv, ROUTES.tableSemanticsList, {})
+    const bizErr = extractBusinessError(payload)
+    if (bizErr) { error(bizErr.code, bizErr.message, { format }); return }
+    const data = unwrapResponse(payload)
+    const items = Array.isArray(data) ? data : []
+    success(items.map((item) => pickTableSemanticsFields(item)), { format, timeMs: Date.now() - t0 })
+  } catch (err) {
+    if (isHandledCliError(err)) return
+    error("ANALYTICS_AGENT_ERROR", err instanceof Error ? err.message : String(err), {
+      format, ...(err instanceof AnalyticsHttpError ? { extra: { request: err.request } } : {}),
+    })
+  }
+}
+
 const DOMAIN_JOIN_RELATIONS = new Set(["n:1", "1:n", "1:1", "MANY_TO_ONE", "ONE_TO_MANY", "ONE_TO_ONE"])
 
 function resolveDomainJoinPathArgv(argv: Record<string, unknown>, format: string): Record<string, unknown> {
@@ -540,6 +558,158 @@ async function executeStatusCommandWithUpdateFallback(
     logOperation(name, { ok: false, timeMs: Date.now() - t0 })
     if (isHandledCliError(err)) return
     error("ANALYTICS_AGENT_ERROR", err instanceof Error ? err.message : String(err), {
+      format,
+      ...(err instanceof AnalyticsHttpError ? { extra: { request: err.request } } : {}),
+    })
+  }
+}
+
+type StatusChangeMode =
+  | { mode: "single"; id: number }
+  | { mode: "batch"; domainId: number; datasourceId: number | undefined }
+
+// Decide whether an enable/disable invocation targets one id (positional) or a
+// whole domain (--all --domain-id). The two are mutually exclusive; one is
+// required. Prints USAGE_ERROR and throws the handled sentinel on misuse.
+function resolveStatusChangeMode(
+  argv: Record<string, unknown>,
+  positionalKey: string,
+  format: string,
+): StatusChangeMode {
+  const rawId = argv[positionalKey]
+  const hasId = rawId !== undefined
+  const all = argv.all === true
+  const domainIdRaw = argv["domain-id"]
+
+  if (hasId && all) {
+    handledError("USAGE_ERROR", `Pass either a single <${positionalKey}> or --all, not both.`, { format })
+  }
+  if (hasId) {
+    return { mode: "single", id: positiveIntegerValue(rawId, `--${positionalKey}`, format) as number }
+  }
+  if (all) {
+    if (domainIdRaw === undefined) {
+      handledError("USAGE_ERROR", "--all requires --domain-id to scope the batch.", { format })
+    }
+    return {
+      mode: "batch",
+      domainId: requiredPositiveIntegerValue(domainIdRaw, "--domain-id", format),
+      datasourceId: positiveIntegerValue(argv["datasource-id"], "--datasource-id", format),
+    }
+  }
+  return handledError("USAGE_ERROR", `Provide a <${positionalKey}> or use --all --domain-id <id> for a batch.`, { format })
+}
+
+interface BatchTargetItem {
+  id: number
+  name: string
+  status: string
+}
+
+function extractBatchTargets(data: unknown, nameKey: string): BatchTargetItem[] {
+  if (!Array.isArray(data)) return []
+  const targets: BatchTargetItem[] = []
+  for (const item of data) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue
+    const record = item as Record<string, unknown>
+    const id = numberValue(record.id)
+    if (id === undefined) continue
+    const rawName = record[nameKey]
+    const name = typeof rawName === "string"
+      ? rawName
+      : Array.isArray(rawName) && typeof rawName[0] === "string"
+        ? rawName[0]
+        : String(id)
+    const status = typeof record.status === "string" ? record.status : ""
+    targets.push({ id, name, status })
+  }
+  return targets
+}
+
+// Per-item status change that throws on failure (for batch use), mirroring the
+// single-item disable's primary→detail→update fallback: some ids reject the
+// direct enable/disable endpoint and must be flipped via a full update payload.
+async function applyStatusChangeWithFallback(
+  argv: Record<string, unknown>,
+  id: number,
+  status: "ENABLE" | "DISABLE",
+  ctx: ResolvedContext,
+  primaryRoute: AnalyticsRoute,
+  detailRoute: AnalyticsRoute,
+  updateRoute: AnalyticsRoute,
+  buildUpdateBody: (detail: unknown, status: "ENABLE" | "DISABLE") => Record<string, unknown> | null,
+): Promise<void> {
+  const body = { id }
+  try {
+    await requestAnalyticsData(argv, primaryRoute, body, {}, ctx)
+    return
+  } catch (err) {
+    const isNotFound = err instanceof AnalyticsBusinessError && shouldFallbackStatusCommand(err)
+    const isServerErr = err instanceof AnalyticsHttpError && (err.request.status ?? 0) >= 500
+    if (!isNotFound && !isServerErr) throw err
+  }
+  const detail = await requestAnalyticsData(argv, detailRoute, body, {}, ctx)
+  const updateBody = buildUpdateBody(detail, status)
+  if (!updateBody) {
+    throw new AnalyticsBusinessError("ANALYTICS_AGENT_ERROR", `could not build update payload for id ${id}`)
+  }
+  await requestAnalyticsData(argv, updateRoute, updateBody, {}, ctx)
+}
+
+async function runBatchStatusChange(
+  name: string,
+  argv: Record<string, unknown>,
+  targetStatus: "ENABLE" | "DISABLE",
+  listRoute: AnalyticsRoute,
+  listBody: Record<string, unknown>,
+  nameKey: string,
+  applyOne: (id: number, ctx: ResolvedContext) => Promise<void>,
+): Promise<void> {
+  const format = typeof argv.format === "string" ? argv.format : "json"
+  const t0 = Date.now()
+  try {
+    const ctx = await resolveAnalyticsContext(argv)
+    const listData = await requestAnalyticsData(argv, listRoute, listBody, {}, ctx)
+    const targets = extractBatchTargets(listData, nameKey)
+
+    const results: Array<Record<string, unknown>> = []
+    let succeeded = 0
+    let failed = 0
+    let skipped = 0
+
+    for (const target of targets) {
+      if (target.status === targetStatus) {
+        skipped++
+        results.push({ id: target.id, name: target.name, result: "skipped", reason: `already ${targetStatus}` })
+        continue
+      }
+      try {
+        await applyOne(target.id, ctx)
+        succeeded++
+        results.push({ id: target.id, name: target.name, result: "succeeded" })
+      } catch (err) {
+        failed++
+        const message = err instanceof AnalyticsBusinessError
+          ? `${err.code}: ${err.message}`
+          : err instanceof Error ? err.message : String(err)
+        results.push({ id: target.id, name: target.name, result: "failed", error: message })
+      }
+    }
+
+    logOperation(name, { ok: failed === 0, timeMs: Date.now() - t0 })
+    success(
+      { total: targets.length, succeeded, failed, skipped, results },
+      { format, timeMs: Date.now() - t0 },
+    )
+    // success() resets exitCode to EXIT_OK; override AFTER it so a partial
+    // failure surfaces as a non-zero exit for scripts.
+    if (failed > 0) process.exitCode = EXIT_BIZ_ERROR
+  } catch (err) {
+    logOperation(name, { ok: false, timeMs: Date.now() - t0 })
+    if (isHandledCliError(err)) return
+    const message = err instanceof AnalyticsBusinessError ? err.message : err instanceof Error ? err.message : String(err)
+    const code = err instanceof AnalyticsBusinessError ? err.code : "ANALYTICS_AGENT_ERROR"
+    error(code, message, {
       format,
       ...(err instanceof AnalyticsHttpError ? { extra: { request: err.request } } : {}),
     })
@@ -1792,29 +1962,20 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
         return commandGroup(domain, "analytics-agent domain")
       })
       .command("table", "Manage Analytics Agent table semantics", (table) => {
+        table
+          .command(
+            "columns <dataset-id>",
+            "List column semantics of a dataset (alias for `table semantics list`)",
+            (y) => y.positional("dataset-id", { type: "number", demandOption: true, describe: "Dataset ID" }),
+            (argv) => runTableSemanticsList(argv as Record<string, unknown>),
+          )
         table.command("semantics", "Manage dataset column semantics", (semantics) => {
           semantics
             .command(
               "list <dataset-id>",
               "List semantics for all columns in a dataset",
               (y) => y.positional("dataset-id", { type: "number", demandOption: true, describe: "Dataset ID" }),
-              async (argv) => {
-                const format = typeof argv.format === "string" ? argv.format : "json"
-                const t0 = Date.now()
-                try {
-                  const payload = await requestAnalytics(argv as Record<string, unknown>, ROUTES.tableSemanticsList, {})
-                  const bizErr = extractBusinessError(payload)
-                  if (bizErr) { error(bizErr.code, bizErr.message, { format }); return }
-                  const data = unwrapResponse(payload)
-                  const items = Array.isArray(data) ? data : []
-                  success(items.map((item) => pickTableSemanticsFields(item)), { format, timeMs: Date.now() - t0 })
-                } catch (err) {
-                  if (isHandledCliError(err)) return
-                  error("ANALYTICS_AGENT_ERROR", err instanceof Error ? err.message : String(err), {
-                    format, ...(err instanceof AnalyticsHttpError ? { extra: { request: err.request } } : {}),
-                  })
-                }
-              },
+              (argv) => runTableSemanticsList(argv as Record<string, unknown>),
             )
             .command(
               "get <dataset-id> <attr-id>",
@@ -2086,7 +2247,15 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("name", { type: "string", demandOption: true, describe: "Metric name" })
                 .option("expression", { type: "string", demandOption: true, describe: "Metric aggregate expression" })
                 .option("alias", { type: "string", array: true, describe: "Metric alias, can be repeated" })
-                .option("description", { type: "string", describe: "Metric description" }),
+                .option("description", { type: "string", describe: "Metric description" })
+                .example(
+                  'cz-cli analytics-agent metric create --domain-id 27 --datasource-id 8448 --table-name "quick_start.construction_dw.v_gpt_fact_bid" --name "总投标次数" --expression "COUNT(*)" --description "投标记录总数"',
+                  "Simple aggregate. --table-name must be fully qualified: catalog.schema.table",
+                )
+                .example(
+                  'cz-cli analytics-agent metric create --domain-id 27 --datasource-id 8448 --table-name "quick_start.construction_dw.v_gpt_fact_bid" --name "中标率" --expression "ROUND(SUM(win_flag)*100.0/COUNT(*),2)"',
+                  "Conditional metric. Wrap string comparisons in a virtual column (e.g. win_flag) instead of a SQL literal",
+                ),
             async (argv) => {
               const format = typeof argv.format === "string" ? argv.format : "json"
               const domainId = positiveIntegerValue(argv["domain-id"], "--domain-id", format)
@@ -2152,7 +2321,11 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("name", { type: "string", demandOption: true, describe: "Metric name" })
                 .option("expression", { type: "string", demandOption: true, describe: "Metric aggregate expression" })
                 .option("alias", { type: "string", array: true, describe: "Metric alias, can be repeated" })
-                .option("description", { type: "string", describe: "Metric description" }),
+                .option("description", { type: "string", describe: "Metric description" })
+                .example(
+                  'cz-cli analytics-agent metric validate --domain-id 27 --datasource-id 8448 --table-name "quick_start.construction_dw.v_gpt_fact_bid" --name "总投标次数" --expression "COUNT(*)"',
+                  "Dry-run a metric definition before create/update",
+                ),
             async (argv) => {
               const format = typeof argv.format === "string" ? argv.format : "json"
               const domainId = positiveIntegerValue(argv["domain-id"], "--domain-id", format)
@@ -2169,31 +2342,87 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
             },
           )
           .command(
-            "enable <metric-id>",
-            "Enable a metric",
+            "enable [metric-id]",
+            "Enable one metric, or all metrics in a domain with --all --domain-id",
             (y) =>
-              y.positional("metric-id", { type: "number", demandOption: true, describe: "Metric ID" }),
+              y
+                .positional("metric-id", { type: "number", describe: "Metric ID (omit and use --all --domain-id for a batch)" })
+                .option("all", { type: "boolean", describe: "Enable every metric in --domain-id" })
+                .option("domain-id", { type: "number", describe: "Domain ID (required with --all)" })
+                .option("datasource-id", { type: "number", describe: "Filter the batch to one datasource" })
+                .example("cz-cli analytics-agent metric enable 197", "Enable a single metric")
+                .example("cz-cli analytics-agent metric enable --all --domain-id 27", "Enable all metrics in a domain"),
             async (argv) => {
-              const body = mergeBody({}, { id: argv["metric-id"] })
-              await executeAnalyticsCommand("analytics-agent metric enable", argv as Record<string, unknown>, ROUTES.simpleMetricEnable, body)
+              const format = typeof argv.format === "string" ? argv.format : "json"
+              let target: StatusChangeMode
+              try {
+                target = resolveStatusChangeMode(argv as Record<string, unknown>, "metric-id", format)
+              } catch (err) {
+                if (isHandledCliError(err)) return
+                throw err
+              }
+              if (target.mode === "single") {
+                const body = mergeBody({}, { id: target.id })
+                await executeAnalyticsCommand("analytics-agent metric enable", argv as Record<string, unknown>, ROUTES.simpleMetricEnable, body)
+                return
+              }
+              await runBatchStatusChange(
+                "analytics-agent metric enable --all",
+                argv as Record<string, unknown>,
+                "ENABLE",
+                ROUTES.simpleMetricList,
+                mergeBody({}, { domainIds: [target.domainId], datasourceId: target.datasourceId }),
+                "names",
+                (id, ctx) => requestAnalyticsData(argv as Record<string, unknown>, ROUTES.simpleMetricEnable, { id }, {}, ctx).then(() => {}),
+              )
             },
           )
           .command(
-            "disable <metric-id>",
-            "Disable a metric",
+            "disable [metric-id]",
+            "Disable one metric, or all metrics in a domain with --all --domain-id",
             (y) =>
-              y.positional("metric-id", { type: "number", demandOption: true, describe: "Metric ID" }),
+              y
+                .positional("metric-id", { type: "number", describe: "Metric ID (omit and use --all --domain-id for a batch)" })
+                .option("all", { type: "boolean", describe: "Disable every metric in --domain-id" })
+                .option("domain-id", { type: "number", describe: "Domain ID (required with --all)" })
+                .option("datasource-id", { type: "number", describe: "Filter the batch to one datasource" })
+                .example("cz-cli analytics-agent metric disable 197", "Disable a single metric")
+                .example("cz-cli analytics-agent metric disable --all --domain-id 27", "Disable all metrics in a domain"),
             async (argv) => {
-              const body = mergeBody({}, { id: argv["metric-id"] })
-              await executeStatusCommandWithUpdateFallback(
-                "analytics-agent metric disable",
+              const format = typeof argv.format === "string" ? argv.format : "json"
+              let target: StatusChangeMode
+              try {
+                target = resolveStatusChangeMode(argv as Record<string, unknown>, "metric-id", format)
+              } catch (err) {
+                if (isHandledCliError(err)) return
+                throw err
+              }
+              if (target.mode === "single") {
+                const body = mergeBody({}, { id: target.id })
+                await executeStatusCommandWithUpdateFallback(
+                  "analytics-agent metric disable",
+                  argv as Record<string, unknown>,
+                  ROUTES.simpleMetricDisable,
+                  body,
+                  ROUTES.simpleMetricDetail,
+                  body,
+                  ROUTES.simpleMetricUpdate,
+                  (detail) => buildMetricUpdateBodyFromDetail(detail, "DISABLE"),
+                )
+                return
+              }
+              await runBatchStatusChange(
+                "analytics-agent metric disable --all",
                 argv as Record<string, unknown>,
-                ROUTES.simpleMetricDisable,
-                body,
-                ROUTES.simpleMetricDetail,
-                body,
-                ROUTES.simpleMetricUpdate,
-                (detail) => buildMetricUpdateBodyFromDetail(detail, "DISABLE"),
+                "DISABLE",
+                ROUTES.simpleMetricList,
+                mergeBody({}, { domainIds: [target.domainId], datasourceId: target.datasourceId }),
+                "names",
+                (id, ctx) => applyStatusChangeWithFallback(
+                  argv as Record<string, unknown>, id, "DISABLE", ctx,
+                  ROUTES.simpleMetricDisable, ROUTES.simpleMetricDetail, ROUTES.simpleMetricUpdate,
+                  buildMetricUpdateBodyFromDetail,
+                ),
               )
             },
           )
@@ -2206,6 +2435,11 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
               const body = mergeBody({}, { id: argv["metric-id"] })
               await executeAnalyticsCommand("analytics-agent metric delete", argv as Record<string, unknown>, ROUTES.simpleMetricDelete, body)
             },
+          )
+          .epilogue(
+            "A metric here is a simple_metric (single aggregate expression over one table). " +
+            "For multi-step / multi-table analysis use `answer-builder` (complex_metric). " +
+            "Both count toward a domain's targetCounts shown by `domain detail`.",
           )
         return commandGroup(metric, "analytics-agent metric")
       })
@@ -2220,7 +2454,11 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("analysis-desc", { type: "string", describe: "Answer builder description" })
                 .option("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
                 .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
-                .option("content", { type: "string", demandOption: true, describe: "Analysis DSL JSON string" }),
+                .option("content", { type: "string", demandOption: true, describe: "Analysis DSL JSON string" })
+                .example(
+                  'cz-cli analytics-agent answer-builder create --domain-id 27 --datasource-id 8448 --analysis-name "各省份中标金额排名" --content \'{"...DSL..."}\'',
+                  "Create a complex metric (answer builder). Run `answer-builder validate` first to check the --content DSL",
+                ),
             async (argv) => {
               const body = mergeBody({}, {
                 analysisName: argv["analysis-name"],
@@ -2256,31 +2494,87 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
             },
           )
           .command(
-            "enable <analysis-id>",
-            "Enable an answer builder",
+            "enable [analysis-id]",
+            "Enable one answer builder, or all in a domain with --all --domain-id",
             (y) =>
-              y.positional("analysis-id", { type: "number", demandOption: true, describe: "Answer builder ID" }),
+              y
+                .positional("analysis-id", { type: "number", describe: "Answer builder ID (omit and use --all --domain-id for a batch)" })
+                .option("all", { type: "boolean", describe: "Enable every answer builder in --domain-id" })
+                .option("domain-id", { type: "number", describe: "Domain ID (required with --all)" })
+                .option("datasource-id", { type: "number", describe: "Filter the batch to one datasource" })
+                .example("cz-cli analytics-agent answer-builder enable 9", "Enable a single answer builder")
+                .example("cz-cli analytics-agent answer-builder enable --all --domain-id 27", "Enable all answer builders in a domain"),
             async (argv) => {
-              const body = mergeBody({}, { id: argv["analysis-id"] })
-              await executeAnalyticsCommand("analytics-agent answer-builder enable", argv as Record<string, unknown>, ROUTES.answerBuilderEnable, body)
+              const format = typeof argv.format === "string" ? argv.format : "json"
+              let target: StatusChangeMode
+              try {
+                target = resolveStatusChangeMode(argv as Record<string, unknown>, "analysis-id", format)
+              } catch (err) {
+                if (isHandledCliError(err)) return
+                throw err
+              }
+              if (target.mode === "single") {
+                const body = mergeBody({}, { id: target.id })
+                await executeAnalyticsCommand("analytics-agent answer-builder enable", argv as Record<string, unknown>, ROUTES.answerBuilderEnable, body)
+                return
+              }
+              await runBatchStatusChange(
+                "analytics-agent answer-builder enable --all",
+                argv as Record<string, unknown>,
+                "ENABLE",
+                ROUTES.answerBuilderList,
+                mergeBody({}, { domainIds: [target.domainId], datasourceId: target.datasourceId }),
+                "analysisName",
+                (id, ctx) => requestAnalyticsData(argv as Record<string, unknown>, ROUTES.answerBuilderEnable, { id }, {}, ctx).then(() => {}),
+              )
             },
           )
           .command(
-            "disable <analysis-id>",
-            "Disable an answer builder",
+            "disable [analysis-id]",
+            "Disable one answer builder, or all in a domain with --all --domain-id",
             (y) =>
-              y.positional("analysis-id", { type: "number", demandOption: true, describe: "Answer builder ID" }),
+              y
+                .positional("analysis-id", { type: "number", describe: "Answer builder ID (omit and use --all --domain-id for a batch)" })
+                .option("all", { type: "boolean", describe: "Disable every answer builder in --domain-id" })
+                .option("domain-id", { type: "number", describe: "Domain ID (required with --all)" })
+                .option("datasource-id", { type: "number", describe: "Filter the batch to one datasource" })
+                .example("cz-cli analytics-agent answer-builder disable 9", "Disable a single answer builder")
+                .example("cz-cli analytics-agent answer-builder disable --all --domain-id 27", "Disable all answer builders in a domain"),
             async (argv) => {
-              const body = mergeBody({}, { id: argv["analysis-id"] })
-              await executeStatusCommandWithUpdateFallback(
-                "analytics-agent answer-builder disable",
+              const format = typeof argv.format === "string" ? argv.format : "json"
+              let target: StatusChangeMode
+              try {
+                target = resolveStatusChangeMode(argv as Record<string, unknown>, "analysis-id", format)
+              } catch (err) {
+                if (isHandledCliError(err)) return
+                throw err
+              }
+              if (target.mode === "single") {
+                const body = mergeBody({}, { id: target.id })
+                await executeStatusCommandWithUpdateFallback(
+                  "analytics-agent answer-builder disable",
+                  argv as Record<string, unknown>,
+                  ROUTES.answerBuilderDisable,
+                  body,
+                  ROUTES.answerBuilderDetail,
+                  body,
+                  ROUTES.answerBuilderUpdate,
+                  (detail) => buildAnswerBuilderUpdateBodyFromDetail(detail, "DISABLE"),
+                )
+                return
+              }
+              await runBatchStatusChange(
+                "analytics-agent answer-builder disable --all",
                 argv as Record<string, unknown>,
-                ROUTES.answerBuilderDisable,
-                body,
-                ROUTES.answerBuilderDetail,
-                body,
-                ROUTES.answerBuilderUpdate,
-                (detail) => buildAnswerBuilderUpdateBodyFromDetail(detail, "DISABLE"),
+                "DISABLE",
+                ROUTES.answerBuilderList,
+                mergeBody({}, { domainIds: [target.domainId], datasourceId: target.datasourceId }),
+                "analysisName",
+                (id, ctx) => applyStatusChangeWithFallback(
+                  argv as Record<string, unknown>, id, "DISABLE", ctx,
+                  ROUTES.answerBuilderDisable, ROUTES.answerBuilderDetail, ROUTES.answerBuilderUpdate,
+                  buildAnswerBuilderUpdateBodyFromDetail,
+                ),
               )
             },
           )
@@ -2343,6 +2637,12 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
               })
               await executeAnalyticsCommand("analytics-agent answer-builder validate", argv as Record<string, unknown>, ROUTES.answerBuilderValidate, body)
             },
+          )
+          .epilogue(
+            "An answer builder is a complex_metric (multi-step / multi-table analysis via a DSL --content). " +
+            "For a single aggregate over one table use `metric` (simple_metric) instead. " +
+            "Both count toward a domain's targetCounts shown by `domain detail`. " +
+            "Pass --domain-id to `answer-builder list` to scope results to one domain.",
           )
         return commandGroup(answerBuilder, "analytics-agent answer-builder")
       })

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -1568,9 +1568,36 @@ async function executeAnalyticsPollCommand(
   }
 }
 
+// Positional/option id args that MUST be positive integers when present.
+// Excludes `parent-id` (0 = root folder is valid) and non-id args. yargs
+// coerces a non-numeric value like "abc" to NaN and a float like "27.5" stays
+// fractional; without this guard those reach the backend and surface as an
+// opaque HTTP 500 instead of a friendly usage error.
+const POSITIVE_INTEGER_ID_KEYS = [
+  "domain-id", "dataset-id", "attr-id", "metric-id", "analysis-id",
+  "node-id", "space-id", "join-id", "table-id", "datasource-id",
+  "question-id", "session-id", "source-id", "join-dataset-id",
+]
+
+function validatePositiveIntegerIds(argv: Record<string, unknown>): void {
+  const format = typeof argv.format === "string" ? argv.format : "json"
+  for (const key of POSITIVE_INTEGER_ID_KEYS) {
+    const value = argv[key]
+    if (value === undefined) continue
+    const values = Array.isArray(value) ? value : [value]
+    for (const v of values) {
+      if (typeof v !== "number") continue
+      if (!Number.isSafeInteger(v) || v <= 0) {
+        handledError("USAGE_ERROR", `--${key} must be a positive integer`, { format })
+      }
+    }
+  }
+}
+
 export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
   cli.command("analytics-agent", "Analytics Agent APIs", (yargs) => {
     yargs
+      .middleware((argv) => validatePositiveIntegerIds(argv as Record<string, unknown>))
       .command("datasource", "Manage Analytics Agent datasources", (datasource) => {
         datasource
           .command(

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -672,9 +672,13 @@ async function runBatchStatusChange(
 
     // Paginate the list so `--all` covers every item, not just the API's
     // default first page. Loop until a page returns fewer than pageSize rows.
+    // Dedup by id and cap the page count so a backend that ignores pageNum
+    // (returning the same page forever) can't cause an infinite loop.
     const pageSize = 200
+    const maxPages = 1000
     const targets: BatchTargetItem[] = []
-    for (let pageNum = 1; ; pageNum++) {
+    const seen = new Set<number>()
+    for (let pageNum = 1; pageNum <= maxPages; pageNum++) {
       const pageData = await requestAnalyticsData(
         argv,
         listRoute,
@@ -683,9 +687,17 @@ async function runBatchStatusChange(
         ctx,
       )
       const pageItems = extractBatchTargets(pageData, nameKey)
-      targets.push(...pageItems)
+      let added = 0
+      for (const item of pageItems) {
+        if (seen.has(item.id)) continue
+        seen.add(item.id)
+        targets.push(item)
+        added++
+      }
       const pageLen = Array.isArray(pageData) ? pageData.length : pageItems.length
-      if (pageLen < pageSize) break
+      // Stop on a short page (last page) or when a full page contributed no new
+      // ids (backend ignored pageNum and returned a duplicate page).
+      if (pageLen < pageSize || added === 0) break
     }
 
     const results: Array<Record<string, unknown>> = []

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -669,8 +669,24 @@ async function runBatchStatusChange(
   const t0 = Date.now()
   try {
     const ctx = await resolveAnalyticsContext(argv)
-    const listData = await requestAnalyticsData(argv, listRoute, listBody, {}, ctx)
-    const targets = extractBatchTargets(listData, nameKey)
+
+    // Paginate the list so `--all` covers every item, not just the API's
+    // default first page. Loop until a page returns fewer than pageSize rows.
+    const pageSize = 200
+    const targets: BatchTargetItem[] = []
+    for (let pageNum = 1; ; pageNum++) {
+      const pageData = await requestAnalyticsData(
+        argv,
+        listRoute,
+        mergeBody({ ...listBody }, { pageNum, pageSize }),
+        {},
+        ctx,
+      )
+      const pageItems = extractBatchTargets(pageData, nameKey)
+      targets.push(...pageItems)
+      const pageLen = Array.isArray(pageData) ? pageData.length : pageItems.length
+      if (pageLen < pageSize) break
+    }
 
     const results: Array<Record<string, unknown>> = []
     let succeeded = 0

--- a/packages/cz-cli/test/analytics-agent-answer-builder.test.ts
+++ b/packages/cz-cli/test/analytics-agent-answer-builder.test.ts
@@ -265,4 +265,58 @@ describe("analytics-agent answer-builder", () => {
     })
     expect(parseData(result.output)).toBe(401)
   })
+
+  test("batch disable lists domain, skips already-disabled, disables the rest", async () => {
+    const requestUrls: string[] = []
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      requestUrls.push(url)
+      if (url.includes("/answer-builders/list")) {
+        return jsonResponse({
+          success: true,
+          data: [
+            { id: 9, analysisName: "中标率概览", status: "ENABLE" },
+            { id: 8, analysisName: "企业投标能力分析", status: "DISABLE" },
+          ],
+        })
+      }
+      return jsonResponse({ success: true, data: null })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "answer-builder",
+      "disable",
+      "--all",
+      "--domain-id",
+      "27",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const disableCalls = requestUrls.filter((u) => u.includes("/answer-builders/disable"))
+    expect(disableCalls.length).toBe(1)
+    const data = parseData(result.output) as Record<string, unknown>
+    expect(data.total).toBe(2)
+    expect(data.succeeded).toBe(1)
+    expect(data.skipped).toBe(1)
+    expect(data.failed).toBe(0)
+  })
+
+  test("enable rejects both an id and --all", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "answer-builder",
+      "enable",
+      "9",
+      "--all",
+    ])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.output.trim())
+    expect(parsed.error.code).toBe("USAGE_ERROR")
+  })
 })

--- a/packages/cz-cli/test/analytics-agent-domain-datasource.test.ts
+++ b/packages/cz-cli/test/analytics-agent-domain-datasource.test.ts
@@ -390,7 +390,7 @@ describe("analytics-agent domain and datasource parameter simplification", () =>
     expect(result.exitCode).toBe(1)
     expect(parseError(result.output)).toEqual({
       code: "USAGE_ERROR",
-      message: "--domain-id must contain only positive integers",
+      message: "--domain-id must be a positive integer",
     })
   })
 

--- a/packages/cz-cli/test/analytics-agent-knowledge.test.ts
+++ b/packages/cz-cli/test/analytics-agent-knowledge.test.ts
@@ -475,7 +475,7 @@ describe("analytics-agent knowledge", () => {
     const parsed = JSON.parse(result.output.trim()) as Record<string, any>
     expect(parsed.error.code).toBe("USAGE_ERROR")
     expect(parsed.error.message).toContain("--domain-id")
-    expect(parsed.error.message).toContain("positive integers")
+    expect(parsed.error.message).toContain("positive integer")
   })
 
   test("node bind-domain still succeeds when detail refresh fails after successful write", async () => {

--- a/packages/cz-cli/test/analytics-agent-metric.test.ts
+++ b/packages/cz-cli/test/analytics-agent-metric.test.ts
@@ -414,6 +414,36 @@ describe("analytics-agent metric", () => {
     expect(data.succeeded).toBe(205)
   })
 
+  test("batch enable stops (no infinite loop) when the backend ignores pageNum", async () => {
+    // Simulate a broken backend that returns the SAME full page regardless of
+    // pageNum. Dedup-by-id + no-new-items guard must terminate after 2 calls.
+    let listCalls = 0
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/metrics/list")) {
+        listCalls++
+        const page = Array.from({ length: 200 }, (_, i) => ({ id: i + 1, names: [`m${i + 1}`], status: "DISABLE" }))
+        return jsonResponse({ success: true, data: page })
+      }
+      return jsonResponse({ success: true, data: null })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "metric",
+      "enable",
+      "--all",
+      "--domain-id",
+      "27",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    // Page 1 adds 200 new ids; page 2 is identical -> 0 new -> stop.
+    expect(listCalls).toBe(2)
+    const data = parseData(result.output) as Record<string, unknown>
+    expect(data.total).toBe(200)
+  })
+
   test("batch enable sets non-zero exit code when an item fails", async () => {
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)

--- a/packages/cz-cli/test/analytics-agent-metric.test.ts
+++ b/packages/cz-cli/test/analytics-agent-metric.test.ts
@@ -576,4 +576,64 @@ describe("analytics-agent metric", () => {
     const parsed = JSON.parse(result.output.trim())
     expect(parsed.error.code).toBe("USAGE_ERROR")
   })
+
+  test("non-numeric positional id is rejected locally, not sent to backend", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli(["analytics-agent", "metric", "detail", "abc"])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.output.trim())
+    expect(parsed.error.code).toBe("USAGE_ERROR")
+    expect(parsed.error.message).toContain("--metric-id must be a positive integer")
+  })
+
+  test("fractional positional id is rejected locally", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli(["analytics-agent", "metric", "detail", "27.5"])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.output.trim())
+    expect(parsed.error.code).toBe("USAGE_ERROR")
+  })
+
+  test("overflow positional id (beyond safe integer) is rejected locally", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli(["analytics-agent", "metric", "detail", "99999999999999999999"])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.output.trim())
+    expect(parsed.error.code).toBe("USAGE_ERROR")
+  })
+
+  test("zero and negative positional id are rejected locally", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const zero = await runAnalyticsCli(["analytics-agent", "metric", "detail", "0"])
+    expect(zero.exitCode).toBe(1)
+    expect(JSON.parse(zero.output.trim()).error.code).toBe("USAGE_ERROR")
+  })
+
+  test("valid positional id passes validation and reaches the backend", async () => {
+    let called = false
+    globalThis.fetch = mock(async () => {
+      called = true
+      return jsonResponse({ success: true, data: { id: 301, names: ["m"] } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli(["analytics-agent", "metric", "detail", "301"])
+
+    expect(called).toBe(true)
+    expect(result.exitCode).toBe(0)
+  })
 })

--- a/packages/cz-cli/test/analytics-agent-metric.test.ts
+++ b/packages/cz-cli/test/analytics-agent-metric.test.ts
@@ -342,4 +342,174 @@ describe("analytics-agent metric", () => {
     })
     expect(parseData(result.output)).toBe(301)
   })
+
+  test("batch enable lists domain, skips already-enabled, enables the rest", async () => {
+    const requestUrls: string[] = []
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      requestUrls.push(url)
+      if (url.includes("/metrics/list")) {
+        return jsonResponse({
+          success: true,
+          data: [
+            { id: 197, names: ["平均预算总额"], status: "ENABLE" },
+            { id: 196, names: ["企业总数"], status: "DISABLE" },
+            { id: 195, names: ["中标率"], status: "DISABLE" },
+          ],
+        })
+      }
+      return jsonResponse({ success: true, data: null })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "metric",
+      "enable",
+      "--all",
+      "--domain-id",
+      "27",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const enableCalls = requestUrls.filter((u) => u.includes("/metrics/enable"))
+    expect(enableCalls.length).toBe(2)
+    const data = parseData(result.output) as Record<string, unknown>
+    expect(data.total).toBe(3)
+    expect(data.succeeded).toBe(2)
+    expect(data.skipped).toBe(1)
+    expect(data.failed).toBe(0)
+  })
+
+  test("batch enable sets non-zero exit code when an item fails", async () => {
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/metrics/list")) {
+        return jsonResponse({
+          success: true,
+          data: [
+            { id: 196, names: ["企业总数"], status: "DISABLE" },
+            { id: 195, names: ["中标率"], status: "DISABLE" },
+          ],
+        })
+      }
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      if (body.id === 195) {
+        return jsonResponse({ success: false, code: "CZLH-42000", message: "invalid metric" })
+      }
+      return jsonResponse({ success: true, data: null })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "metric",
+      "enable",
+      "--all",
+      "--domain-id",
+      "27",
+    ])
+
+    expect(result.exitCode).toBe(1)
+    const data = parseData(result.output) as Record<string, unknown>
+    expect(data.succeeded).toBe(1)
+    expect(data.failed).toBe(1)
+  })
+
+  test("batch disable reuses the detail+update fallback per item on not-found", async () => {
+    const requestUrls: string[] = []
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      requestUrls.push(url)
+      if (url.includes("/metrics/list")) {
+        return jsonResponse({
+          success: true,
+          data: [{ id: 196, names: ["企业总数"], status: "ENABLE" }],
+        })
+      }
+      if (url.includes("/metrics/disable")) {
+        return jsonResponse({ success: false, code: "CZD-404", message: "metric not found: 196" })
+      }
+      if (url.includes("/metrics/detail")) {
+        return jsonResponse({
+          success: true,
+          data: {
+            id: 196,
+            datasourceId: 11,
+            tableName: "orders",
+            names: ["企业总数"],
+            aggExpr: "count(*)",
+            domainIds: [27],
+          },
+        })
+      }
+      return jsonResponse({ success: true, data: 196 })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "metric",
+      "disable",
+      "--all",
+      "--domain-id",
+      "27",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(requestUrls.some((u) => u.includes("/metrics/detail"))).toBe(true)
+    expect(requestUrls.some((u) => u.includes("/metrics/update"))).toBe(true)
+    const data = parseData(result.output) as Record<string, unknown>
+    expect(data.succeeded).toBe(1)
+    expect(data.failed).toBe(0)
+  })
+
+  test("enable rejects passing both an id and --all", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "metric",
+      "enable",
+      "197",
+      "--all",
+    ])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.output.trim())
+    expect(parsed.error.code).toBe("USAGE_ERROR")
+  })
+
+  test("enable --all without --domain-id is a usage error", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "metric",
+      "enable",
+      "--all",
+    ])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.output.trim())
+    expect(parsed.error.code).toBe("USAGE_ERROR")
+    expect(parsed.error.message).toContain("--domain-id")
+  })
+
+  test("enable with no id and no --all is a usage error", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "metric",
+      "enable",
+    ])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.output.trim())
+    expect(parsed.error.code).toBe("USAGE_ERROR")
+  })
 })

--- a/packages/cz-cli/test/analytics-agent-metric.test.ts
+++ b/packages/cz-cli/test/analytics-agent-metric.test.ts
@@ -380,6 +380,40 @@ describe("analytics-agent metric", () => {
     expect(data.failed).toBe(0)
   })
 
+  test("batch enable paginates the list so it covers items past the first page", async () => {
+    let listCalls = 0
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/metrics/list")) {
+        listCalls++
+        const body = init?.body ? JSON.parse(String(init.body)) : {}
+        // Page 1 is full (200 rows) -> forces a second page; page 2 has 5 rows.
+        if (body.pageNum === 1) {
+          const page = Array.from({ length: 200 }, (_, i) => ({ id: i + 1, names: [`m${i + 1}`], status: "DISABLE" }))
+          return jsonResponse({ success: true, data: page })
+        }
+        const page = Array.from({ length: 5 }, (_, i) => ({ id: 200 + i + 1, names: [`m${200 + i + 1}`], status: "DISABLE" }))
+        return jsonResponse({ success: true, data: page })
+      }
+      return jsonResponse({ success: true, data: null })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "metric",
+      "enable",
+      "--all",
+      "--domain-id",
+      "27",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(listCalls).toBe(2)
+    const data = parseData(result.output) as Record<string, unknown>
+    expect(data.total).toBe(205)
+    expect(data.succeeded).toBe(205)
+  })
+
   test("batch enable sets non-zero exit code when an item fails", async () => {
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)

--- a/packages/cz-cli/test/analytics-agent-table-semantics.test.ts
+++ b/packages/cz-cli/test/analytics-agent-table-semantics.test.ts
@@ -126,6 +126,43 @@ describe("analytics-agent table semantics", () => {
     }])
   })
 
+  test("columns alias hits the same semantics endpoint as semantics list", async () => {
+    let requestUrl = ""
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      requestUrl = String(input)
+      return jsonResponse({
+        success: true,
+        data: [{
+          attrId: 31,
+          datasetId: 195,
+          attrCode: "order_date",
+          description: "订单日期",
+          semanticType: "DATE_AND_TIME",
+          hidden: false,
+        }],
+      })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "table",
+      "columns",
+      "195",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const url = new URL(requestUrl)
+    expect(url.pathname).toBe("/open/api/v1/analytics-agent/datasets/195/semantics")
+    expect(parseData(result.output)).toEqual([{
+      attrId: 31,
+      datasetId: 195,
+      attrCode: "order_date",
+      description: "订单日期",
+      semanticType: "DATE_AND_TIME",
+      hidden: false,
+    }])
+  })
+
   test("get calls dataset semantics detail endpoint", async () => {
     let requestUrl = ""
     globalThis.fetch = mock(async (input: RequestInfo | URL) => {

--- a/packages/cz-cli/test/group-help-fallback.test.ts
+++ b/packages/cz-cli/test/group-help-fallback.test.ts
@@ -104,6 +104,44 @@ describe("bare command group renders help (exit 0), not USAGE_ERROR", () => {
     expect(r.stdout).toContain("key")
     expect(r.stdout).toContain("model")
   })
+
+  test("cz-cli analytics-agent metric help explains simple vs complex metric", () => {
+    const r = run(["analytics-agent", "metric"])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain("simple_metric")
+    expect(r.stdout).toContain("answer-builder")
+    expect(r.stdout).toContain("targetCounts")
+  })
+
+  test("cz-cli analytics-agent answer-builder help explains complex vs simple metric", () => {
+    const r = run(["analytics-agent", "answer-builder"])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain("complex_metric")
+    expect(r.stdout).toContain("simple_metric")
+    expect(r.stdout).toContain("targetCounts")
+  })
+
+  test("cz-cli analytics-agent table help lists the columns alias", () => {
+    const r = run(["analytics-agent", "table"])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain("columns")
+    expect(r.stdout).toContain("semantics")
+  })
+
+  test("cz-cli analytics-agent metric create --help shows usage examples", () => {
+    const r = run(["analytics-agent", "metric", "create", "--help"])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain("Examples:")
+    expect(r.stdout).toContain("catalog.schema.table")
+    expect(r.stdout).toContain("virtual column")
+  })
+
+  test("cz-cli analytics-agent answer-builder create --help shows a usage example", () => {
+    const r = run(["analytics-agent", "answer-builder", "create", "--help"])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain("Examples:")
+    expect(r.stdout).toContain("validate")
+  })
 })
 
 describe("nested bare group shows its OWN help, not the parent's", () => {


### PR DESCRIPTION
## Summary

Addresses analytics-agent usability findings from the governed-analytics review. Four CLI improvements, each with updated spec + tests per the spec-driven workflow.

- **Batch enable/disable** — `metric` and `answer-builder` `enable`/`disable` now accept `--all --domain-id <id>` for batch operations (single positional id still works). Batch lists the domain, skips items already in the target state, applies the rest per-item, and aggregates `{total, succeeded, failed, skipped, results}`; partial failure exits non-zero. Batch disable reuses the single-item detail+update fallback.
- **`table columns <dataset-id>`** — flat alias for `table semantics list`, shortening the command depth.
- **Help examples** — copy-paste examples on `metric create`/`validate` and `answer-builder create`; examples steer users to virtual columns instead of SQL string literals (which the backend SQL validator rejects).
- **Relationship epilogues** — clarify `simple_metric` (metric) vs `complex_metric` (answer-builder) and that both count toward `domain detail` targetCounts.

## Testing

- 70 unit tests pass across the 4 affected test files (`bun test` from `packages/cz-cli`).
- `bun typecheck` clean.
- Live-verified against the Shanghai environment (`aliyun_shanghai_prod`, domain 27/28):
  - `table columns 82` returns byte-identical output to `table semantics list 82`.
  - `metric/answer-builder enable --all` correctly skips already-enabled items (non-mutating path).
  - Batch disable exercised end-to-end; reversible round-trip left domain state unchanged.
  - Help examples/epilogues render as expected.

## Known backend limitation (not addressed here)

`metric disable` can trigger `CZD-99999` (`common_reference_relationship.source_id` not-null violation) on some environments; both single and batch disable hit it. This is a **backend defect** — the CLI faithfully reports the error, exits non-zero, and leaves local state unchanged. A separate report has been prepared for the backend team.

## Scope notes

Report items already resolved by prior refactors (PR #57/#58) — knowledge binding (#1/#3), domain joins CRUD (#4) — were re-verified live and need no change here. Items #5/#7 were confirmed as report inaccuracies (current code already correct). Item #2 (SQL string literals) is backend-only.

Co-Authored-By: cz-cli <noreply@clickzetta.com>