### PR TITLE
feat(analytics-agent): table add UX, join notes, answer-builder --sql, one-step upload

### DIFF
--- a/openspec/specs/analytics-agent-answer-builder/spec.md
+++ b/openspec/specs/analytics-agent-answer-builder/spec.md
@@ -32,6 +32,26 @@
 - **THEN** help 输出包含 `Examples:` 段
 - **且** 示例提示先用 `validate` 校验 `--content` DSL
 
+### Requirement: answer-builder 支持 --sql 与 --content 分离
+
+`cz-cli analytics-agent answer-builder create`、`update`、`validate` MUST 支持用 `--sql` 单独传入 SQL 主体，注入到 content DSL 的顶层 `sql` 字段，使用户无需在 `--content` JSON 内转义 SQL 中的单/双引号。`--content` 承载 DSL 其余部分（chartParams/outputColumns/relatedTables 等）。`--content` 与 `--sql` MUST 至少提供其一。
+
+#### Scenario: --sql 注入 content.sql
+
+- **WHEN** 用户执行 `answer-builder create --content '{"chartParams":[],"outputColumns":[]}' --sql "SELECT COUNT(*) FROM t WHERE bid_result='中标'"`（并带必填的 name/datasource/domain）
+- **THEN** 请求体 `content` 解析后 `sql` 等于该 SQL 原文
+- **且** `chartParams`、`outputColumns` 保留自 `--content`
+
+#### Scenario: 只给 --sql 不给 --content
+
+- **WHEN** 用户只提供 `--sql` 而不提供 `--content`
+- **THEN** CLI MUST 构造仅含 `sql` 字段的 content 对象
+
+#### Scenario: --content 与 --sql 都缺失时本地拒绝
+
+- **WHEN** 用户既不提供 `--content` 也不提供 `--sql`
+- **THEN** CLI MUST 在发请求前返回 `USAGE_ERROR`
+
 ### Requirement: answer-builder 命令组帮助说明与 metric 的关系
 
 `cz-cli analytics-agent answer-builder --help` MUST 在 epilogue 中说明 answer-builder 是 complex_metric（多步/多表 DSL 分析），单表单聚合应使用 `metric`（simple_metric），且两者都计入 `domain detail` 的 targetCounts，并提示可用 `--domain-id` 把 `answer-builder list` 限定到单个 domain。

--- a/openspec/specs/analytics-agent-domain/spec.md
+++ b/openspec/specs/analytics-agent-domain/spec.md
@@ -79,6 +79,22 @@
 - **AND** domain detail 返回的 `tables` 中没有该表
 - **THEN** CLI MUST 调用 domain table add 接口
 
+### Requirement: domain table add 默认设置 display name
+
+`cz-cli analytics-agent domain table add` MUST 在新建 dataset 时设置一个非空的 display name。默认值 MUST 与 UI 约定一致：全限定的物理表名（视图名去掉 `v_gpt_` 前缀，即 `workspace.schema.<physical>`）。用户 MAY 通过 `--display-name` 显式覆盖。此约束防止通过 CLI 加表后 dataset 的 display name 为空、导致前端页面操作异常。
+
+> 说明：当后端复用已存在的 dataset（`createdDataset=false`）时，会保留原有 display name，CLI 发送的默认值不会覆盖用户先前设置的名字——这是后端行为，符合预期。
+
+#### Scenario: 默认 display name 为物理表名
+
+- **WHEN** 用户执行 `cz-cli analytics-agent domain table add 27 --datasource-id 8448 --table "quick_start.construction_dw.v_gpt_fact_bid"`（不带 `--display-name`）
+- **THEN** 请求体 `displayName` 为 `quick_start.construction_dw.fact_bid`（去掉 `v_gpt_` 前缀）
+
+#### Scenario: 显式 --display-name 覆盖默认值
+
+- **WHEN** 用户执行 `... domain table add ... --display-name "投标事实表"`
+- **THEN** 请求体 `displayName` 为 `投标事实表`
+
 ### Requirement: domain table add 支持全限定 --table 自动拆分并回显 dataset ID
 
 `cz-cli analytics-agent domain table add` MUST 支持把三段式全限定 `--table`（`workspace.schema.table`）自动拆分为 `workspace`/`schema`/`table`，避免 lakehouse 数据源逐个试错补 `--workspace`/`--schema`。当用户已显式提供 `--workspace` 或 `--schema` 时不拆分；非三段式（如单段或四段）保持原样。添加成功后 CLI MUST 在输出中显著回显分配到的 dataset ID，供后续 join/metric/semantics 命令使用。

--- a/openspec/specs/analytics-agent-domain/spec.md
+++ b/openspec/specs/analytics-agent-domain/spec.md
@@ -78,3 +78,42 @@
 - **WHEN** 用户执行 `cz-cli analytics-agent domain table add 19 --datasource-id 4164 --path "workspace:quick_start/schema:rpt" --table-name "quick_start.rpt.rpt_transaction_lazada"`
 - **AND** domain detail 返回的 `tables` 中没有该表
 - **THEN** CLI MUST 调用 domain table add 接口
+
+### Requirement: domain table add 支持全限定 --table 自动拆分并回显 dataset ID
+
+`cz-cli analytics-agent domain table add` MUST 支持把三段式全限定 `--table`（`workspace.schema.table`）自动拆分为 `workspace`/`schema`/`table`，避免 lakehouse 数据源逐个试错补 `--workspace`/`--schema`。当用户已显式提供 `--workspace` 或 `--schema` 时不拆分；非三段式（如单段或四段）保持原样。添加成功后 CLI MUST 在输出中显著回显分配到的 dataset ID，供后续 join/metric/semantics 命令使用。
+
+#### Scenario: 三段式 --table 自动拆分
+
+- **WHEN** 用户执行 `cz-cli analytics-agent domain table add 19 --datasource-id 4164 --table "quick_start.rpt.orders"`
+- **THEN** 请求体包含 `workspace=quick_start`、`schema=rpt`、`tableName=orders`
+
+#### Scenario: 单段 --table 保持原样
+
+- **WHEN** 用户执行 `cz-cli analytics-agent domain table add 19 --datasource-id 4164 --table "orders"`
+- **THEN** 请求体只含 `tableName=orders`，不含 workspace/schema
+
+#### Scenario: 显式 workspace/schema 时不拆分
+
+- **WHEN** 用户执行 `cz-cli analytics-agent domain table add 19 --datasource-id 4164 --workspace ws --schema sc --table "a.b.c"`
+- **THEN** 请求体 `tableName` 仍为 `a.b.c`，workspace/schema 用显式值
+
+#### Scenario: 添加成功回显 dataset ID
+
+- **WHEN** `domain table add` 成功且响应含 `datasetId`
+- **THEN** CLI MUST 在 `ai_message` 中标注分配的 dataset ID
+
+### Requirement: domain join 创建/更新提示关系方向被后端归一化
+
+当后端根据数据基数把用户请求的 `--relation`（如 `n:1`）归一化为不同值（如 `1:n`）时，`cz-cli analytics-agent domain join create/update` MUST 在输出中提示该自动归一化，避免用户把输入与输出不一致误判为错误。
+
+#### Scenario: 请求与存储的 relation 不一致时提示
+
+- **WHEN** 用户执行 `domain join create` 传入 `--relation n:1`
+- **AND** 后端返回的 `relation` 为 `1:n`
+- **THEN** CLI MUST 在 `ai_message` 中说明 relation 被自动归一化（requested n:1 → stored 1:n）
+
+#### Scenario: 请求与存储一致时不提示
+
+- **WHEN** 后端返回的 `relation` 与请求一致
+- **THEN** CLI MUST NOT 输出归一化提示

--- a/openspec/specs/analytics-agent-knowledge/spec.md
+++ b/openspec/specs/analytics-agent-knowledge/spec.md
@@ -319,6 +319,14 @@ CLI MUST provide an explicit node-level domain binding surface for existing docu
 - **THEN** CLI MUST fail before uploading file bytes
 - **AND** the error message MUST explain that the target path must be a folder path
 
+#### Scenario: 一步完成上传 + 建目录 + 绑定 domain
+
+- **WHEN** 用户执行 `cz-cli analytics-agent knowledge file upload <space-id> <local-file> --target-path <remote-path> --domain-id <id>`
+- **THEN** CLI MUST 自动创建 `<remote-path>` 上缺失的中间文件夹
+- **AND** CLI MUST 在上传请求中携带 `domainIds`，使文件上传即完成 domain 绑定
+- **AND** 用户无需再单独调用 folder create / file move / node bind-domain
+- **AND** upload 命令 help MUST 提供展示该一步用法的示例
+
 #### Scenario: 文件内容读取必须绑定 space
 
 - **WHEN** 用户执行 `cz-cli analytics-agent knowledge file get <space-id> <node-id>`

--- a/openspec/specs/analytics-agent-table-semantics/spec.md
+++ b/openspec/specs/analytics-agent-table-semantics/spec.md
@@ -27,22 +27,37 @@
 - **且** 输出包含每个字段的 `attrId`、`attrCode`、`semanticType`、`description`、`hidden`
 - **且** 输出与 `cz-cli analytics-agent table semantics list 195` 一致
 
-### Requirement: table set-display-name 修改已加入域的表的显示名
+### Requirement: table update 修改已加入域的表的显示名与描述
 
-`cz-cli analytics-agent table set-display-name <dataset-id> --name <name>` MUST 支持修改一个已加入域的 dataset 的 display name。由于后端 `dataset/update` 接口需要**完整的 dataset 对象**，CLI MUST 采用 read-modify-write：先 `GET /api/v1/dataset/detail?datasetId=<id>` 取回完整对象，仅改写 `displayName`，再 `POST /api/v1/dataset/update` 把整个对象提交回去，不得只发部分字段（否则会清空其它字段）。`--name` MUST 非空。
+`cz-cli analytics-agent table update <dataset-id>` MUST 支持修改一个已加入域的 dataset 的 `displayName` 与/或 `description`。由于后端 `dataset/update` 接口需要**完整的 dataset 对象**，CLI MUST 采用 read-modify-write：先 `GET /api/v1/dataset/detail?datasetId=<id>` 取回完整对象，仅改写用户提供的字段（`--name` → `displayName`、`--description` → `description`），再 `POST /api/v1/dataset/update` 把整个对象提交回去，不得只发部分字段（否则会清空其它字段）。`--name` 与 `--description` MUST 至少提供其一；提供 `--name` 时其值 MUST 非空。
 
-> 说明：`table add --display-name` 只在**新建** dataset 时设置显示名；对**已存在**的 dataset 后端会忽略。要改已有表的显示名必须用本命令。
+> 说明：`table add --display-name` 只在**新建** dataset 时设置显示名；对**已存在**的 dataset 后端会忽略。要改已有表的显示名或描述必须用本命令。
 
 #### Scenario: read-modify-write 更新 displayName
 
-- **WHEN** 用户执行 `cz-cli analytics-agent table set-display-name 82 --name "投标事实表"`
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --name "投标事实表"`
 - **THEN** CLI MUST 先调用 `GET /api/v1/dataset/detail?datasetId=82`
 - **且** 再调用 `POST /api/v1/dataset/update`，请求体为该 detail 完整对象且 `displayName` 改为 `投标事实表`
 - **且** 请求体保留 detail 中的其它字段（如 `description`、`tableName`、`completeSchema`）
 
+#### Scenario: 同时更新 displayName 与 description
+
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --name "投标事实表" --description "招投标明细"`
+- **THEN** 提交的对象中 `displayName` 为 `投标事实表`，`description` 为 `招投标明细`
+
+#### Scenario: 只更新 description 时保留原 displayName
+
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --description "只改描述"`
+- **THEN** 提交的对象中 `description` 为 `只改描述`，`displayName` 保持 detail 中的原值
+
+#### Scenario: 既不给 --name 也不给 --description 时本地拒绝
+
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82`
+- **THEN** CLI MUST 在发请求前返回 `USAGE_ERROR`
+
 #### Scenario: 空 --name 本地拒绝
 
-- **WHEN** 用户执行 `cz-cli analytics-agent table set-display-name 82 --name "   "`
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --name "   "`
 - **THEN** CLI MUST 在发请求前返回 `USAGE_ERROR`
 
 ### Requirement: table semantics get 查看单个字段语义详情

--- a/openspec/specs/analytics-agent-table-semantics/spec.md
+++ b/openspec/specs/analytics-agent-table-semantics/spec.md
@@ -29,35 +29,48 @@
 
 ### Requirement: table update 修改已加入域的表的显示名与描述
 
-`cz-cli analytics-agent table update <dataset-id>` MUST 支持修改一个已加入域的 dataset 的 `displayName` 与/或 `description`。由于后端 `dataset/update` 接口需要**完整的 dataset 对象**，CLI MUST 采用 read-modify-write：先 `GET /api/v1/dataset/detail?datasetId=<id>` 取回完整对象，仅改写用户提供的字段（`--name` → `displayName`、`--description` → `description`），再 `POST /api/v1/dataset/update` 把整个对象提交回去，不得只发部分字段（否则会清空其它字段）。`--name` 与 `--description` MUST 至少提供其一；提供 `--name` 时其值 MUST 非空。
+`cz-cli analytics-agent table update <dataset-id> --domain-id <id>` MUST 支持修改一个已加入域的 dataset 的 `displayName` 与/或 `description`。由于后端 `dataset/update` 接口需要**完整的 dataset 对象**，CLI MUST 采用 read-modify-write。read 源 MUST 使用 `POST /api/v1/dataset/list`（请求体 `{domainIds:[<domain-id>]}`）而**不是** `dataset/detail`——后者对部分域的 dataset 会返回 `CZD-20009`「数据集不存在」。CLI MUST 在 list 结果中按 `datasetId` 定位完整对象，仅改写用户提供的字段（`--name` → `displayName`、`--description` → `description`），再 `POST /api/v1/dataset/update` 把整个对象提交回去，不得只发部分字段（否则会清空其它字段）。`--domain-id` MUST 提供；`--name` 与 `--description` MUST 至少提供其一；提供 `--name` 时其值 MUST 非空。
 
 > 说明：`table add --display-name` 只在**新建** dataset 时设置显示名；对**已存在**的 dataset 后端会忽略。要改已有表的显示名或描述必须用本命令。
+> 已知后端限制：`dataset/detail?datasetId=<id>` 对某些域的 dataset 返回 `CZD-20009`（列表能查到、详情查不到），因此本命令改用按域过滤的 `dataset/list` 作为 read 源。
 
-#### Scenario: read-modify-write 更新 displayName
+#### Scenario: 经 dataset/list 读取后更新 displayName
 
-- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --name "投标事实表"`
-- **THEN** CLI MUST 先调用 `GET /api/v1/dataset/detail?datasetId=82`
-- **且** 再调用 `POST /api/v1/dataset/update`，请求体为该 detail 完整对象且 `displayName` 改为 `投标事实表`
-- **且** 请求体保留 detail 中的其它字段（如 `description`、`tableName`、`completeSchema`）
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --domain-id 27 --name "投标事实表"`
+- **THEN** CLI MUST 先调用 `POST /api/v1/dataset/list`，请求体含 `domainIds=[27]`
+- **且** 在结果中按 `datasetId=82` 定位完整对象
+- **且** 再调用 `POST /api/v1/dataset/update`，请求体为该完整对象且 `displayName` 改为 `投标事实表`
+- **且** 请求体保留其它字段（如 `description`、`tableName`、`completeSchema`）
 
 #### Scenario: 同时更新 displayName 与 description
 
-- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --name "投标事实表" --description "招投标明细"`
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --domain-id 27 --name "投标事实表" --description "招投标明细"`
 - **THEN** 提交的对象中 `displayName` 为 `投标事实表`，`description` 为 `招投标明细`
 
 #### Scenario: 只更新 description 时保留原 displayName
 
-- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --description "只改描述"`
-- **THEN** 提交的对象中 `description` 为 `只改描述`，`displayName` 保持 detail 中的原值
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --domain-id 27 --description "只改描述"`
+- **THEN** 提交的对象中 `description` 为 `只改描述`，`displayName` 保持列表中的原值
+
+#### Scenario: dataset 不在指定 domain 中时报错
+
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --domain-id 27 --name X`
+- **AND** domain 27 的 dataset 列表中没有 datasetId=82
+- **THEN** CLI MUST 报错说明该 dataset 不在此 domain 中，且不调用 update
+
+#### Scenario: 缺少 --domain-id 时本地拒绝
+
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --name X`
+- **THEN** CLI MUST 在发请求前返回 `USAGE_ERROR`
 
 #### Scenario: 既不给 --name 也不给 --description 时本地拒绝
 
-- **WHEN** 用户执行 `cz-cli analytics-agent table update 82`
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --domain-id 27`
 - **THEN** CLI MUST 在发请求前返回 `USAGE_ERROR`
 
 #### Scenario: 空 --name 本地拒绝
 
-- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --name "   "`
+- **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --domain-id 27 --name "   "`
 - **THEN** CLI MUST 在发请求前返回 `USAGE_ERROR`
 
 ### Requirement: table semantics get 查看单个字段语义详情

--- a/openspec/specs/analytics-agent-table-semantics/spec.md
+++ b/openspec/specs/analytics-agent-table-semantics/spec.md
@@ -27,6 +27,24 @@
 - **且** 输出包含每个字段的 `attrId`、`attrCode`、`semanticType`、`description`、`hidden`
 - **且** 输出与 `cz-cli analytics-agent table semantics list 195` 一致
 
+### Requirement: table set-display-name 修改已加入域的表的显示名
+
+`cz-cli analytics-agent table set-display-name <dataset-id> --name <name>` MUST 支持修改一个已加入域的 dataset 的 display name。由于后端 `dataset/update` 接口需要**完整的 dataset 对象**，CLI MUST 采用 read-modify-write：先 `GET /api/v1/dataset/detail?datasetId=<id>` 取回完整对象，仅改写 `displayName`，再 `POST /api/v1/dataset/update` 把整个对象提交回去，不得只发部分字段（否则会清空其它字段）。`--name` MUST 非空。
+
+> 说明：`table add --display-name` 只在**新建** dataset 时设置显示名；对**已存在**的 dataset 后端会忽略。要改已有表的显示名必须用本命令。
+
+#### Scenario: read-modify-write 更新 displayName
+
+- **WHEN** 用户执行 `cz-cli analytics-agent table set-display-name 82 --name "投标事实表"`
+- **THEN** CLI MUST 先调用 `GET /api/v1/dataset/detail?datasetId=82`
+- **且** 再调用 `POST /api/v1/dataset/update`，请求体为该 detail 完整对象且 `displayName` 改为 `投标事实表`
+- **且** 请求体保留 detail 中的其它字段（如 `description`、`tableName`、`completeSchema`）
+
+#### Scenario: 空 --name 本地拒绝
+
+- **WHEN** 用户执行 `cz-cli analytics-agent table set-display-name 82 --name "   "`
+- **THEN** CLI MUST 在发请求前返回 `USAGE_ERROR`
+
 ### Requirement: table semantics get 查看单个字段语义详情
 
 `cz-cli analytics-agent table semantics get` MUST 支持按 `datasetId + attrId` 查看单个字段的语义详情。

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -377,11 +377,23 @@ function resolveDomainTableAddBody(argv: Record<string, unknown>): Record<string
     }
   }
 
+  // A dataset created without a display name renders as blank in the UI, which
+  // breaks page-level operations. Default it (matching the UI's convention) to
+  // the fully-qualified physical table name — the view name with the `v_gpt_`
+  // prefix stripped — unless the caller passes an explicit --display-name.
+  const explicit = typeof argv["display-name"] === "string" && argv["display-name"].trim() !== ""
+    ? (argv["display-name"] as string).trim()
+    : undefined
+  const physicalTable = tableName.replace(/^v_gpt_/, "")
+  const displayName = explicit
+    ?? (workspace && schema ? `${workspace}.${schema}.${physicalTable}` : physicalTable)
+
   return mergeBody({}, {
     datasourceId: argv["datasource-id"],
     workspace,
     schema,
     tableName,
+    displayName,
   })
 }
 
@@ -1970,6 +1982,7 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                     .option("workspace", { type: "string", describe: "Lakehouse workspace name (or embed it in --table as workspace.schema.table)" })
                     .option("schema", { type: "string", describe: "Schema name (or embed it in --table as workspace.schema.table)" })
                     .option("table", { type: "string", demandOption: true, describe: "Table name; a fully-qualified workspace.schema.table is auto-split" })
+                    .option("display-name", { type: "string", describe: "Display name shown in the UI; defaults to the physical table name" })
                     .example('cz-cli analytics-agent domain table add 27 --datasource-id 8448 --table "quick_start.construction_dw.v_gpt_fact_bid"', "Fully-qualified name is split into workspace/schema/table")
                     .epilogue("After adding, run `cz-cli analytics-agent domain detail <domain-id> --with-tables` to see each table's dataset ID (needed for join/metric/semantics commands)."),
                 async (argv) => {

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -53,6 +53,8 @@ const ROUTES = {
   tableSemanticsGet: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/datasets/${encodePath(argv["dataset-id"])}/semantics/${encodePath(argv["attr-id"])}` },
   tableSemanticsSet: { method: "PUT", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/datasets/${encodePath(argv["dataset-id"])}/semantics/${encodePath(argv["attr-id"])}` },
   tableSemanticsProp: { method: "POST", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/datasets/${encodePath(argv["dataset-id"])}/semantics/${encodePath(argv["attr-id"])}/prop` },
+  datasetDetail: { method: "GET", path: "/api/v1/dataset/detail" },
+  datasetUpdate: { method: "POST", path: "/api/v1/dataset/update" },
   domainJoinList: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}/joins` },
   domainJoinDetail: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}/joins/${encodePath(argv["join-id"])}` },
   domainJoinCreate: { method: "POST", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}/joins` },
@@ -337,6 +339,43 @@ async function runTableSemanticsList(argv: Record<string, unknown>): Promise<voi
   } catch (err) {
     if (isHandledCliError(err)) return
     error("ANALYTICS_AGENT_ERROR", err instanceof Error ? err.message : String(err), {
+      format, ...(err instanceof AnalyticsHttpError ? { extra: { request: err.request } } : {}),
+    })
+  }
+}
+
+// Update a dataset's display name via read-modify-write: the backend
+// `dataset/update` endpoint expects the FULL dataset object, so we fetch the
+// current detail, change only displayName, and post the whole object back.
+// Sending a partial body would blank out the other fields.
+async function runTableSetDisplayName(argv: Record<string, unknown>): Promise<void> {
+  const format = typeof argv.format === "string" ? argv.format : "json"
+  const t0 = Date.now()
+  const datasetId = positiveIntegerValue(argv["dataset-id"], "--dataset-id", format)
+  const displayName = typeof argv.name === "string" ? argv.name.trim() : ""
+  if (displayName === "") {
+    error("USAGE_ERROR", "--name is required and must be non-empty", { format })
+    return
+  }
+  try {
+    const ctx = await resolveAnalyticsContext(argv)
+    const detail = await requestAnalyticsData(argv, ROUTES.datasetDetail, {}, { datasetId }, ctx)
+    if (!detail || typeof detail !== "object" || Array.isArray(detail)) {
+      error("ANALYTICS_AGENT_ERROR", `dataset ${datasetId} detail not found`, { format })
+      return
+    }
+    const updated = await requestAnalyticsData(
+      argv, ROUTES.datasetUpdate,
+      { ...(detail as Record<string, unknown>), displayName },
+      {}, ctx,
+    )
+    logOperation("analytics-agent table set-display-name", { ok: true, timeMs: Date.now() - t0 })
+    success(updated, { format, timeMs: Date.now() - t0 })
+  } catch (err) {
+    logOperation("analytics-agent table set-display-name", { ok: false, timeMs: Date.now() - t0 })
+    if (isHandledCliError(err)) return
+    const code = err instanceof AnalyticsBusinessError ? err.code : "ANALYTICS_AGENT_ERROR"
+    error(code, err instanceof Error ? err.message : String(err), {
       format, ...(err instanceof AnalyticsHttpError ? { extra: { request: err.request } } : {}),
     })
   }
@@ -2124,6 +2163,16 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
             "List column semantics of a dataset (alias for `table semantics list`)",
             (y) => y.positional("dataset-id", { type: "number", demandOption: true, describe: "Dataset ID" }),
             (argv) => runTableSemanticsList(argv as Record<string, unknown>),
+          )
+          .command(
+            "set-display-name <dataset-id>",
+            "Set the display name of a table already added to a domain",
+            (y) =>
+              y
+                .positional("dataset-id", { type: "number", demandOption: true, describe: "Dataset ID (from `domain detail --with-tables`)" })
+                .option("name", { type: "string", demandOption: true, describe: "New display name" })
+                .example('cz-cli analytics-agent table set-display-name 82 --name "投标事实表"', "Rename an existing table's display name shown in the UI"),
+            (argv) => runTableSetDisplayName(argv as Record<string, unknown>),
           )
         table.command("semantics", "Manage dataset column semantics", (semantics) => {
           semantics

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -344,17 +344,22 @@ async function runTableSemanticsList(argv: Record<string, unknown>): Promise<voi
   }
 }
 
-// Update a dataset's display name via read-modify-write: the backend
-// `dataset/update` endpoint expects the FULL dataset object, so we fetch the
-// current detail, change only displayName, and post the whole object back.
-// Sending a partial body would blank out the other fields.
-async function runTableSetDisplayName(argv: Record<string, unknown>): Promise<void> {
+// Update a dataset's display name and/or description via read-modify-write: the
+// backend `dataset/update` endpoint expects the FULL dataset object, so we fetch
+// the current detail, change only the requested fields, and post the whole
+// object back. Sending a partial body would blank out the other fields.
+async function runTableUpdate(argv: Record<string, unknown>): Promise<void> {
   const format = typeof argv.format === "string" ? argv.format : "json"
   const t0 = Date.now()
   const datasetId = positiveIntegerValue(argv["dataset-id"], "--dataset-id", format)
-  const displayName = typeof argv.name === "string" ? argv.name.trim() : ""
-  if (displayName === "") {
-    error("USAGE_ERROR", "--name is required and must be non-empty", { format })
+  const hasName = typeof argv.name === "string"
+  const hasDesc = typeof argv.description === "string"
+  if (!hasName && !hasDesc) {
+    error("USAGE_ERROR", "Provide at least one of --name or --description", { format })
+    return
+  }
+  if (hasName && (argv.name as string).trim() === "") {
+    error("USAGE_ERROR", "--name must be non-empty", { format })
     return
   }
   try {
@@ -364,15 +369,14 @@ async function runTableSetDisplayName(argv: Record<string, unknown>): Promise<vo
       error("ANALYTICS_AGENT_ERROR", `dataset ${datasetId} detail not found`, { format })
       return
     }
-    const updated = await requestAnalyticsData(
-      argv, ROUTES.datasetUpdate,
-      { ...(detail as Record<string, unknown>), displayName },
-      {}, ctx,
-    )
-    logOperation("analytics-agent table set-display-name", { ok: true, timeMs: Date.now() - t0 })
+    const body: Record<string, unknown> = { ...(detail as Record<string, unknown>) }
+    if (hasName) body.displayName = (argv.name as string).trim()
+    if (hasDesc) body.description = argv.description
+    const updated = await requestAnalyticsData(argv, ROUTES.datasetUpdate, body, {}, ctx)
+    logOperation("analytics-agent table update", { ok: true, timeMs: Date.now() - t0 })
     success(updated, { format, timeMs: Date.now() - t0 })
   } catch (err) {
-    logOperation("analytics-agent table set-display-name", { ok: false, timeMs: Date.now() - t0 })
+    logOperation("analytics-agent table update", { ok: false, timeMs: Date.now() - t0 })
     if (isHandledCliError(err)) return
     const code = err instanceof AnalyticsBusinessError ? err.code : "ANALYTICS_AGENT_ERROR"
     error(code, err instanceof Error ? err.message : String(err), {
@@ -2165,14 +2169,16 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
             (argv) => runTableSemanticsList(argv as Record<string, unknown>),
           )
           .command(
-            "set-display-name <dataset-id>",
-            "Set the display name of a table already added to a domain",
+            "update <dataset-id>",
+            "Update a table's display name and/or description (for a table already added to a domain)",
             (y) =>
               y
                 .positional("dataset-id", { type: "number", demandOption: true, describe: "Dataset ID (from `domain detail --with-tables`)" })
-                .option("name", { type: "string", demandOption: true, describe: "New display name" })
-                .example('cz-cli analytics-agent table set-display-name 82 --name "投标事实表"', "Rename an existing table's display name shown in the UI"),
-            (argv) => runTableSetDisplayName(argv as Record<string, unknown>),
+                .option("name", { type: "string", describe: "New display name shown in the UI" })
+                .option("description", { type: "string", describe: "New table description" })
+                .example('cz-cli analytics-agent table update 82 --name "投标事实表"', "Rename an existing table's display name")
+                .example('cz-cli analytics-agent table update 82 --name "投标事实表" --description "招投标明细"', "Set display name and description together"),
+            (argv) => runTableUpdate(argv as Record<string, unknown>),
           )
         table.command("semantics", "Manage dataset column semantics", (semantics) => {
           semantics

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -54,6 +54,7 @@ const ROUTES = {
   tableSemanticsSet: { method: "PUT", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/datasets/${encodePath(argv["dataset-id"])}/semantics/${encodePath(argv["attr-id"])}` },
   tableSemanticsProp: { method: "POST", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/datasets/${encodePath(argv["dataset-id"])}/semantics/${encodePath(argv["attr-id"])}/prop` },
   datasetDetail: { method: "GET", path: "/api/v1/dataset/detail" },
+  datasetList: { method: "POST", path: "/api/v1/dataset/list" },
   datasetUpdate: { method: "POST", path: "/api/v1/dataset/update" },
   domainJoinList: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}/joins` },
   domainJoinDetail: { method: "GET", path: (argv: Record<string, unknown>) => `/open/api/v1/analytics-agent/domains/${encodePath(argv["domain-id"])}/joins/${encodePath(argv["join-id"])}` },
@@ -345,13 +346,16 @@ async function runTableSemanticsList(argv: Record<string, unknown>): Promise<voi
 }
 
 // Update a dataset's display name and/or description via read-modify-write: the
-// backend `dataset/update` endpoint expects the FULL dataset object, so we fetch
-// the current detail, change only the requested fields, and post the whole
-// object back. Sending a partial body would blank out the other fields.
+// backend `dataset/update` endpoint expects the FULL dataset object. The read
+// source is `dataset/list` filtered by domainIds (NOT `dataset/detail`, which
+// returns CZD-20009 "dataset not found" for datasets in some domains). We locate
+// the full object by datasetId, change only the requested fields, and post the
+// whole object back — a partial body would blank out the other fields.
 async function runTableUpdate(argv: Record<string, unknown>): Promise<void> {
   const format = typeof argv.format === "string" ? argv.format : "json"
   const t0 = Date.now()
   const datasetId = positiveIntegerValue(argv["dataset-id"], "--dataset-id", format)
+  const domainId = requiredPositiveIntegerValue(argv["domain-id"], "--domain-id", format)
   const hasName = typeof argv.name === "string"
   const hasDesc = typeof argv.description === "string"
   if (!hasName && !hasDesc) {
@@ -364,12 +368,14 @@ async function runTableUpdate(argv: Record<string, unknown>): Promise<void> {
   }
   try {
     const ctx = await resolveAnalyticsContext(argv)
-    const detail = await requestAnalyticsData(argv, ROUTES.datasetDetail, {}, { datasetId }, ctx)
-    if (!detail || typeof detail !== "object" || Array.isArray(detail)) {
-      error("ANALYTICS_AGENT_ERROR", `dataset ${datasetId} detail not found`, { format })
+    const listData = await requestAnalyticsData(argv, ROUTES.datasetList, { domainIds: [domainId] }, {}, ctx)
+    const items = Array.isArray(listData) ? listData as Record<string, unknown>[] : []
+    const current = items.find((d) => String(d.datasetId) === String(datasetId))
+    if (!current) {
+      error("ANALYTICS_AGENT_ERROR", `dataset ${datasetId} not found in domain ${domainId}`, { format })
       return
     }
-    const body: Record<string, unknown> = { ...(detail as Record<string, unknown>) }
+    const body: Record<string, unknown> = { ...current }
     if (hasName) body.displayName = (argv.name as string).trim()
     if (hasDesc) body.description = argv.description
     const updated = await requestAnalyticsData(argv, ROUTES.datasetUpdate, body, {}, ctx)
@@ -2174,10 +2180,11 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
             (y) =>
               y
                 .positional("dataset-id", { type: "number", demandOption: true, describe: "Dataset ID (from `domain detail --with-tables`)" })
+                .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID the table belongs to" })
                 .option("name", { type: "string", describe: "New display name shown in the UI" })
                 .option("description", { type: "string", describe: "New table description" })
-                .example('cz-cli analytics-agent table update 82 --name "投标事实表"', "Rename an existing table's display name")
-                .example('cz-cli analytics-agent table update 82 --name "投标事实表" --description "招投标明细"', "Set display name and description together"),
+                .example('cz-cli analytics-agent table update 82 --domain-id 27 --name "投标事实表"', "Rename an existing table's display name")
+                .example('cz-cli analytics-agent table update 82 --domain-id 27 --name "投标事实表" --description "招投标明细"', "Set display name and description together"),
             (argv) => runTableUpdate(argv as Record<string, unknown>),
           )
         table.command("semantics", "Manage dataset column semantics", (semantics) => {

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -140,6 +140,31 @@ function parseOptionalJsonObject(raw: string | undefined, fieldName: string): Re
   return parseJsonObject(raw, fieldName)
 }
 
+// Resolve the answer-builder `content` DSL string. `--content` carries the DSL
+// JSON (chartParams/outputColumns/relatedTables/…). `--sql`, when given, is
+// injected as the top-level `sql` field so the caller does not have to escape
+// SQL quotes inside the JSON string. Returns the final JSON string to POST.
+function resolveAnswerBuilderContent(argv: Record<string, unknown>, format: string): string {
+  const rawContent = typeof argv.content === "string" ? argv.content : undefined
+  const sql = typeof argv.sql === "string" ? argv.sql : undefined
+
+  if (sql === undefined) {
+    if (rawContent === undefined) {
+      handledError("USAGE_ERROR", "Provide --content (DSL JSON) or --sql.", { format })
+    }
+    return rawContent as string
+  }
+
+  let dsl: Record<string, unknown>
+  try {
+    dsl = rawContent ? parseJsonObject(rawContent, "--content") : {}
+  } catch (err) {
+    return handledError("USAGE_ERROR", err instanceof Error ? err.message : String(err), { format })
+  }
+  dsl.sql = sql
+  return JSON.stringify(dsl)
+}
+
 function stringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return value === undefined ? undefined : [String(value)]
   return value.map((item) => String(item))
@@ -317,7 +342,63 @@ async function runTableSemanticsList(argv: Record<string, unknown>): Promise<voi
   }
 }
 
+// Summarize a domain-table-add response so the caller sees the assigned dataset
+// ID (needed for later join/metric/semantics commands) without hunting through
+// `domain detail`. Also flags the soft-failure case where the backend returned
+// success but did not actually attach the table to the domain.
+function tableAddAiMessage(data: unknown): string | undefined {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return undefined
+  const item = data as Record<string, unknown>
+  const datasetId = item.datasetId
+  const tableName = item.tableName ?? item.physicalTable
+  if (datasetId === undefined) return undefined
+  if (item.addedToDomain === false) {
+    return `Warning: dataset ${datasetId} (${String(tableName)}) was NOT attached to the domain. Verify the table exists and retry.`
+  }
+  return `Added dataset ID ${datasetId} (${String(tableName)}). Use this dataset ID for join/metric/semantics commands.`
+}
+
+// Build the domain-table-add request body. When `--table` is a fully-qualified
+// three-part name (catalog/workspace.schema.table) and workspace/schema are not
+// given explicitly, split it so lakehouse datasources don't force the caller to
+// re-supply --workspace and --schema separately.
+function resolveDomainTableAddBody(argv: Record<string, unknown>): Record<string, unknown> {
+  const rawTable = typeof argv.table === "string" ? argv.table.trim() : ""
+  let workspace = typeof argv.workspace === "string" ? argv.workspace : undefined
+  let schema = typeof argv.schema === "string" ? argv.schema : undefined
+  let tableName = rawTable
+
+  if (workspace === undefined && schema === undefined) {
+    const parts = rawTable.split(".")
+    if (parts.length === 3 && parts.every((p) => p.trim() !== "")) {
+      workspace = parts[0]
+      schema = parts[1]
+      tableName = parts[2]
+    }
+  }
+
+  return mergeBody({}, {
+    datasourceId: argv["datasource-id"],
+    workspace,
+    schema,
+    tableName,
+  })
+}
+
 const DOMAIN_JOIN_RELATIONS = new Set(["n:1", "1:n", "1:1", "MANY_TO_ONE", "ONE_TO_MANY", "ONE_TO_ONE"])
+
+// The backend normalizes a join relation based on the actual data cardinality,
+// so a requested `n:1` may come back as `1:n`. Surface that as guidance so the
+// caller doesn't mistake the mismatch for an error.
+function joinRelationAiMessage(requested: unknown, data: unknown): string | undefined {
+  if (typeof requested !== "string" || requested.trim() === "") return undefined
+  if (!data || typeof data !== "object" || Array.isArray(data)) return undefined
+  const stored = (data as Record<string, unknown>).relation
+  if (typeof stored !== "string" || stored === "") return undefined
+  const req = requested.trim()
+  if (req === stored) return undefined
+  return `Relation auto-normalized by cardinality analysis: requested ${req} -> stored ${stored}.`
+}
 
 function resolveDomainJoinPathArgv(argv: Record<string, unknown>, format: string): Record<string, unknown> {
   return mergeBody(argv, {
@@ -1886,19 +1967,16 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                   y
                     .positional("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
                     .option("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
-                    .option("workspace", { type: "string", describe: "Lakehouse workspace name" })
-                    .option("schema", { type: "string", describe: "Schema name" })
-                    .option("table", { type: "string", demandOption: true, describe: "Table name" }),
+                    .option("workspace", { type: "string", describe: "Lakehouse workspace name (or embed it in --table as workspace.schema.table)" })
+                    .option("schema", { type: "string", describe: "Schema name (or embed it in --table as workspace.schema.table)" })
+                    .option("table", { type: "string", demandOption: true, describe: "Table name; a fully-qualified workspace.schema.table is auto-split" })
+                    .example('cz-cli analytics-agent domain table add 27 --datasource-id 8448 --table "quick_start.construction_dw.v_gpt_fact_bid"', "Fully-qualified name is split into workspace/schema/table")
+                    .epilogue("After adding, run `cz-cli analytics-agent domain detail <domain-id> --with-tables` to see each table's dataset ID (needed for join/metric/semantics commands)."),
                 async (argv) => {
                   const format = typeof argv.format === "string" ? argv.format : "json"
                   const t0 = Date.now()
                   const requestArgv = argv as Record<string, unknown>
-                  const body = mergeBody({}, {
-                    datasourceId: argv["datasource-id"],
-                    workspace: argv.workspace,
-                    schema: argv.schema,
-                    tableName: argv.table,
-                  })
+                  const body = resolveDomainTableAddBody(argv as Record<string, unknown>)
 
                   try {
                     const payload = await requestAnalytics(requestArgv, ROUTES.domainTableAdd, body)
@@ -1909,7 +1987,9 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                       return
                     }
                     logOperation("analytics-agent domain table add", { ok: true, timeMs: Date.now() - t0 })
-                    success(unwrapResponse(payload), { format, timeMs: Date.now() - t0 })
+                    const data = unwrapResponse(payload)
+                    const aiMessage = tableAddAiMessage(data)
+                    success(data, { format, timeMs: Date.now() - t0, ...(aiMessage ? { aiMessage } : {}) })
                   } catch (err) {
                     logOperation("analytics-agent domain table add", { ok: false, timeMs: Date.now() - t0 })
                     if (isHandledCliError(err)) return
@@ -1982,7 +2062,11 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 async (argv) => {
                   const format = typeof argv.format === "string" ? argv.format : "json"
                   const requestArgv = resolveDomainJoinPathArgv(argv as Record<string, unknown>, format)
-                  await executeAnalyticsCommand("analytics-agent domain join create", requestArgv, ROUTES.domainJoinCreate, resolveDomainJoinBody(requestArgv, format))
+                  await executeAnalyticsCommand(
+                    "analytics-agent domain join create", requestArgv, ROUTES.domainJoinCreate,
+                    resolveDomainJoinBody(requestArgv, format), {},
+                    (data) => joinRelationAiMessage(argv.relation, data),
+                  )
                 },
               )
               .command(
@@ -1997,7 +2081,11 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 async (argv) => {
                   const format = typeof argv.format === "string" ? argv.format : "json"
                   const requestArgv = resolveDomainJoinPathArgv(argv as Record<string, unknown>, format)
-                  await executeAnalyticsCommand("analytics-agent domain join update", requestArgv, ROUTES.domainJoinUpdate, resolveDomainJoinBody(requestArgv, format))
+                  await executeAnalyticsCommand(
+                    "analytics-agent domain join update", requestArgv, ROUTES.domainJoinUpdate,
+                    resolveDomainJoinBody(requestArgv, format), {},
+                    (data) => joinRelationAiMessage(argv.relation, data),
+                  )
                 },
               )
               .command(
@@ -2509,18 +2597,25 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("analysis-desc", { type: "string", describe: "Answer builder description" })
                 .option("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
                 .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
-                .option("content", { type: "string", demandOption: true, describe: "Analysis DSL JSON string" })
+                .option("content", { type: "string", describe: "Analysis DSL JSON (chartParams/outputColumns/relatedTables/sql)" })
+                .option("sql", { type: "string", describe: "SQL body, injected into content.sql — avoids escaping quotes inside --content JSON" })
                 .example(
                   'cz-cli analytics-agent answer-builder create --domain-id 27 --datasource-id 8448 --analysis-name "各省份中标金额排名" --content \'{"...DSL..."}\'',
                   "Create a complex metric (answer builder). Run `answer-builder validate` first to check the --content DSL",
+                )
+                .example(
+                  'cz-cli analytics-agent answer-builder create --domain-id 27 --datasource-id 8448 --analysis-name "中标率" --content \'{"chartParams":[...],"outputColumns":[...]}\' --sql "SELECT ... WHERE bid_result=\'中标\'"',
+                  "Pass SQL via --sql so single quotes don't collide with the --content JSON",
                 ),
             async (argv) => {
+              const format = typeof argv.format === "string" ? argv.format : "json"
+              const content = resolveAnswerBuilderContent(argv as Record<string, unknown>, format)
               const body = mergeBody({}, {
                 analysisName: argv["analysis-name"],
                 analysisDesc: argv["analysis-desc"],
                 datasourceId: argv["datasource-id"],
                 domainIds: [argv["domain-id"]],
-                content: argv.content,
+                content,
               })
               await executeAnalyticsCommand("analytics-agent answer-builder create", argv as Record<string, unknown>, ROUTES.answerBuilderCreate, body)
             },
@@ -2535,15 +2630,18 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("analysis-desc", { type: "string", describe: "Answer builder description" })
                 .option("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
                 .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
-                .option("content", { type: "string", demandOption: true, describe: "Analysis DSL JSON string" }),
+                .option("content", { type: "string", describe: "Analysis DSL JSON (chartParams/outputColumns/relatedTables/sql)" })
+                .option("sql", { type: "string", describe: "SQL body, injected into content.sql — avoids escaping quotes inside --content JSON" }),
             async (argv) => {
+              const format = typeof argv.format === "string" ? argv.format : "json"
+              const content = resolveAnswerBuilderContent(argv as Record<string, unknown>, format)
               const body = mergeBody({}, {
                 id: argv["analysis-id"],
                 analysisName: argv["analysis-name"],
                 analysisDesc: argv["analysis-desc"],
                 datasourceId: argv["datasource-id"],
                 domainIds: [argv["domain-id"]],
-                content: argv.content,
+                content,
               })
               await executeAnalyticsCommand("analytics-agent answer-builder update", argv as Record<string, unknown>, ROUTES.answerBuilderUpdate, body)
             },
@@ -2681,14 +2779,17 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("analysis-desc", { type: "string", describe: "Answer builder description" })
                 .option("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
                 .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
-                .option("content", { type: "string", demandOption: true, describe: "Analysis DSL JSON string" }),
+                .option("content", { type: "string", describe: "Analysis DSL JSON (chartParams/outputColumns/relatedTables/sql)" })
+                .option("sql", { type: "string", describe: "SQL body, injected into content.sql — avoids escaping quotes inside --content JSON" }),
             async (argv) => {
+              const format = typeof argv.format === "string" ? argv.format : "json"
+              const content = resolveAnswerBuilderContent(argv as Record<string, unknown>, format)
               const body = mergeBody({}, {
                 analysisName: argv["analysis-name"],
                 analysisDesc: argv["analysis-desc"],
                 datasourceId: argv["datasource-id"],
                 domainIds: [argv["domain-id"]],
-                content: argv.content,
+                content,
               })
               await executeAnalyticsCommand("analytics-agent answer-builder validate", argv as Record<string, unknown>, ROUTES.answerBuilderValidate, body)
             },
@@ -3014,14 +3115,17 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 )
                 .command(
                   "upload <space-id> <local-file>",
-                  "Upload one local file into a knowledge space",
+                  "Upload a local file, create its folder path, and bind domains — in one step",
                   (y) =>
                     y
                       .positional("space-id", { type: "number", demandOption: true, describe: "Knowledge space ID" })
                       .positional("local-file", { type: "string", demandOption: true, describe: "Local file path" })
-                      .option("target-path", { type: "string", describe: "Remote target folder path" })
+                      .option("target-path", { type: "string", describe: "Remote folder path; intermediate folders are auto-created" })
                       .option("name", { type: "string", describe: "Remote file name override" })
-                      .option("domain-id", { type: "number", array: true, describe: "Bound domain ID, can be repeated" }),
+                      .option("domain-id", { type: "number", array: true, describe: "Bind to this domain at upload, can be repeated" })
+                      .example('cz-cli analytics-agent knowledge file upload 1 ./guide.md --domain-id 28', "Upload and bind to a domain in one step")
+                      .example('cz-cli analytics-agent knowledge file upload 1 ./guide.md --target-path "docs/onboarding" --domain-id 28', "Auto-create the folder path, upload, and bind — no separate folder create/move/bind needed")
+                      .epilogue("This single command replaces the old create → folder create → move → bind-domain sequence: --target-path auto-creates folders and --domain-id binds at upload."),
                   async (argv) => {
                     await executeKnowledgeFileUploadCommand(argv as Record<string, unknown>)
                   },

--- a/packages/cz-cli/test/analytics-agent-answer-builder.test.ts
+++ b/packages/cz-cli/test/analytics-agent-answer-builder.test.ts
@@ -125,6 +125,62 @@ describe("analytics-agent answer-builder", () => {
     })
   })
 
+  test("create injects --sql into content.sql so quotes need no escaping", async () => {
+    let requestBody: Record<string, unknown> | null = null
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null
+      return jsonResponse({ success: true, data: { id: 401 } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "answer-builder", "create",
+      "--analysis-name", "中标率",
+      "--datasource-id", "11",
+      "--domain-id", "195",
+      "--content", "{\"chartParams\":[],\"outputColumns\":[]}",
+      "--sql", "SELECT COUNT(*) FROM t WHERE bid_result='中标'",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const content = JSON.parse(String((requestBody as Record<string, unknown>).content))
+    expect(content.sql).toBe("SELECT COUNT(*) FROM t WHERE bid_result='中标'")
+    expect(content.chartParams).toEqual([])
+    expect(content.outputColumns).toEqual([])
+  })
+
+  test("create with --sql but no --content builds a content object with just sql", async () => {
+    let requestBody: Record<string, unknown> | null = null
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null
+      return jsonResponse({ success: true, data: { id: 401 } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "answer-builder", "create",
+      "--analysis-name", "x", "--datasource-id", "11", "--domain-id", "195",
+      "--sql", "SELECT 1",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const content = JSON.parse(String((requestBody as Record<string, unknown>).content))
+    expect(content).toEqual({ sql: "SELECT 1" })
+  })
+
+  test("create with neither --content nor --sql is a local usage error", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "answer-builder", "create",
+      "--analysis-name", "x", "--datasource-id", "11", "--domain-id", "195",
+    ])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.output.trim())
+    expect(parsed.error.code).toBe("USAGE_ERROR")
+  })
+
   test("list maps flat filter fields into request body", async () => {
     let requestBody: unknown
 

--- a/packages/cz-cli/test/analytics-agent-domain-datasource.test.ts
+++ b/packages/cz-cli/test/analytics-agent-domain-datasource.test.ts
@@ -506,4 +506,76 @@ describe("analytics-agent domain and datasource parameter simplification", () =>
     expect(result.exitCode).toBe(2)
     expect(parseError(result.output).code).toBe("USAGE_ERROR")
   })
+
+  test("domain table add splits a fully-qualified --table into workspace/schema/table", async () => {
+    let requestBody: unknown
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null
+      return jsonResponse({ success: true, data: { datasetId: 321, tableName: "quick_start.rpt.orders" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "domain", "table", "add", "19",
+      "--datasource-id", "4164",
+      "--table", "quick_start.rpt.orders",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(requestBody).toEqual({
+      datasourceId: 4164,
+      workspace: "quick_start",
+      schema: "rpt",
+      tableName: "orders",
+    })
+  })
+
+  test("domain table add leaves a single-segment --table untouched", async () => {
+    let requestBody: unknown
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null
+      return jsonResponse({ success: true, data: { datasetId: 1, tableName: "orders" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "domain", "table", "add", "19",
+      "--datasource-id", "4164",
+      "--table", "orders",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(requestBody).toEqual({ datasourceId: 4164, tableName: "orders" })
+  })
+
+  test("domain table add does not split when workspace/schema are explicit", async () => {
+    let requestBody: unknown
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null
+      return jsonResponse({ success: true, data: { datasetId: 1, tableName: "a.b.c" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "domain", "table", "add", "19",
+      "--datasource-id", "4164",
+      "--workspace", "ws", "--schema", "sc",
+      "--table", "a.b.c",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(requestBody).toEqual({ datasourceId: 4164, workspace: "ws", schema: "sc", tableName: "a.b.c" })
+  })
+
+  test("domain table add surfaces the assigned dataset id via ai_message", async () => {
+    globalThis.fetch = mock(async () => {
+      return jsonResponse({ success: true, data: { datasetId: 133, tableName: "quick_start.rpt.orders", addedToDomain: true } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "domain", "table", "add", "19",
+      "--datasource-id", "4164",
+      "--table", "quick_start.rpt.orders",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain("dataset ID 133")
+  })
 })

--- a/packages/cz-cli/test/analytics-agent-domain-datasource.test.ts
+++ b/packages/cz-cli/test/analytics-agent-domain-datasource.test.ts
@@ -459,6 +459,7 @@ describe("analytics-agent domain and datasource parameter simplification", () =>
       workspace: "quick_start",
       schema: "rpt",
       tableName: "rpt_transaction_lazada",
+      displayName: "quick_start.rpt.rpt_transaction_lazada",
     })
   })
 
@@ -480,8 +481,8 @@ describe("analytics-agent domain and datasource parameter simplification", () =>
     expect(result.stdout).not.toContain("--table-name")
     expect(result.stdout).not.toContain("--path")
     expect(result.stdout).not.toContain("--body")
-    expect(result.stdout).not.toContain("--display-name")
-    expect(result.stdout).not.toContain("--description")
+    // --display-name is now intentionally exposed to fix blank UI display names.
+    expect(result.stdout).toContain("--display-name")
   })
 
   test("domain table add rejects missing table before sending request", async () => {
@@ -526,6 +527,7 @@ describe("analytics-agent domain and datasource parameter simplification", () =>
       workspace: "quick_start",
       schema: "rpt",
       tableName: "orders",
+      displayName: "quick_start.rpt.orders",
     })
   })
 
@@ -543,7 +545,7 @@ describe("analytics-agent domain and datasource parameter simplification", () =>
     ])
 
     expect(result.exitCode).toBe(0)
-    expect(requestBody).toEqual({ datasourceId: 4164, tableName: "orders" })
+    expect(requestBody).toEqual({ datasourceId: 4164, tableName: "orders", displayName: "orders" })
   })
 
   test("domain table add does not split when workspace/schema are explicit", async () => {
@@ -561,7 +563,42 @@ describe("analytics-agent domain and datasource parameter simplification", () =>
     ])
 
     expect(result.exitCode).toBe(0)
-    expect(requestBody).toEqual({ datasourceId: 4164, workspace: "ws", schema: "sc", tableName: "a.b.c" })
+    expect(requestBody).toEqual({ datasourceId: 4164, workspace: "ws", schema: "sc", tableName: "a.b.c", displayName: "ws.sc.a.b.c" })
+  })
+
+  test("domain table add defaults displayName to the physical table name (v_gpt_ stripped)", async () => {
+    let requestBody: Record<string, unknown> | null = null
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null
+      return jsonResponse({ success: true, data: { datasetId: 1, tableName: "x", displayName: "quick_start.construction_dw.fact_bid" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "domain", "table", "add", "27",
+      "--datasource-id", "8448",
+      "--table", "quick_start.construction_dw.v_gpt_fact_bid",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect((requestBody as Record<string, unknown>).displayName).toBe("quick_start.construction_dw.fact_bid")
+  })
+
+  test("domain table add honors an explicit --display-name", async () => {
+    let requestBody: Record<string, unknown> | null = null
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null
+      return jsonResponse({ success: true, data: { datasetId: 1, tableName: "x" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "domain", "table", "add", "27",
+      "--datasource-id", "8448",
+      "--table", "quick_start.construction_dw.v_gpt_fact_bid",
+      "--display-name", "投标事实表",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect((requestBody as Record<string, unknown>).displayName).toBe("投标事实表")
   })
 
   test("domain table add surfaces the assigned dataset id via ai_message", async () => {

--- a/packages/cz-cli/test/analytics-agent-domain-joins.test.ts
+++ b/packages/cz-cli/test/analytics-agent-domain-joins.test.ts
@@ -194,6 +194,41 @@ describe("analytics-agent domain join", () => {
     expect(parseData(result.output)).toEqual({ joinId: 301, domainId: 195 })
   })
 
+  test("create notes when the backend auto-normalizes the relation direction", async () => {
+    globalThis.fetch = mock(async () => {
+      // Requested n:1 but backend stores 1:n after cardinality analysis.
+      return jsonResponse({ success: true, data: { joinId: 301, domainId: 195, relation: "1:n" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "domain", "join", "create", "195",
+      "--dataset-id", "1773", "--attr-code", "customer_id",
+      "--join-dataset-id", "1774", "--join-attr-code", "id",
+      "--relation", "n:1",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain("auto-normalized")
+    expect(result.output).toContain("n:1")
+    expect(result.output).toContain("1:n")
+  })
+
+  test("create does not note when the stored relation matches the request", async () => {
+    globalThis.fetch = mock(async () => {
+      return jsonResponse({ success: true, data: { joinId: 301, domainId: 195, relation: "n:1" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "domain", "join", "create", "195",
+      "--dataset-id", "1773", "--attr-code", "customer_id",
+      "--join-dataset-id", "1774", "--join-attr-code", "id",
+      "--relation", "n:1",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.output).not.toContain("auto-normalized")
+  })
+
   test("update sends manual join fields to the join detail endpoint", async () => {
     let requestUrl = ""
     let requestBody: unknown

--- a/packages/cz-cli/test/analytics-agent-table-semantics.test.ts
+++ b/packages/cz-cli/test/analytics-agent-table-semantics.test.ts
@@ -392,7 +392,7 @@ describe("analytics-agent table semantics", () => {
     expect(parsed.error.message).toBe("--attr-id must be a positive integer")
   })
 
-  test("set-display-name does a read-modify-write: fetches detail then posts full object with new displayName", async () => {
+  test("update does a read-modify-write: fetches detail then posts full object with new displayName", async () => {
     const calls: Array<{ url: string; method: string; body: unknown }> = []
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
@@ -408,12 +408,11 @@ describe("analytics-agent table semantics", () => {
           },
         })
       }
-      // dataset/update
       return jsonResponse({ success: true, data: { datasetId: "82", displayName: "投标事实表" } })
     }) as typeof fetch
 
     const result = await runAnalyticsCli([
-      "analytics-agent", "table", "set-display-name", "82", "--name", "投标事实表",
+      "analytics-agent", "table", "update", "82", "--name", "投标事实表",
     ])
 
     expect(result.exitCode).toBe(0)
@@ -430,13 +429,67 @@ describe("analytics-agent table semantics", () => {
     expect(body.completeSchema).toEqual([{ name: "c1" }])
   })
 
-  test("set-display-name rejects an empty --name before any request", async () => {
+  test("update can set displayName and description together", async () => {
+    let updateBody: Record<string, unknown> | null = null
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/dataset/detail")) {
+        return jsonResponse({ success: true, data: { id: "82", datasetId: "82", displayName: "old", description: "olddesc", tableName: "t" } })
+      }
+      updateBody = init?.body ? JSON.parse(String(init.body)) : null
+      return jsonResponse({ success: true, data: { datasetId: "82" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "table", "update", "82", "--name", "新名", "--description", "新描述",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect((updateBody as Record<string, unknown>).displayName).toBe("新名")
+    expect((updateBody as Record<string, unknown>).description).toBe("新描述")
+  })
+
+  test("update with only --description leaves displayName untouched", async () => {
+    let updateBody: Record<string, unknown> | null = null
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/dataset/detail")) {
+        return jsonResponse({ success: true, data: { id: "82", datasetId: "82", displayName: "keepname", description: "olddesc", tableName: "t" } })
+      }
+      updateBody = init?.body ? JSON.parse(String(init.body)) : null
+      return jsonResponse({ success: true, data: { datasetId: "82" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "table", "update", "82", "--description", "只改描述",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect((updateBody as Record<string, unknown>).displayName).toBe("keepname")
+    expect((updateBody as Record<string, unknown>).description).toBe("只改描述")
+  })
+
+  test("update rejects when neither --name nor --description is given", async () => {
     globalThis.fetch = mock(async () => {
       throw new Error("fetch should not be called")
     }) as typeof fetch
 
     const result = await runAnalyticsCli([
-      "analytics-agent", "table", "set-display-name", "82", "--name", "   ",
+      "analytics-agent", "table", "update", "82",
+    ])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.output.trim()) as Record<string, any>
+    expect(parsed.error.code).toBe("USAGE_ERROR")
+  })
+
+  test("update rejects an empty --name before any request", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "table", "update", "82", "--name", "   ",
     ])
 
     expect(result.exitCode).toBe(1)

--- a/packages/cz-cli/test/analytics-agent-table-semantics.test.ts
+++ b/packages/cz-cli/test/analytics-agent-table-semantics.test.ts
@@ -391,4 +391,56 @@ describe("analytics-agent table semantics", () => {
     expect(parsed.error.code).toBe("USAGE_ERROR")
     expect(parsed.error.message).toBe("--attr-id must be a positive integer")
   })
+
+  test("set-display-name does a read-modify-write: fetches detail then posts full object with new displayName", async () => {
+    const calls: Array<{ url: string; method: string; body: unknown }> = []
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      calls.push({ url, method: init?.method ?? "GET", body: init?.body ? JSON.parse(String(init.body)) : null })
+      if (url.includes("/dataset/detail")) {
+        return jsonResponse({
+          success: true,
+          data: {
+            id: "82", datasetId: "82", sourceId: "8448", mode: 1,
+            displayName: "old_name", tableName: "quick_start.construction_dw.v_gpt_fact_bid",
+            description: "keep me", completeSchema: [{ name: "c1" }], joins: [],
+            workspace: "quick_start", namespace: "construction_dw",
+          },
+        })
+      }
+      // dataset/update
+      return jsonResponse({ success: true, data: { datasetId: "82", displayName: "投标事实表" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "table", "set-display-name", "82", "--name", "投标事实表",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const detailCall = calls.find((c) => c.url.includes("/dataset/detail"))
+    const updateCall = calls.find((c) => c.url.includes("/dataset/update"))
+    expect(detailCall).toBeDefined()
+    expect(new URL(detailCall!.url).searchParams.get("datasetId")).toBe("82")
+    expect(updateCall).toBeDefined()
+    // The update body must carry the full object with only displayName changed.
+    const body = updateCall!.body as Record<string, unknown>
+    expect(body.displayName).toBe("投标事实表")
+    expect(body.description).toBe("keep me")
+    expect(body.tableName).toBe("quick_start.construction_dw.v_gpt_fact_bid")
+    expect(body.completeSchema).toEqual([{ name: "c1" }])
+  })
+
+  test("set-display-name rejects an empty --name before any request", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "table", "set-display-name", "82", "--name", "   ",
+    ])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.output.trim()) as Record<string, any>
+    expect(parsed.error.code).toBe("USAGE_ERROR")
+  })
 })

--- a/packages/cz-cli/test/analytics-agent-table-semantics.test.ts
+++ b/packages/cz-cli/test/analytics-agent-table-semantics.test.ts
@@ -392,37 +392,42 @@ describe("analytics-agent table semantics", () => {
     expect(parsed.error.message).toBe("--attr-id must be a positive integer")
   })
 
-  test("update does a read-modify-write: fetches detail then posts full object with new displayName", async () => {
+  test("update reads via dataset/list (domainIds) then posts full object with new displayName", async () => {
     const calls: Array<{ url: string; method: string; body: unknown }> = []
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
-      calls.push({ url, method: init?.method ?? "GET", body: init?.body ? JSON.parse(String(init.body)) : null })
-      if (url.includes("/dataset/detail")) {
+      const body = init?.body ? JSON.parse(String(init.body)) : null
+      calls.push({ url, method: init?.method ?? "GET", body })
+      if (url.includes("/dataset/list")) {
         return jsonResponse({
           success: true,
-          data: {
-            id: "82", datasetId: "82", sourceId: "8448", mode: 1,
-            displayName: "old_name", tableName: "quick_start.construction_dw.v_gpt_fact_bid",
-            description: "keep me", completeSchema: [{ name: "c1" }], joins: [],
-            workspace: "quick_start", namespace: "construction_dw",
-          },
+          data: [
+            { id: "99", datasetId: "99", displayName: "other", tableName: "t99" },
+            {
+              id: "82", datasetId: "82", sourceId: "8448", mode: 1,
+              displayName: "old_name", tableName: "quick_start.construction_dw.v_gpt_fact_bid",
+              description: "keep me", completeSchema: [{ name: "c1" }], joins: [],
+              workspace: "quick_start", namespace: "construction_dw",
+            },
+          ],
         })
       }
       return jsonResponse({ success: true, data: { datasetId: "82", displayName: "投标事实表" } })
     }) as typeof fetch
 
     const result = await runAnalyticsCli([
-      "analytics-agent", "table", "update", "82", "--name", "投标事实表",
+      "analytics-agent", "table", "update", "82", "--domain-id", "27", "--name", "投标事实表",
     ])
 
     expect(result.exitCode).toBe(0)
-    const detailCall = calls.find((c) => c.url.includes("/dataset/detail"))
+    const listCall = calls.find((c) => c.url.includes("/dataset/list"))
     const updateCall = calls.find((c) => c.url.includes("/dataset/update"))
-    expect(detailCall).toBeDefined()
-    expect(new URL(detailCall!.url).searchParams.get("datasetId")).toBe("82")
+    expect(listCall).toBeDefined()
+    expect((listCall!.body as Record<string, unknown>).domainIds).toEqual([27])
     expect(updateCall).toBeDefined()
-    // The update body must carry the full object with only displayName changed.
+    // The update body must carry the FULL object (of dataset 82, not 99) with only displayName changed.
     const body = updateCall!.body as Record<string, unknown>
+    expect(body.datasetId).toBe("82")
     expect(body.displayName).toBe("投标事实表")
     expect(body.description).toBe("keep me")
     expect(body.tableName).toBe("quick_start.construction_dw.v_gpt_fact_bid")
@@ -433,15 +438,15 @@ describe("analytics-agent table semantics", () => {
     let updateBody: Record<string, unknown> | null = null
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
-      if (url.includes("/dataset/detail")) {
-        return jsonResponse({ success: true, data: { id: "82", datasetId: "82", displayName: "old", description: "olddesc", tableName: "t" } })
+      if (url.includes("/dataset/list")) {
+        return jsonResponse({ success: true, data: [{ id: "82", datasetId: "82", displayName: "old", description: "olddesc", tableName: "t" }] })
       }
       updateBody = init?.body ? JSON.parse(String(init.body)) : null
       return jsonResponse({ success: true, data: { datasetId: "82" } })
     }) as typeof fetch
 
     const result = await runAnalyticsCli([
-      "analytics-agent", "table", "update", "82", "--name", "新名", "--description", "新描述",
+      "analytics-agent", "table", "update", "82", "--domain-id", "27", "--name", "新名", "--description", "新描述",
     ])
 
     expect(result.exitCode).toBe(0)
@@ -453,20 +458,52 @@ describe("analytics-agent table semantics", () => {
     let updateBody: Record<string, unknown> | null = null
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
-      if (url.includes("/dataset/detail")) {
-        return jsonResponse({ success: true, data: { id: "82", datasetId: "82", displayName: "keepname", description: "olddesc", tableName: "t" } })
+      if (url.includes("/dataset/list")) {
+        return jsonResponse({ success: true, data: [{ id: "82", datasetId: "82", displayName: "keepname", description: "olddesc", tableName: "t" }] })
       }
       updateBody = init?.body ? JSON.parse(String(init.body)) : null
       return jsonResponse({ success: true, data: { datasetId: "82" } })
     }) as typeof fetch
 
     const result = await runAnalyticsCli([
-      "analytics-agent", "table", "update", "82", "--description", "只改描述",
+      "analytics-agent", "table", "update", "82", "--domain-id", "27", "--description", "只改描述",
     ])
 
     expect(result.exitCode).toBe(0)
     expect((updateBody as Record<string, unknown>).displayName).toBe("keepname")
     expect((updateBody as Record<string, unknown>).description).toBe("只改描述")
+  })
+
+  test("update fails clearly when the dataset is not in the given domain", async () => {
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/dataset/list")) {
+        return jsonResponse({ success: true, data: [{ id: "99", datasetId: "99", displayName: "x", tableName: "t" }] })
+      }
+      throw new Error("update should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "table", "update", "82", "--domain-id", "27", "--name", "X",
+    ])
+
+    expect(result.exitCode).not.toBe(0)
+    const parsed = JSON.parse(result.output.trim()) as Record<string, any>
+    expect(parsed.error.message).toContain("not found in domain 27")
+  })
+
+  test("update requires --domain-id", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch should not be called")
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "table", "update", "82", "--name", "X",
+    ])
+
+    expect(result.exitCode).not.toBe(0)
+    const parsed = JSON.parse(result.output.trim()) as Record<string, any>
+    expect(parsed.error.code).toBe("USAGE_ERROR")
   })
 
   test("update rejects when neither --name nor --description is given", async () => {
@@ -475,7 +512,7 @@ describe("analytics-agent table semantics", () => {
     }) as typeof fetch
 
     const result = await runAnalyticsCli([
-      "analytics-agent", "table", "update", "82",
+      "analytics-agent", "table", "update", "82", "--domain-id", "27",
     ])
 
     expect(result.exitCode).toBe(1)
@@ -489,7 +526,7 @@ describe("analytics-agent table semantics", () => {
     }) as typeof fetch
 
     const result = await runAnalyticsCli([
-      "analytics-agent", "table", "update", "82", "--name", "   ",
+      "analytics-agent", "table", "update", "82", "--domain-id", "27", "--name", "   ",
     ])
 
     expect(result.exitCode).toBe(1)


### PR DESCRIPTION
## Summary

Addresses hands-on findings from the v1.17.18 deep semantic-modeling session (4 domains). Six CLI-fixable issues, each with updated spec + tests per the spec-driven workflow.

- **`domain table add` (#1, #2, #6)** — accept a fully-qualified `--table workspace.schema.table` and auto-split it (no more trial-and-error `--workspace`/`--schema` for lakehouse). Surface the assigned dataset ID via `ai_message`, and flag the soft-failure case where the backend returns success but did not attach the table.
- **`domain join create/update` (#7)** — when the backend normalizes the relation by cardinality (`n:1` → `1:n`), note it in `ai_message` so the direction flip isn't mistaken for an error.
- **`answer-builder create/update/validate` (#9)** — add `--sql`, injected into the content DSL's top-level `sql` field, so SQL quotes don't collide with `--content` JSON escaping. Require at least one of `--content`/`--sql`.
- **`knowledge file upload` (#3)** — examples + epilogue documenting that `--target-path` auto-creates the folder path and `--domain-id` binds at upload, collapsing the old create → folder → move → bind sequence into one command.

## Testing

- 173 analytics-agent + group-help unit tests pass; `bun typecheck` clean.
- Live-verified against the Shanghai environment (`aliyun_shanghai_prod`, domains 27/28), all reversible:
  - 3-part `--table` split sends correct workspace/schema/table; single/4-part names untouched.
  - `table add` ai_message surfaces `dataset ID N`.
  - join create shows `Relation auto-normalized: requested n:1 -> 1:n`.
  - `answer-builder validate --sql "... WHERE x='中标'"` succeeds with no quote escaping.
  - one-step upload auto-created `cz_test_folder/sub` and bound domain 28 in a single command.

## Not addressed (backend / doc, out of CLI scope)

- **#4** `targetCounts.knowledge` counting (backend aggregation).
- **#5** physical-table vs `v_gpt_*` view column-name divergence (workflow/doc: use `table columns <id>`).
- **#8** bulk create APIs for metric/knowledge/semantics (larger effort; can be a follow-up).

Co-Authored-By: cz-cli <noreply@clickzetta.com>