### PR TITLE
feat(analytics-agent): answer-builder DSL help, list pagination surfacing, --sql quoting warning, table-update pagination fix

### DIFF
--- a/openspec/specs/analytics-agent-answer-builder/spec.md
+++ b/openspec/specs/analytics-agent-answer-builder/spec.md
@@ -52,6 +52,22 @@
 - **WHEN** 用户既不提供 `--content` 也不提供 `--sql`
 - **THEN** CLI MUST 在发请求前返回 `USAGE_ERROR`
 
+### Requirement: answer-builder create/validate 提供 DSL 语法帮助
+
+`cz-cli analytics-agent answer-builder create --help` 与 `validate --help` MUST 在 epilogue 中提供 `--content` DSL 的语法参考，至少覆盖：DSL 结构（`chartParams` / `outputColumns` / `relatedTables` / `sql`）、`${name}` 占位符必须在 `chartParams` 中有对应项、`outputColumns[].metricName` 为必填且**在域内唯一**、以及窗口/ROLLUP 引用 `${dims}` 列时需用子查询包裹的规避方法。目的是让用户无需查阅外部文档即可构造合法的 `--content`。
+
+#### Scenario: create help 展示 DSL 结构与关键规则
+
+- **WHEN** 用户执行 `cz-cli analytics-agent answer-builder create --help`
+- **THEN** help 输出包含 `chartParams`、`outputColumns`
+- **且** 包含 `metricName` 及其"域内唯一"（UNIQUE within the domain）的说明
+- **且** 包含 `${name}` 占位符须有对应 chartParams 项的规则
+
+#### Scenario: validate help 同样展示 DSL 语法参考
+
+- **WHEN** 用户执行 `cz-cli analytics-agent answer-builder validate --help`
+- **THEN** help 输出包含 `chartParams` 与 `metricName` 语法说明
+
 ### Requirement: answer-builder 命令组帮助说明与 metric 的关系
 
 `cz-cli analytics-agent answer-builder --help` MUST 在 epilogue 中说明 answer-builder 是 complex_metric（多步/多表 DSL 分析），单表单聚合应使用 `metric`（simple_metric），且两者都计入 `domain detail` 的 targetCounts，并提示可用 `--domain-id` 把 `answer-builder list` 限定到单个 domain。

--- a/openspec/specs/analytics-agent-answer-builder/spec.md
+++ b/openspec/specs/analytics-agent-answer-builder/spec.md
@@ -68,6 +68,22 @@
 - **WHEN** 用户执行 `cz-cli analytics-agent answer-builder validate --help`
 - **THEN** help 输出包含 `chartParams` 与 `metricName` 语法说明
 
+### Requirement: --sql 帮助提示 shell 引号陷阱且示例不得示范该陷阱
+
+`--sql` 里的 `${name}` 占位符若置于双引号且不转义，会被 shell（bash/zsh）展开成空串，使后端收到 `SELECT , ... WHERE  GROUP BY`、报 `CZLH-42000: Syntax error at or near ','`。因此 `cz-cli analytics-agent answer-builder create`、`update`、`validate` 的 DSL epilogue MUST 说明该陷阱及规避方法（`--sql` 用单引号，或双引号内把 `$` 转义为 `\$`）。同时，help 中任何带 `--sql` 的示例 MUST NOT 示范该陷阱——即示例里 `--sql` 若含 `${...}` 占位符，MUST 使用单引号或转义写法，不得出现「双引号包裹且未转义的裸 `${...}`」。
+
+#### Scenario: create help 说明 shell 引号陷阱
+
+- **WHEN** 用户执行 `cz-cli analytics-agent answer-builder create --help`
+- **THEN** epilogue MUST 提到 `--sql` 的 `${...}` 占位符在双引号下会被 shell 展开
+- **且** MUST 给出规避方法（单引号包裹或 `\$` 转义）
+
+#### Scenario: help 示例不得示范未转义的裸占位符
+
+- **WHEN** 用户执行 `cz-cli analytics-agent answer-builder create --help`
+- **THEN** help 中所有 `--sql` 示例 MUST NOT 出现「双引号包裹且未转义的裸 `${dims}`/`${filters}`」
+- **且** 含占位符的 `--sql` 示例 MUST 用单引号或 `\$` 转义
+
 ### Requirement: answer-builder 命令组帮助说明与 metric 的关系
 
 `cz-cli analytics-agent answer-builder --help` MUST 在 epilogue 中说明 answer-builder 是 complex_metric（多步/多表 DSL 分析），单表单聚合应使用 `metric`（simple_metric），且两者都计入 `domain detail` 的 targetCounts，并提示可用 `--domain-id` 把 `answer-builder list` 限定到单个 domain。

--- a/openspec/specs/analytics-agent-table-semantics/spec.md
+++ b/openspec/specs/analytics-agent-table-semantics/spec.md
@@ -29,10 +29,11 @@
 
 ### Requirement: table update 修改已加入域的表的显示名与描述
 
-`cz-cli analytics-agent table update <dataset-id> --domain-id <id>` MUST 支持修改一个已加入域的 dataset 的 `displayName` 与/或 `description`。CLI MUST 全部使用 Analytics Agent open API：先调用 `POST /open/api/v1/analytics-agent/datasets/list`（请求体 `{domainIds:[<domain-id>]}`）按 domain 校验 dataset 归属，再调用 `POST /open/api/v1/analytics-agent/datasets/update` 进行局部更新。open update 会在服务端加载现有详情并覆盖请求字段，因此 CLI MUST 只提交 `datasetId` 和用户提供的更新字段（`--name` → `displayName`、`--description` → `description`），不得继续依赖非 open 的 MVC dataset 接口。`--domain-id` MUST 提供；`--name` 与 `--description` MUST 至少提供其一；提供 `--name` 时其值 MUST 非空。
+`cz-cli analytics-agent table update <dataset-id> --domain-id <id>` MUST 支持修改一个已加入域的 dataset 的 `displayName` 与/或 `description`。CLI MUST 全部使用 Analytics Agent open API：先调用 `POST /open/api/v1/analytics-agent/datasets/list`（请求体 `{domainIds:[<domain-id>]}`）按 domain 校验 dataset 归属，再调用 `POST /open/api/v1/analytics-agent/datasets/update` 进行局部更新。open update 会在服务端加载现有详情并覆盖请求字段，因此 CLI MUST 只提交 `datasetId` 和用户提供的更新字段（`--name` → `displayName`、`--description` → `description`），不得继续依赖非 open 的 MVC dataset 接口。datasets/list 分页返回（默认 `pageSize=10`），因此归属校验 MUST 翻页读取该域的**全部** dataset（逐页 `pageNum` 递增直到取满 `total`/遇到短页），再在合并后的完整集合中按 `datasetId` 定位；MUST NOT 只读第一页——否则域内表数超过一页时，落在后续页的 dataset 会被误判为「不在此 domain」而报 not found。`--domain-id` MUST 提供；`--name` 与 `--description` MUST 至少提供其一；提供 `--name` 时其值 MUST 非空。
 
 > 说明：`table add --display-name` 只在**新建** dataset 时设置显示名；对**已存在**的 dataset 后端会忽略。要改已有表的显示名或描述必须用本命令。
 > 已知后端限制：旧的非 open `dataset/detail?datasetId=<id>` 对某些域的 dataset 返回 `CZD-20009`（列表能查到、详情查不到），因此本命令改用按域过滤的 open dataset list 作为归属校验源。
+> 分页陷阱：datasets/list 默认每页 10 条。曾经只读第一页，导致域内第 11 张表起（第 2 页）的 dataset 更新时报 `dataset <id> not found in domain <domain-id>`——这不是后端异步索引问题，而是 CLI 未翻页。现要求翻页读全。
 
 #### Scenario: 经 dataset/list 读取后更新 displayName
 
@@ -53,10 +54,18 @@
 - **THEN** update 请求体中 `description` 为 `只改描述`
 - **且** 请求体不包含 `displayName`，由 open update 在服务端保留原显示名
 
+#### Scenario: 更新落在 dataset/list 第二页的 dataset
+
+- **WHEN** 某域有 13 张表（`dataset/list` 默认每页 10 条，共 2 页），目标 `datasetId` 在第 2 页
+- **AND** 用户执行 `cz-cli analytics-agent table update <id> --domain-id <domain-id> --name X`
+- **THEN** CLI MUST 翻页读取所有页
+- **且** 在合并集合中定位到该 dataset 并成功 `dataset/update`
+- **且** MUST NOT 因只读第一页而报 `dataset <id> not found in domain`
+
 #### Scenario: dataset 不在指定 domain 中时报错
 
 - **WHEN** 用户执行 `cz-cli analytics-agent table update 82 --domain-id 27 --name X`
-- **AND** domain 27 的 dataset 列表中没有 datasetId=82
+- **AND** domain 27 的 dataset 列表中（含所有分页）没有 datasetId=82
 - **THEN** CLI MUST 报错说明该 dataset 不在此 domain 中，且不调用 update
 
 #### Scenario: 缺少 --domain-id 时本地拒绝

--- a/openspec/specs/analytics-agent/spec.md
+++ b/openspec/specs/analytics-agent/spec.md
@@ -50,6 +50,22 @@
 - **THEN** CLI MUST NOT 因 `parent-id=0` 报 `USAGE_ERROR`
 - **且** 正常按根节点查询
 
+### Requirement: 分页 list 命令透出总量并提示截断
+
+当后端 list 响应携带分页信息（`total`/`pageNum`/`pageSize`/`pageCount`）时，`analytics-agent` 的分页类命令（metric list、answer-builder list、datasource list 等经 executeAnalyticsCommand 的命令）MUST 把这些字段透出到输出（`total`、`page_num`、`page_size`、`page_count`、`has_more`），不得只保留等于当前页条数的 `count`。当仍有后续页（`has_more` 为真）时，MUST 通过 `ai_message` 提示总量与翻页方式。目的：避免当前页条数恰好等于 page_size 时无法判断是否还有数据、导致漏读。
+
+#### Scenario: 结果被分页截断时透出总量并提示
+
+- **WHEN** 某域有 14 条 answer-builder，用户执行 `cz-cli analytics-agent answer-builder list --domain-id <id>`（默认 page_size 10）
+- **THEN** 输出 MUST 包含 `count=10`、`total=14`、`page_count=2`、`has_more=true`
+- **且** `ai_message` MUST 提示"Showing 10 of 14"及用 `--page-num`/`--page-size` 获取其余数据
+
+#### Scenario: 单页结果不设 has_more
+
+- **WHEN** 结果总量不超过一页
+- **THEN** 输出 `has_more` 为 `false`
+- **且** 不输出翻页提示 `ai_message`
+
 ### Requirement: 输出字段面向用户和 agent
 
 本需求 MUST 按以下场景执行。

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -192,6 +192,9 @@ const ANSWER_BUILDER_DSL_HELP = [
   "  (Pass the SQL via --sql instead of embedding it in --content to avoid quote escaping.)",
   "",
   "Rules:",
+  "  - Shell quoting: wrap --sql in single quotes so bash/zsh won't expand ${...} to empty",
+  "    (an expanded placeholder yields `SELECT ,` -> CZLH-42000 at ','); or escape as \\${name}",
+  "    inside double quotes. The ${...} must reach the CLI intact.",
   "  - Every ${name} in the SQL MUST have a matching chartParams entry, else CZLH-42000 syntax error.",
   "  - outputColumns[].metricName is REQUIRED and must be UNIQUE within the domain",
   "    (prefix generic names, e.g. 区域销售额 vs 行业销售额).",
@@ -2763,7 +2766,7 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
                 .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
                 .option("content", { type: "string", describe: "Analysis DSL JSON (chartParams/outputColumns/relatedTables/sql) — see the syntax reference below" })
-                .option("sql", { type: "string", describe: "SQL body, injected into content.sql — avoids escaping quotes inside --content JSON" })
+                .option("sql", { type: "string", describe: "SQL body, injected into content.sql. Single-quote it so the shell keeps ${...} placeholders intact (see notes below)" })
                 .example(
                   'cz-cli analytics-agent answer-builder create --domain-id 27 --datasource-id 8448 --analysis-name "各省份中标金额排名" --content \'{"...DSL..."}\'',
                   "Create a complex metric (answer builder). Run `answer-builder validate` first to check the --content DSL",
@@ -2773,8 +2776,8 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                   "Pass SQL via --sql so single quotes don't collide with the --content JSON",
                 )
                 .example(
-                  'cz-cli analytics-agent answer-builder create --domain-id 43 --datasource-id 8448 --analysis-name "各区域销售汇总" --content \'{"chartParams":[{"name":"dims","type":"dimension","allowMulti":true,"fromTableRefs":[{"tableName":"quick_start.ict_industry_demo.v_gpt_fact_sales","columns":["region"]}]}],"outputColumns":[{"name":"order_count","metricName":"区域订单数","type":"bigint","stdTypeName":"int"},{"name":"total_amount","metricName":"区域销售额","type":"decimal","stdTypeName":"double"}],"relatedTables":["quick_start.ict_industry_demo.v_gpt_fact_sales"]}\' --sql "SELECT ${dims}, COUNT(*) AS order_count, SUM(final_amount) AS total_amount FROM quick_start.ict_industry_demo.v_gpt_fact_sales GROUP BY ${dims}"',
-                  "Full example: dims placeholder + required unique metricName per output column",
+                  'cz-cli analytics-agent answer-builder create --domain-id 43 --datasource-id 8448 --analysis-name "各区域销售汇总" --content \'{"chartParams":[{"name":"dims","type":"dimension","allowMulti":true,"fromTableRefs":[{"tableName":"quick_start.ict_industry_demo.v_gpt_fact_sales","columns":["region"]}]}],"outputColumns":[{"name":"order_count","metricName":"区域订单数","type":"bigint","stdTypeName":"int"},{"name":"total_amount","metricName":"区域销售额","type":"decimal","stdTypeName":"double"}],"relatedTables":["quick_start.ict_industry_demo.v_gpt_fact_sales"]}\' --sql \'SELECT ${dims}, COUNT(*) AS order_count, SUM(final_amount) AS total_amount FROM quick_start.ict_industry_demo.v_gpt_fact_sales GROUP BY ${dims}\'',
+                  "Full example: single-quote --sql so ${dims} reaches the CLI; unique metricName per output column",
                 )
                 .epilogue(ANSWER_BUILDER_DSL_HELP),
             async (argv) => {
@@ -2801,7 +2804,8 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
                 .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
                 .option("content", { type: "string", describe: "Analysis DSL JSON (chartParams/outputColumns/relatedTables/sql)" })
-                .option("sql", { type: "string", describe: "SQL body, injected into content.sql — avoids escaping quotes inside --content JSON" }),
+                .option("sql", { type: "string", describe: "SQL body, injected into content.sql. Single-quote it so the shell keeps ${...} placeholders intact (see notes below)" })
+                .epilogue(ANSWER_BUILDER_DSL_HELP),
             async (argv) => {
               const format = typeof argv.format === "string" ? argv.format : "json"
               const content = resolveAnswerBuilderContent(argv as Record<string, unknown>, format)
@@ -2950,7 +2954,7 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
                 .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
                 .option("content", { type: "string", describe: "Analysis DSL JSON (chartParams/outputColumns/relatedTables/sql) — see the syntax reference below" })
-                .option("sql", { type: "string", describe: "SQL body, injected into content.sql — avoids escaping quotes inside --content JSON" })
+                .option("sql", { type: "string", describe: "SQL body, injected into content.sql. Single-quote it so the shell keeps ${...} placeholders intact (see notes below)" })
                 .epilogue(ANSWER_BUILDER_DSL_HELP),
             async (argv) => {
               const format = typeof argv.format === "string" ? argv.format : "json"

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -1101,6 +1101,31 @@ function unwrapResponse(payload: unknown): unknown {
   return data ?? payload
 }
 
+interface PageInfo {
+  total: number
+  page_num: number
+  page_size: number
+  page_count: number
+  has_more: boolean
+}
+
+// The backend list envelope carries total/pageNum/pageSize/pageCount alongside
+// `data`. unwrapResponse() keeps only `data`, so `count` (= data.length) reflects
+// the current page, not the total — hiding that more pages exist. Extract the
+// pagination fields so list commands can surface them and warn on truncation.
+function extractPageInfo(payload: unknown): PageInfo | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined
+  const p = payload as Record<string, unknown>
+  const total = numberValue(p.total)
+  const pageNum = numberValue(p.pageNum)
+  const pageSize = numberValue(p.pageSize)
+  const pageCount = numberValue(p.pageCount)
+  if (total === undefined || pageSize === undefined) return undefined
+  const num = pageNum ?? 1
+  const count = pageCount ?? (pageSize > 0 ? Math.ceil(total / pageSize) : 1)
+  return { total, page_num: num, page_size: pageSize, page_count: count, has_more: num < count }
+}
+
 /**
  * Analytics Agent backend always returns HTTP 200, using `success: false`
  * inside the envelope to signal business errors. Detect that here so callers
@@ -1355,7 +1380,17 @@ async function executeAnalyticsCommand(
     }
     logOperation(name, { ok: true, timeMs: Date.now() - t0 })
     const data = unwrapResponse(payload)
-    success(data, { format, timeMs: Date.now() - t0, aiMessage: buildAiMessage?.(data) })
+    const page = extractPageInfo(payload)
+    const customAi = buildAiMessage?.(data)
+    const pageAi = page?.has_more
+      ? `Showing ${Array.isArray(data) ? data.length : 0} of ${page.total} (page ${page.page_num}/${page.page_count}). Pass --page-num/--page-size to fetch the rest.`
+      : undefined
+    success(data, {
+      format,
+      timeMs: Date.now() - t0,
+      aiMessage: customAi ?? pageAi,
+      ...(page ? { extra: { total: page.total, page_num: page.page_num, page_size: page.page_size, page_count: page.page_count, has_more: page.has_more } } : {}),
+    })
   } catch (err) {
     logOperation(name, { ok: false, timeMs: Date.now() - t0 })
     if (isHandledCliError(err)) return

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -396,6 +396,36 @@ async function runTableSemanticsList(argv: Record<string, unknown>): Promise<voi
   }
 }
 
+// Read every dataset in a domain via `dataset/list`, paginating until exhausted.
+// The list defaults to pageSize 10, so a single-page read misses datasets past
+// the first page — the cause of spurious "not found in domain" on tables 11+.
+// Dedup by datasetId and cap page count so a backend that ignores pageNum can't
+// loop forever.
+async function fetchAllDatasetsInDomain(
+  argv: Record<string, unknown>,
+  domainId: number,
+  ctx: ResolvedContext,
+): Promise<Record<string, unknown>[]> {
+  const pageSize = 200
+  const maxPages = 1000
+  const all: Record<string, unknown>[] = []
+  const seen = new Set<string>()
+  for (let pageNum = 1; pageNum <= maxPages; pageNum++) {
+    const pageData = await requestAnalyticsData(argv, ROUTES.datasetList, { domainIds: [domainId], pageNum, pageSize }, {}, ctx)
+    const pageItems = Array.isArray(pageData) ? pageData as Record<string, unknown>[] : []
+    let added = 0
+    for (const item of pageItems) {
+      const key = String(item.datasetId)
+      if (seen.has(key)) continue
+      seen.add(key)
+      all.push(item)
+      added++
+    }
+    if (pageItems.length < pageSize || added === 0) break
+  }
+  return all
+}
+
 // Update a dataset's display name and/or description through the open dataset
 // API. The list step verifies the dataset belongs to the requested domain; the
 // open update endpoint supports partial updates, so only changed fields are sent.
@@ -416,8 +446,7 @@ async function runTableUpdate(argv: Record<string, unknown>): Promise<void> {
   }
   try {
     const ctx = await resolveAnalyticsContext(argv)
-    const listData = await requestAnalyticsData(argv, ROUTES.datasetList, { domainIds: [domainId] }, {}, ctx)
-    const items = Array.isArray(listData) ? listData as Record<string, unknown>[] : []
+    const items = await fetchAllDatasetsInDomain(argv, domainId, ctx)
     const current = items.find((d) => String(d.datasetId) === String(datasetId))
     if (!current) {
       error("ANALYTICS_AGENT_ERROR", `dataset ${datasetId} not found in domain ${domainId}`, { format })

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -168,6 +168,38 @@ function resolveAnswerBuilderContent(argv: Record<string, unknown>, format: stri
   return JSON.stringify(dsl)
 }
 
+// Syntax reference shown in the epilogue of answer-builder create/validate.
+// Derived from hands-on authoring: the DSL shape, the ${placeholder} rule, the
+// required+domain-unique metricName, and the window/CTE subquery-wrap trick.
+const ANSWER_BUILDER_DSL_HELP = [
+  "DSL (--content) structure:",
+  "  {",
+  '    "chartParams": [        // interactive inputs; reference in SQL as ${name}',
+  '      {"name":"dims","type":"dimension","allowMulti":true,   // -> GROUP BY ${dims}',
+  '       "fromTableRefs":[{"tableName":"cat.schema.table","columns":["region"]}]},',
+  '      {"name":"filters","type":"filter","allowMulti":true,   // -> WHERE ${filters}',
+  '       "fromTableRefs":[{"tableName":"cat.schema.table","columns":["channel"]}]}',
+  "    ],",
+  '    "outputColumns": [      // one per SELECT output column',
+  '      {"name":"total_amt",           // MUST match the SQL AS alias',
+  '       "metricName":"区域销售额",     // REQUIRED, and UNIQUE within the domain',
+  '       "type":"decimal","stdTypeName":"double",  // type required; stdTypeName optional',
+  '       "alias":["销售额"],            // optional display aliases',
+  '       "description":"..."}           // optional',
+  "    ],",
+  '    "relatedTables": ["cat.schema.table", ...]   // every table the SQL touches',
+  "  }",
+  "  (Pass the SQL via --sql instead of embedding it in --content to avoid quote escaping.)",
+  "",
+  "Rules:",
+  "  - Every ${name} in the SQL MUST have a matching chartParams entry, else CZLH-42000 syntax error.",
+  "  - outputColumns[].metricName is REQUIRED and must be UNIQUE within the domain",
+  "    (prefix generic names, e.g. 区域销售额 vs 行业销售额).",
+  "  - Window/ROLLUP whose PARTITION BY / ORDER BY references a ${dims} column: compute in an",
+  "    inner subquery with fixed column names, then `SELECT ${dims}, ...` in the outer query.",
+  "  - Always run `answer-builder validate` (dry-run) before create.",
+].join("\n")
+
 function stringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return value === undefined ? undefined : [String(value)]
   return value.map((item) => String(item))
@@ -2695,7 +2727,7 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("analysis-desc", { type: "string", describe: "Answer builder description" })
                 .option("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
                 .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
-                .option("content", { type: "string", describe: "Analysis DSL JSON (chartParams/outputColumns/relatedTables/sql)" })
+                .option("content", { type: "string", describe: "Analysis DSL JSON (chartParams/outputColumns/relatedTables/sql) — see the syntax reference below" })
                 .option("sql", { type: "string", describe: "SQL body, injected into content.sql — avoids escaping quotes inside --content JSON" })
                 .example(
                   'cz-cli analytics-agent answer-builder create --domain-id 27 --datasource-id 8448 --analysis-name "各省份中标金额排名" --content \'{"...DSL..."}\'',
@@ -2704,7 +2736,12 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .example(
                   'cz-cli analytics-agent answer-builder create --domain-id 27 --datasource-id 8448 --analysis-name "中标率" --content \'{"chartParams":[...],"outputColumns":[...]}\' --sql "SELECT ... WHERE bid_result=\'中标\'"',
                   "Pass SQL via --sql so single quotes don't collide with the --content JSON",
-                ),
+                )
+                .example(
+                  'cz-cli analytics-agent answer-builder create --domain-id 43 --datasource-id 8448 --analysis-name "各区域销售汇总" --content \'{"chartParams":[{"name":"dims","type":"dimension","allowMulti":true,"fromTableRefs":[{"tableName":"quick_start.ict_industry_demo.v_gpt_fact_sales","columns":["region"]}]}],"outputColumns":[{"name":"order_count","metricName":"区域订单数","type":"bigint","stdTypeName":"int"},{"name":"total_amount","metricName":"区域销售额","type":"decimal","stdTypeName":"double"}],"relatedTables":["quick_start.ict_industry_demo.v_gpt_fact_sales"]}\' --sql "SELECT ${dims}, COUNT(*) AS order_count, SUM(final_amount) AS total_amount FROM quick_start.ict_industry_demo.v_gpt_fact_sales GROUP BY ${dims}"',
+                  "Full example: dims placeholder + required unique metricName per output column",
+                )
+                .epilogue(ANSWER_BUILDER_DSL_HELP),
             async (argv) => {
               const format = typeof argv.format === "string" ? argv.format : "json"
               const content = resolveAnswerBuilderContent(argv as Record<string, unknown>, format)
@@ -2877,8 +2914,9 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("analysis-desc", { type: "string", describe: "Answer builder description" })
                 .option("datasource-id", { type: "number", demandOption: true, describe: "Datasource ID" })
                 .option("domain-id", { type: "number", demandOption: true, describe: "Domain ID" })
-                .option("content", { type: "string", describe: "Analysis DSL JSON (chartParams/outputColumns/relatedTables/sql)" })
-                .option("sql", { type: "string", describe: "SQL body, injected into content.sql — avoids escaping quotes inside --content JSON" }),
+                .option("content", { type: "string", describe: "Analysis DSL JSON (chartParams/outputColumns/relatedTables/sql) — see the syntax reference below" })
+                .option("sql", { type: "string", describe: "SQL body, injected into content.sql — avoids escaping quotes inside --content JSON" })
+                .epilogue(ANSWER_BUILDER_DSL_HELP),
             async (argv) => {
               const format = typeof argv.format === "string" ? argv.format : "json"
               const content = resolveAnswerBuilderContent(argv as Record<string, unknown>, format)

--- a/packages/cz-cli/test/analytics-agent-answer-builder.test.ts
+++ b/packages/cz-cli/test/analytics-agent-answer-builder.test.ts
@@ -212,6 +212,54 @@ describe("analytics-agent answer-builder", () => {
     })
   })
 
+  test("list surfaces backend pagination (total/page_count/has_more) and warns when truncated", async () => {
+    globalThis.fetch = mock(async () => {
+      // Backend envelope: 10 rows on page 1 of 2, total 14.
+      return jsonResponse({
+        success: true,
+        code: "200",
+        data: Array.from({ length: 10 }, (_, i) => ({ id: i + 1, analysisName: `ab${i + 1}` })),
+        total: "14",
+        pageNum: 1,
+        pageSize: 10,
+        pageCount: 2,
+      })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "answer-builder", "list", "--domain-id", "43",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const out = JSON.parse(result.output.trim()) as Record<string, any>
+    expect(out.count).toBe(10)
+    expect(out.total).toBe(14)
+    expect(out.page_count).toBe(2)
+    expect(out.has_more).toBe(true)
+    // ai_message must warn there are more pages
+    expect(out.ai_message).toContain("Showing 10 of 14")
+  })
+
+  test("list does not set has_more when all rows fit on one page", async () => {
+    globalThis.fetch = mock(async () => {
+      return jsonResponse({
+        success: true, code: "200",
+        data: Array.from({ length: 3 }, (_, i) => ({ id: i + 1 })),
+        total: "3", pageNum: 1, pageSize: 10, pageCount: 1,
+      })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "answer-builder", "list", "--domain-id", "43",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const out = JSON.parse(result.output.trim()) as Record<string, any>
+    expect(out.total).toBe(3)
+    expect(out.has_more).toBe(false)
+    expect(out.ai_message).toBeUndefined()
+  })
+
   test("validate maps flat fields into request body", async () => {
     let requestBody: unknown
 

--- a/packages/cz-cli/test/analytics-agent-answer-builder.test.ts
+++ b/packages/cz-cli/test/analytics-agent-answer-builder.test.ts
@@ -311,6 +311,28 @@ describe("analytics-agent answer-builder", () => {
     expect(result.stdout).not.toContain("--body")
   })
 
+  test("create help warns about the shell-quoting trap for --sql placeholders", async () => {
+    const result = spawnSync(process.execPath, [
+      "./src/main.ts", "analytics-agent", "answer-builder", "create", "--help",
+    ], { cwd: process.cwd(), encoding: "utf-8" })
+
+    expect(result.status).toBe(0)
+    // epilogue must mention the shell expansion trap and the single-quote / escape fix
+    expect(result.stdout).toMatch(/single quote|single-quote|'\.\.\.'/)
+    expect(result.stdout).toContain("\\${")
+  })
+
+  test("create help --sql examples do not demonstrate the unescaped double-quote trap", async () => {
+    const result = spawnSync(process.execPath, [
+      "./src/main.ts", "analytics-agent", "answer-builder", "create", "--help",
+    ], { cwd: process.cwd(), encoding: "utf-8" })
+
+    expect(result.status).toBe(0)
+    // No example may pass --sql "...${dims}..." with a bare, unescaped ${ inside double quotes.
+    const doubleQuotedSql = /--sql\s+"[^"]*\$\{/
+    expect(doubleQuotedSql.test(result.stdout)).toBe(false)
+  })
+
   test("disable falls back to detail plus update when direct status route says not found", async () => {
     const requestUrls: string[] = []
     const requestBodies: unknown[] = []

--- a/packages/cz-cli/test/analytics-agent-table-semantics.test.ts
+++ b/packages/cz-cli/test/analytics-agent-table-semantics.test.ts
@@ -433,6 +433,48 @@ describe("analytics-agent table semantics", () => {
     expect(body.completeSchema).toBeUndefined()
   })
 
+  test("update paginates dataset/list and finds a dataset on the second page", async () => {
+    const listPages: number[] = []
+    let updateBody: Record<string, unknown> | null = null
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      if (url.includes("/datasets/list")) {
+        const pageNum = Number((body as Record<string, unknown>).pageNum)
+        const pageSize = Number((body as Record<string, unknown>).pageSize)
+        listPages.push(pageNum)
+        // Page 1 returns a full page (== pageSize) so the loop must continue to page 2.
+        if (pageNum === 1) {
+          const rows = Array.from({ length: pageSize }, (_, i) => ({
+            id: String(1000 + i), datasetId: String(1000 + i), displayName: `t${i}`, tableName: `t${i}`,
+          }))
+          return jsonResponse({ success: true, data: rows, total: String(pageSize + 1), pageNum: 1, pageSize, pageCount: 2 })
+        }
+        // Page 2 holds the target dataset 1935.
+        return jsonResponse({
+          success: true,
+          data: [{ id: "1935", datasetId: "1935", displayName: "能耗事实表", tableName: "v_gpt_fact_energy" }],
+          total: String(pageSize + 1), pageNum: 2, pageSize, pageCount: 2,
+        })
+      }
+      updateBody = init?.body ? JSON.parse(String(init.body)) : null
+      return jsonResponse({ success: true, data: { datasetId: "1935" } })
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent", "table", "update", "1935", "--domain-id", "308", "--name", "能耗事实表(改)",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    // Must have requested at least two pages (dataset on page 2 was previously unreachable).
+    expect(listPages).toContain(1)
+    expect(listPages).toContain(2)
+    // Open update is partial: only datasetId + changed displayName are sent.
+    expect(updateBody).not.toBeNull()
+    expect((updateBody as Record<string, unknown>).datasetId).toBe(1935)
+    expect((updateBody as Record<string, unknown>).displayName).toBe("能耗事实表(改)")
+  })
+
   test("update can set displayName and description together", async () => {
     let updateBody: Record<string, unknown> | null = null
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/cz-cli/test/group-help-fallback.test.ts
+++ b/packages/cz-cli/test/group-help-fallback.test.ts
@@ -142,6 +142,25 @@ describe("bare command group renders help (exit 0), not USAGE_ERROR", () => {
     expect(r.stdout).toContain("Examples:")
     expect(r.stdout).toContain("validate")
   })
+
+  test("cz-cli analytics-agent answer-builder create --help documents the DSL syntax", () => {
+    const r = run(["analytics-agent", "answer-builder", "create", "--help"])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain("chartParams")
+    expect(r.stdout).toContain("outputColumns")
+    // metricName is required + domain-unique — the key learning
+    expect(r.stdout).toContain("metricName")
+    expect(r.stdout).toContain("UNIQUE within the domain")
+    // placeholder rule
+    expect(r.stdout).toContain("matching chartParams entry")
+  })
+
+  test("cz-cli analytics-agent answer-builder validate --help documents the DSL syntax", () => {
+    const r = run(["analytics-agent", "answer-builder", "validate", "--help"])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain("chartParams")
+    expect(r.stdout).toContain("metricName")
+  })
 })
 
 describe("nested bare group shows its OWN help, not the parent's", () => {


### PR DESCRIPTION
Four analytics-agent improvements, distilled from hands-on authoring in real domains. Rebased onto main after #64 (which reworked dataset routes to the open API and made table update a partial update); this branch keeps #64's approach and the `--display-name` fallback, and no longer contains any breaking change.

## 1. Answer-builder DSL syntax help (`docs`)

Adds a `--content` DSL syntax reference to the epilogue of `answer-builder create`, `update`, and `validate`:

- **DSL structure**: `chartParams` / `outputColumns` / `relatedTables` / `sql`
- **Placeholder rule**: every `${name}` in the SQL must have a matching `chartParams` entry — otherwise `CZLH-42000` syntax error
- **`metricName` is REQUIRED and domain-unique** (prefix generic names, e.g. 区域销售额 vs 行业销售额)
- **Window/ROLLUP + `${dims}` workaround**: compute in an inner subquery with fixed column names, then `SELECT ${dims}` in the outer query
- **Always `validate` (dry-run) before create**

## 2. List pagination surfacing (`fix`)

List responses carry `total/pageNum/pageSize/pageCount`, but `unwrapResponse` kept only `data`, so the emitted `count` equaled the current page length — silent under-reads when a page was exactly `page_size` (a 14-item domain looked like 10).

`executeAnalyticsCommand` now surfaces `total` / `page_num` / `page_size` / `page_count` / `has_more`, plus an `ai_message` (`Showing 10 of 14 ...`) when `has_more` is true.

## 3. `--sql` shell-quoting trap warning + fixed example (`docs`)

Bare `${dims}`/`${filters}` inside a double-quoted `--sql` get expanded to empty by bash/zsh before reaching the CLI, yielding `SELECT ,` and a confusing `CZLH-42000: Syntax error at or near ','`. The DSL epilogue now documents the trap (single-quote `--sql`, or escape `\$`), each `--sql` describe hints single-quoting, and the misleading full `create` example — which itself demonstrated the trap — was rewritten to single-quote `--sql`.

## 4. `table update` dataset/list pagination fix (`fix`)

`runTableUpdate` verified domain membership via a single `datasets/list` call with no page params. The backend defaults to `pageSize 10`, so in a domain with >10 tables every dataset on page 2+ was missing from the local lookup and `table update` failed with `dataset <id> not found in domain <id>`.

This was previously misattributed to a backend async-index timing window; it is purely a client-side missing-pagination bug. Verified live on domain 308 (13 tables): datasets 1930/1931/1935 on page 2 failed before, succeed after. Fix fetches all pages (`fetchAllDatasetsInDomain`: pageSize 200, dedup by datasetId, page cap) before locating the dataset. Adapted to #64's open API route and partial-update body.

## Testing

- Full analytics-agent suite passes (152 tests); `bun typecheck` clean.
- Help text verified via built binary (`create`/`update`/`validate --help` render the DSL reference incl. the shell-quoting rule).
- Pagination #2 verified live (`answer-builder list --domain-id 43`, 14 items).
- Pagination #4 verified live on domain 308: page-2 datasets 1930/1931/1935 now update successfully.
- Specs updated: `analytics-agent-answer-builder`, `analytics-agent`, `analytics-agent-table-semantics`.

Co-Authored-By: cz-cli <noreply@clickzetta.com>