### PR TITLE
feat(analytics-agent): support arbitrary modelSettings via --model-setting

### DIFF
--- a/docs/analytics-agent-commands.md
+++ b/docs/analytics-agent-commands.md
@@ -204,7 +204,7 @@ cz-cli analytics-agent knowledge file upload 1 ./manual.md --target-path /sales 
 | `analytics-agent service enabled` | 检查当前 tenant 是否启用 Analytics Agent | 无 |
 | `analytics-agent session list` | 列出 text2insight 会话 | `--domain-id`、`--source-type`、`--source-id` |
 | `analytics-agent session create` | 创建安全 text2insight 会话 | `--domain-id`、`--title`、`--source-type`、`--source-id` |
-| `analytics-agent session run` | 发起问题并等待结果 | `--domain-id`、`--session-id`、`--msg`、`--model-name`、`--interval-ms`、`--timeout-ms`、`--summary` |
+| `analytics-agent session run` | 发起问题并等待结果 | `--domain-id`、`--session-id`、`--msg`、`--model-name`、`--model-setting KEY=VALUE`（可重复）、`--interval-ms`、`--timeout-ms`、`--summary` |
 | `analytics-agent session result <question-id>` | 查询问题结果 | `--wait`、`--interval-ms`、`--timeout-ms` |
 | `analytics-agent session stop [session-id] [question-id]` | 停止运行中的问题 | `[session-id]`、`[question-id]` |
 
@@ -214,6 +214,7 @@ cz-cli analytics-agent knowledge file upload 1 ./manual.md --target-path /sales 
 cz-cli analytics-agent service enabled
 cz-cli analytics-agent session create --domain-id 195 --title "销售分析"
 cz-cli analytics-agent session run --domain-id 195 --msg "上周销售额是多少？" --summary
+cz-cli analytics-agent session run --domain-id 195 --msg "分析趋势" --model-setting thinkingLevel=off --model-setting language=zh-CN
 cz-cli analytics-agent session result 123 --wait --interval-ms 1000 --timeout-ms 60000
 ```
 

--- a/openspec/specs/analytics-agent-session/spec.md
+++ b/openspec/specs/analytics-agent-session/spec.md
@@ -51,6 +51,27 @@
 - **且** 请求体包含 `domainId`、`sessionId`、`msg`
 - **且** 请求体中的 `modelSettings.model_name` 为 `deepseek`
 
+`cz-cli analytics-agent session run` MUST 支持通过可重复的 `--model-setting KEY=VALUE` 传入 0 到多个任意 `modelSettings` 字段，不再固定暴露 `thinking-level` 这类单一开关。当前后端可用的键为 `language`（如 `zh-CN`）与 `thinkingLevel`（如 `off`）。每个条目按第一个 `=` 拆分：`=` 左侧为字段名（去除首尾空格），右侧为字段值；值 MUST 按宽松 JSON 规则解析（`true`/`false`/`null`、数字、`{...}`/`[...]`/带引号的字符串按 JSON 解析，其余保留为原始字符串）。`--model-name` 作为 `model_name` 的便捷写法保留；同名 `--model-setting` 条目 MUST 覆盖 `--model-name` 的值。
+
+#### Scenario: run 传入多个 --model-setting 时写入 modelSettings
+
+- **WHEN** 用户执行 `cz-cli analytics-agent session run --domain-id 195 --session-id 7 --msg "hello" --model-setting thinkingLevel=off --model-setting language=zh-CN`
+- **THEN** CLI 调用 query API
+- **且** 请求体中的 `modelSettings.thinkingLevel` 为字符串 `off`
+- **且** 请求体中的 `modelSettings.language` 为字符串 `zh-CN`
+
+#### Scenario: run 未传任何 model 相关参数时不携带 modelSettings
+
+- **WHEN** 用户执行 `cz-cli analytics-agent session run --domain-id 195 --session-id 7 --msg "hello"`
+- **THEN** CLI 调用 query API
+- **且** 请求体 MUST NOT 包含 `modelSettings` 字段
+
+#### Scenario: run 的 --model-setting 覆盖 --model-name
+
+- **WHEN** 用户执行 `cz-cli analytics-agent session run --domain-id 195 --session-id 7 --msg "hello" --model-name deepseek --model-setting model_name=qwen`
+- **THEN** CLI 调用 query API
+- **且** 请求体中的 `modelSettings.model_name` 为 `qwen`
+
 #### Scenario: run 只有 session-id 但缺少 domain-id
 
 - **WHEN** 用户执行 `cz-cli analytics-agent session run --session-id 7 --msg "hello"`

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -268,6 +268,16 @@ function parseLooseJsonValue(raw: string): unknown {
   return raw
 }
 
+function parseModelSettingValue(raw: string): unknown {
+  const value = raw.trim()
+  if (value === "") return raw
+  try {
+    return JSON.parse(value)
+  } catch {
+    return raw
+  }
+}
+
 function resolveTableSemanticsSetBody(argv: Record<string, unknown>): Record<string, unknown> {
   return mergeBody({}, {
     alias: stringArray(argv.alias),
@@ -2766,7 +2776,8 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
                 .option("session-id", { type: "number", describe: "Session ID (creates a new session if omitted)" })
                 .option("domain-id", { type: "number", describe: "Domain ID (required when --session-id is omitted)" })
                 .option("msg", { type: "string", describe: "Question text" })
-                .option("model-name", { type: "string", describe: "Model name" })
+                .option("model-name", { type: "string", describe: "Model name (shorthand for --model-setting model_name=<name>)" })
+                .option("model-setting", { type: "string", array: true, describe: "modelSettings entry KEY=VALUE (repeatable). Available keys: language, thinkingLevel. E.g. --model-setting thinkingLevel=off --model-setting language=zh-CN" })
                 .option("interval-ms", { type: "number", describe: "Polling interval in milliseconds" })
                 .option("timeout-ms", { type: "number", describe: "Polling timeout in milliseconds" })
                 .option("summary", { type: "boolean", default: false, describe: "Show the final answer instead of the full poll payload" }),
@@ -2776,9 +2787,17 @@ export function registerAnalyticsAgentCommand(cli: Argv<GlobalArgs>): void {
               if (!argv["domain-id"]) {
                 handledError("USAGE_ERROR", "--domain-id is required", { format, exitCode: 2 })
               }
-              const modelSettings = undefinedIfEmpty(mergeBody({}, {
-                model_name: argv["model-name"],
-              }))
+              const modelSettingEntries = (stringArray(argv["model-setting"]) ?? [])
+                .filter((entry) => entry.includes("="))
+                .map((entry) => {
+                  const eq = entry.indexOf("=")
+                  return [entry.slice(0, eq).trim(), parseModelSettingValue(entry.slice(eq + 1))] as const
+                })
+                .filter(([key]) => key.length > 0)
+              const modelSettings = undefinedIfEmpty(mergeBody(
+                mergeBody({}, { model_name: argv["model-name"] }),
+                Object.fromEntries(modelSettingEntries),
+              ))
               let sessionId: number | undefined = argv["session-id"]
               if (!sessionId) {
                 try {

--- a/packages/cz-cli/test/analytics-agent-session-run.test.ts
+++ b/packages/cz-cli/test/analytics-agent-session-run.test.ts
@@ -296,4 +296,141 @@ describe("analytics-agent session run", () => {
     expect(calls[1]?.url).toContain("/open/text2insight/query")
     expect(calls[1]?.body).toMatchObject({ domainId: 195, sessionId: 88, msg: "hello" })
   })
+
+  test("merges multiple --model-setting entries into modelSettings with loose typing", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = []
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const body = init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {}
+      calls.push({ url, body })
+      if (url.includes("/open/text2insight/query")) {
+        return jsonResponse({ data: { questionId: 123 } })
+      }
+      if (url.includes("/open/safe_question_poll")) {
+        return jsonResponse({
+          success: true,
+          data: {
+            questionId: 123,
+            responses: [
+              { resGroupId: 1, dataType: "finish", modelRes: { data: { message: "done" } } },
+            ],
+          },
+        })
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "session",
+      "run",
+      "--domain-id",
+      "195",
+      "--session-id",
+      "7",
+      "--msg",
+      "hello",
+      "--model-setting",
+      "thinkingLevel=off",
+      "--model-setting",
+      "language=zh-CN",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const queryCall = calls.find((call) => call.url.includes("/open/text2insight/query"))
+    expect(queryCall?.body).toMatchObject({
+      domainId: 195,
+      sessionId: 7,
+      msg: "hello",
+      modelSettings: { thinkingLevel: "off", language: "zh-CN" },
+    })
+  })
+
+  test("--model-setting overrides --model-name", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = []
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const body = init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {}
+      calls.push({ url, body })
+      if (url.includes("/open/text2insight/query")) {
+        return jsonResponse({ data: { questionId: 123 } })
+      }
+      if (url.includes("/open/safe_question_poll")) {
+        return jsonResponse({
+          success: true,
+          data: {
+            questionId: 123,
+            responses: [
+              { resGroupId: 1, dataType: "finish", modelRes: { data: { message: "done" } } },
+            ],
+          },
+        })
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "session",
+      "run",
+      "--domain-id",
+      "195",
+      "--session-id",
+      "7",
+      "--msg",
+      "hello",
+      "--model-name",
+      "deepseek",
+      "--model-setting",
+      "model_name=qwen",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const queryCall = calls.find((call) => call.url.includes("/open/text2insight/query"))
+    const modelSettings = (queryCall?.body as Record<string, unknown>)?.modelSettings as Record<string, unknown>
+    expect(modelSettings?.model_name).toBe("qwen")
+  })
+
+  test("omits modelSettings when no model params are set", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = []
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const body = init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {}
+      calls.push({ url, body })
+      if (url.includes("/open/text2insight/query")) {
+        return jsonResponse({ data: { questionId: 123 } })
+      }
+      if (url.includes("/open/safe_question_poll")) {
+        return jsonResponse({
+          success: true,
+          data: {
+            questionId: 123,
+            responses: [
+              { resGroupId: 1, dataType: "finish", modelRes: { data: { message: "done" } } },
+            ],
+          },
+        })
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }) as typeof fetch
+
+    const result = await runAnalyticsCli([
+      "analytics-agent",
+      "session",
+      "run",
+      "--domain-id",
+      "195",
+      "--session-id",
+      "7",
+      "--msg",
+      "hello",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const queryCall = calls.find((call) => call.url.includes("/open/text2insight/query"))
+    expect(queryCall?.body).not.toHaveProperty("modelSettings")
+  })
 })


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`analytics-agent session run` previously only let you set the model thinking
level through a single fixed `--thinking-level` flag. That does not scale as the
backend `modelSettings` object grows more fields.

This replaces `--thinking-level` with a repeatable `--model-setting KEY=VALUE`
flag that accepts 0..N arbitrary `modelSettings` entries, following the same
idiom already used by `--set` / `--variable` / `--header` elsewhere in the CLI.
Each entry is split on the first `=`; the key is trimmed and the value is parsed
with loose JSON typing (so booleans / numbers / null / JSON objects keep their
type, and bare words stay strings).

Currently the backend accepts these keys:

- `language` (e.g. `zh-CN`)
- `thinkingLevel` (e.g. `off`)

`--model-name` is kept as a shorthand for `model_name`, and a same-named
`--model-setting` overrides it. When no model params are given, `modelSettings`
is omitted from the request body entirely.

Example:

```
cz-cli analytics-agent session run --domain-id 195 --session-id 7 --msg "hi" \
  --model-setting thinkingLevel=off --model-setting language=zh-CN
```

Note: the branch name still says `thinking-level` for continuity; the feature
itself is now the general `--model-setting`.

### How did you verify your code works?

From `packages/cz-cli`:

- `bun run typecheck` — passes, no errors
- `bun test test/analytics-agent-*.test.ts` — 110 pass / 0 fail (10 files)
- Built a local binary and smoke-tested the flag:
  - `--thinking-level off` -> now rejected with `USAGE_ERROR: Unknown arguments`
  - `--model-setting thinkingLevel=off --model-setting language=zh-CN` -> parses and proceeds past arg-parsing to the endpoint/auth stage

Spec (`openspec/specs/analytics-agent-session/spec.md`) and docs
(`docs/analytics-agent-commands.md`) updated with the new scenarios.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR