### PR TITLE
fix(studio): pass workspace and projectId when rerunning task instance

### DIFF
--- a/packages/clickzetta-sdk/src/studio/runs.ts
+++ b/packages/clickzetta-sdk/src/studio/runs.ts
@@ -84,6 +84,8 @@ export function rerunInstance(config: StudioConfig, taskInstanceId: number) {
   return studioRequest(config, "/ide-admin/v1/taskInst/reRunTaskInstance", {
     taskInstanceId,
     nextType:0,
+    workspace: config.workspaceName,
+    projectId: config.projectId,
     updateBy: "cli-agent"
   })
 }


### PR DESCRIPTION
  - rerunInstance now sends workspace and projectId in the reRunTaskInstance request, matching the pattern already used by stopRun.                                                                                        
