### PR TITLE
feat(task): guide UI-only task types to their exact CLI config command

### DIFF
--- a/openspec/specs/task-management/spec.md
+++ b/openspec/specs/task-management/spec.md
@@ -259,3 +259,53 @@ CLI task 类型、状态、调度频率等 Studio 后端契约 MUST 通过集中
 - **WHEN** 执行未在 `--max-wait-seconds` 内完成
 - **THEN** CLI 返回 timeout 语义
 - **AND** `ai_message` SHOULD 提供后续查询 run/job 的命令
+
+### Requirement: create-setup 对 UI-only 同步任务给出精确的下一步命令引导
+
+本需求 MUST 按以下场景执行。
+
+`task create-setup` 对 `UI_ONLY_FILE_TYPES` 类型只创建任务空壳、不保存内容。此时返回的 `ai_message` MUST 根据具体任务类型给出**精确的下一步 CLI 命令**，而不是笼统地让用户「打开 Studio 配置」：
+
+- **离线数据集成同步**（MULTI_DI 多表、INTEGRATION/DI 单表）MUST 引导用户使用 `cz-cli task integration setup <task> --sync-type ...` 在 CLI 内配置源表/目标/映射。
+- **实时多表同步**（MULTI_REALTIME）MUST 引导用户使用 `cz-cli task create-realtime-sync` 或 `cz-cli task save-realtime-sync`。
+- **实时单表同步**（REALTIME，Kafka/AutoMQ → Lakehouse）MUST 引导用户使用 `cz-cli task create-stream-sync`。
+- **归并任务**（MERGE）MUST 引导用户使用 `cz-cli task save-merge`。
+- **组合流程任务**（FLOW）MUST 引导用户使用 `cz-cli task flow` 命令组。
+- 其余没有类型匹配的 CLI 配置命令的类型（如 STREAMING/FULL_INCREMENTAL/DYNAMIC_TABLE/SPARK/DATABRICKS 等）MUST 保留「打开 Studio 配置」的引导，并附 `studio_url`；MUST NOT 引导到不适用于该类型的命令。
+
+所有分支返回的成功载荷 MUST 继续包含 `task_id`、`studio_url`，且 `content_saved=false`、`cron_saved=false`。
+
+#### Scenario: 创建 MULTI_DI 任务引导到 integration setup
+
+- **WHEN** 用户执行 `cz-cli task create-setup NAME --type MULTI_DI --folder F`
+- **THEN** CLI 创建任务空壳并返回成功
+- **AND** `ai_message` MUST 包含 `task integration setup`
+- **AND** 载荷包含 `task_id` 与 `studio_url`
+
+#### Scenario: 创建 MULTI_REALTIME 任务引导到 realtime-sync 命令
+
+- **WHEN** 用户执行 `cz-cli task create-setup NAME --type MULTI_REALTIME --folder F`
+- **THEN** `ai_message` MUST 包含 `create-realtime-sync`
+
+#### Scenario: 创建 MERGE 任务引导到 save-merge
+
+- **WHEN** 用户执行 `cz-cli task create-setup NAME --type MERGE --folder F`
+- **THEN** `ai_message` MUST 包含 `save-merge`
+
+#### Scenario: 创建 FLOW 任务引导到 flow 命令组
+
+- **WHEN** 用户执行 `cz-cli task create-setup NAME --type FLOW --folder F`
+- **THEN** `ai_message` MUST 包含 `flow`
+
+#### Scenario: 纯 UI 类型保留 Studio 引导
+
+- **WHEN** 用户执行 `cz-cli task create-setup NAME --type SPARK --folder F`
+- **THEN** `ai_message` MUST 提示打开 Studio 配置
+- **AND** `ai_message` MUST NOT 包含 `task integration setup`
+
+#### Scenario: 无匹配命令的类型不得误导到不适用命令
+
+- **WHEN** 用户执行 `cz-cli task create-setup NAME --type STREAMING --folder F`
+- **THEN** `ai_message` MUST 提示打开 Studio 配置
+- **AND** `ai_message` MUST NOT 包含 `create-stream-sync`
+- **AND** `ai_message` MUST NOT 包含 `task integration setup`

--- a/packages/cz-cli/src/commands/task.ts
+++ b/packages/cz-cli/src/commands/task.ts
@@ -130,6 +130,34 @@ function parseTaskType(value: string): number {
   throw new Error(`Unsupported task type: ${value}. Use ${TASK_TYPE_OPTIONS.join("/")} or integer code.`)
 }
 
+// UI_ONLY tasks are created as shells; point the user at the exact CLI command
+// that configures each type, instead of a generic "open Studio". Only types with
+// a verified, type-matched CLI command get a precise hint; the rest fall back to
+// Studio (no CLI config command exists for them).
+const OFFLINE_SYNC_FILE_TYPES = new Set<number>([
+  StudioFileType.MultipleDISync,
+  StudioFileType.DataIntegration,
+])
+
+function uiOnlyNextStep(fileType: number, name: string, url: string): string {
+  if (OFFLINE_SYNC_FILE_TYPES.has(fileType)) {
+    return `Task '${name}' created (offline sync shell). Configure source/target/mapping in the CLI: cz-cli task integration setup ${name} --sync-type single|multi|whole_db --source-datasource ... --sink-datasource ... (run 'cz-cli task integration setup --help' for all options). Or open Studio: ${url}`
+  }
+  if (fileType === StudioFileType.MultipleRISync) {
+    return `Task '${name}' created (realtime multi-table sync shell). Configure it in one step with: cz-cli task create-realtime-sync, or configure this task with: cz-cli task save-realtime-sync ${name} --source ... --target ... Or open Studio: ${url}`
+  }
+  if (fileType === StudioFileType.RealTimeDI) {
+    return `Task '${name}' created (realtime sync shell). Configure a Kafka/AutoMQ → Lakehouse stream in the CLI: cz-cli task create-stream-sync. Or open Studio: ${url}`
+  }
+  if (fileType === StudioFileType.Merge) {
+    return `Task '${name}' created (merge shell). Configure merge rules and schedule in the CLI: cz-cli task save-merge ${name} (run 'cz-cli task save-merge --help' for options). Or open Studio: ${url}`
+  }
+  if (fileType === StudioFileType.Flow) {
+    return `Task '${name}' created (flow shell). Build the flow in the CLI: cz-cli task flow create-node ${name} ... then flow node-save / node-save-config / bind / submit (run 'cz-cli task flow --help'). Or open Studio: ${url}`
+  }
+  return `Task '${name}' created (UI-only type). Open Studio to configure this task: ${url}`
+}
+
 const LINEAGE_ROW_FORMATS = new Set(["table", "csv", "text", "jsonl"])
 
 const SYSTEM_PARAM_NAMES = new Set([
@@ -1978,7 +2006,7 @@ export function registerTaskCommand(cli: Argv<GlobalArgs>): void {
                 studio_url: studioUrl(sc, fileId),
               }, {
                 format,
-                aiMessage: `Task created (type=${argv.type} is UI-only). Open Studio to configure data source, field mapping, and sync rules: ${studioUrl(sc, fileId)}`,
+                aiMessage: uiOnlyNextStep(parsedFileType, argv.name as string, studioUrl(sc, fileId)),
               })
               return
             }

--- a/packages/cz-cli/test/task-create-setup-guidance.test.ts
+++ b/packages/cz-cli/test/task-create-setup-guidance.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const home = mkdtempSync(join(tmpdir(), "cz-cli-task-create-setup-"))
+const profileDir = join(home, ".clickzetta")
+const profileFile = join(profileDir, "profiles.toml")
+
+const actualSdk = await import("@clickzetta/sdk")
+const actualResolver = await import("../src/resolver.ts")
+
+mock.module("@clickzetta/sdk", () => ({
+  ...actualSdk,
+  listTasks: async () => ({ data: { list: [], total: 0, totalPages: 0 } }),
+  createTask: async () => ({ data: 12345 }),
+}))
+
+const actualStudioContext = await import("../src/commands/studio-context.ts")
+
+mock.module("../src/commands/studio-context.js", () => ({
+  ...actualStudioContext,
+  getStudioContext: async () => ({
+    projectId: 60001,
+    workspaceId: "workspace-1",
+    userId: 12365,
+    tenantId: 1223,
+    instanceId: 32,
+    instanceName: "inst",
+    workspaceName: "ws",
+    baseUrl: "https://dev-api.clickzetta.com",
+    token: "token",
+    env: "prod",
+  }),
+}))
+
+mock.module("../src/resolver.js", () => ({
+  ...actualResolver,
+  resolveFolderIdByName: async () => 389001,
+}))
+
+mock.module("../src/logger.js", () => ({ logOperation: () => {} }))
+
+const { execute } = await import("../src/execute.ts")
+
+function payload(output: string): Record<string, unknown> {
+  const start = output.indexOf("{")
+  const end = output.lastIndexOf("}")
+  return JSON.parse(output.slice(start, end + 1)) as Record<string, unknown>
+}
+
+beforeEach(() => {
+  mkdirSync(profileDir, { recursive: true })
+  writeFileSync(profileFile, "[profiles.test]\npat = 'pat'\nworkspace = 'ws'\ninstance = 'inst'\n")
+  process.env.CLICKZETTA_TEST_HOME = home
+})
+
+afterAll(() => {
+  delete process.env.CLICKZETTA_TEST_HOME
+  rmSync(home, { recursive: true, force: true })
+})
+
+describe("task create-setup UI-only next-step guidance", () => {
+  test("MULTI_DI guides to `task integration setup`", async () => {
+    const result = await execute("task create-setup di_job --type MULTI_DI --folder 389001")
+    expect(result.exitCode).toBe(0)
+    const envelope = payload(result.output)
+    const data = envelope.data as Record<string, unknown>
+    expect(String(envelope.ai_message)).toContain("task integration setup")
+    expect(data.task_id).toBe(12345)
+    expect(typeof data.studio_url).toBe("string")
+    expect(String(data.studio_url)).toContain("12345")
+    expect(data.content_saved).toBe(false)
+    expect(data.cron_saved).toBe(false)
+  })
+
+  test("single-table INTEGRATION guides to `task integration setup`", async () => {
+    const result = await execute("task create-setup di_single --type INTEGRATION --folder 389001")
+    expect(result.exitCode).toBe(0)
+    expect(String(payload(result.output).ai_message)).toContain("task integration setup")
+  })
+
+  test("MULTI_REALTIME guides to a realtime-sync command", async () => {
+    const result = await execute("task create-setup ri_job --type MULTI_REALTIME --folder 389001")
+    expect(result.exitCode).toBe(0)
+    const msg = String(payload(result.output).ai_message)
+    expect(msg).toContain("create-realtime-sync")
+    expect(msg).not.toContain("task integration setup")
+  })
+
+  test("REALTIME guides to `create-stream-sync`", async () => {
+    const result = await execute("task create-setup cdc_job --type REALTIME --folder 389001")
+    expect(result.exitCode).toBe(0)
+    const msg = String(payload(result.output).ai_message)
+    expect(msg).toContain("create-stream-sync")
+    expect(msg).not.toContain("task integration setup")
+  })
+
+  test("MERGE guides to `save-merge`", async () => {
+    const result = await execute("task create-setup merge_job --type MERGE --folder 389001")
+    expect(result.exitCode).toBe(0)
+    const msg = String(payload(result.output).ai_message)
+    expect(msg).toContain("save-merge")
+    expect(msg).not.toContain("task integration setup")
+  })
+
+  test("FLOW guides to the flow command group", async () => {
+    const result = await execute("task create-setup flow_job --type FLOW --folder 389001")
+    expect(result.exitCode).toBe(0)
+    const msg = String(payload(result.output).ai_message)
+    expect(msg).toContain("flow")
+    expect(msg).not.toContain("task integration setup")
+  })
+
+  test("pure-UI SPARK keeps the Studio guidance and no integration setup hint", async () => {
+    const result = await execute("task create-setup spark_job --type SPARK --folder 389001")
+    expect(result.exitCode).toBe(0)
+    const msg = String(payload(result.output).ai_message)
+    expect(msg).toContain("Studio")
+    expect(msg).not.toContain("task integration setup")
+  })
+
+  test("STREAMING has no matching command, must not mislead to stream-sync", async () => {
+    const result = await execute("task create-setup stream_job --type STREAMING --folder 389001")
+    expect(result.exitCode).toBe(0)
+    const msg = String(payload(result.output).ai_message)
+    expect(msg).toContain("Studio")
+    expect(msg).not.toContain("create-stream-sync")
+    expect(msg).not.toContain("task integration setup")
+  })
+})


### PR DESCRIPTION
## 背景

`task create-setup` 对 `UI_ONLY_FILE_TYPES` 类型只创建任务空壳、不保存内容。此前所有 UI-only 类型都返回同一句笼统的 "Open Studio to configure..."，即使其中若干类型其实有对应的 CLI 配置命令——用户被引导去 UI，而不是被告知下一条可用命令。

以 MULTI_DI（离线多表同步）为例：建壳后正确的下一步是 `cz-cli task integration setup`，但旧提示只说"去 Studio 配"，导致用户误以为 CLI 不支持。

## 改动

在 create-setup 的 UI-only 分支，按 fileType 给出**精确的下一步 CLI 命令**：

| 类型 | 引导 |
|---|---|
| MULTI_DI / INTEGRATION（离线同步） | `task integration setup` |
| MULTI_REALTIME | `create-realtime-sync` / `save-realtime-sync` |
| REALTIME（Kafka/AutoMQ→Lakehouse） | `create-stream-sync` |
| MERGE | `save-merge` |
| FLOW | `flow` 命令组 |
| STREAMING / FULL_INCREMENTAL / DYNAMIC_TABLE / SPARK / DATABRICKS | 保留 Studio 兜底 |

只对**已验证存在且类型匹配**的命令给精确引导；无匹配命令的类型诚实兜底到 Studio，且**不误导**到不适用的命令（如 STREAMING 不再被指向 create-stream-sync）。

## 测试

- 新增 `test/task-create-setup-guidance.test.ts`：8 个用例覆盖 MULTI_DI / INTEGRATION / MULTI_REALTIME / REALTIME / MERGE / FLOW / SPARK 兜底 / STREAMING 反向（不得误导）
- spec 新增需求 + 6 个场景（含"不得误导到不适用命令"的反向场景）
- `bun test test/task-create-setup-guidance.test.ts` 全过（8 pass）
- `bun run typecheck` 干净
- Live 验证（真实建壳→读 ai_message→删除）：MULTI_DI / MERGE / FLOW / STREAMING 四类引导文案均正确

## 说明

- 未新增任何后端调用，仅改动成功返回的 `ai_message` 文案。
- 唯一的既有失败 `task-params.test.ts`（Windows over-escaped JSON）在纯净 main 上即存在，与本 PR 无关。