### PR TITLE
feat(integration): bind sync VCluster when saving multi/whole_db offline tasks

### DIFF
--- a/packages/cz-cli/src/commands/integration.ts
+++ b/packages/cz-cli/src/commands/integration.ts
@@ -5,6 +5,8 @@ import {
   getTaskDetail,
   getTaskConfigDetail,
   saveTaskContent,
+  listVclusters,
+  resolveVclusterId,
   type StudioConfig,
 } from "@clickzetta/sdk"
 import type { GlobalArgs } from "../cli.js"
@@ -675,7 +677,7 @@ async function loadIntegrationContent(sc: StudioConfig, taskId: number): Promise
 // ---------------------------------------------------------------------------
 // Save helpers
 // ---------------------------------------------------------------------------
-async function saveContent(sc: StudioConfig, taskId: number, content: Json, paramValueList: unknown[] = []): Promise<void> {
+async function saveContent(sc: StudioConfig, taskId: number, content: Json, paramValueList: unknown[] = [], adhocConfigs?: string): Promise<void> {
   await saveTaskContent(sc, {
     dataFileId: taskId,
     dataFileContent: content,
@@ -684,6 +686,69 @@ async function saveContent(sc: StudioConfig, taskId: number, content: Json, para
     instanceName: sc.instanceName,
     replaceEscapedChars: false,
     paramValueList,
+    ...(adhocConfigs !== undefined && { adhocConfigs }),
+  })
+}
+
+function isIntegrationVc(v: { type?: string }): boolean {
+  return String(v.type ?? "").toUpperCase() === "INTEGRATION"
+}
+
+// Integration tasks execute on a sync-type (INTEGRATION) VCluster. A GENERAL/ANALYTICS
+// VC cannot run sync jobs, so binding one would only surface as a run-time failure later.
+// When vcName is given, validate its type; when omitted, auto-pick the workspace's sole
+// INTEGRATION VC (mirroring Studio, which binds an execution VC on save). Returns the
+// adhocConfigs JSON string to persist alongside the pipeline content.
+async function resolveSyncVcAdhocConfigs(
+  sc: StudioConfig,
+  vcName: string | undefined,
+  sinkSchema: string,
+  format: string | undefined,
+): Promise<string> {
+  const list = await listVclusters(sc).catch(() => [])
+  const integrationVcs = list.filter(isIntegrationVc)
+
+  let resolvedName = vcName
+  let adhocVcId: string | undefined
+
+  if (vcName) {
+    const match = list.find((v) => v.name === vcName || v.id === vcName)
+    if (match && !isIntegrationVc(match)) {
+      const hint = integrationVcs.length
+        ? `Available INTEGRATION VClusters: ${integrationVcs.map((v) => v.name).filter(Boolean).join(", ")}.`
+        : "No INTEGRATION VCluster found in this workspace — create one or check permissions."
+      handledError(
+        "INVALID_VCLUSTER",
+        `VCluster '${vcName}' is type ${match.type}, but offline sync tasks require an INTEGRATION (sync-type) VCluster. ${hint}`,
+        { format, exitCode: 2 },
+      )
+    }
+    adhocVcId = match?.id ?? (await resolveVclusterId(sc, vcName).catch(() => undefined))
+  } else {
+    // No VC given: auto-pick the workspace's INTEGRATION VC.
+    if (integrationVcs.length === 0) {
+      handledError(
+        "SYNC_VC_REQUIRED",
+        "Offline sync tasks require an INTEGRATION (sync-type) VCluster, but none was found in this workspace. Create one in Studio, or pass --vc <SYNC_VC>.",
+        { format, exitCode: 2 },
+      )
+    }
+    if (integrationVcs.length > 1) {
+      handledError(
+        "SYNC_VC_AMBIGUOUS",
+        `Multiple INTEGRATION VClusters found: ${integrationVcs.map((v) => v.name).filter(Boolean).join(", ")}. Pass --vc <SYNC_VC> to choose one.`,
+        { format, exitCode: 2 },
+      )
+    }
+    resolvedName = integrationVcs[0]!.name
+    adhocVcId = integrationVcs[0]!.id
+  }
+
+  return JSON.stringify({
+    multiDataSource: [],
+    schema: sinkSchema,
+    adhocVcCode: resolvedName,
+    ...(adhocVcId != null && { adhocVcId: String(adhocVcId) }),
   })
 }
 
@@ -706,6 +771,10 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               choices: ["single", "multi", "whole_db"],
               default: "single",
               describe: "single: one table (creates sink table + field mapping); multi: many tables; whole_db: whole database (no table creation)",
+            })
+            .option("vc", {
+              type: "string",
+              describe: "[multi/whole_db] Sync VCluster name (INTEGRATION type) to bind to the task. Falls back to the session --vcluster. Required for the task to run.",
             })
             .option("source-datasource", { type: "string", demandOption: true, describe: "Source datasource name or ID" })
             .option("source-schema", { type: "string", demandOption: true, describe: "Source schema/database" })
@@ -762,14 +831,20 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
                 jobsSpec,
                 dbNamespaces,
               })
-              await saveContent(sc, fileId, content)
+              // A literal "default"/"DEFAULT" vcluster is the connection default, not a
+              // real sync VC — treat it as "not provided" so the auto-pick kicks in.
+              const vcArg = (argv.vc as string | undefined) ?? conn.vcluster
+              const vcName = vcArg && vcArg.toLowerCase() !== "default" ? vcArg : undefined
+              const adhocConfigs = await resolveSyncVcAdhocConfigs(sc, vcName, sinkSchema, format)
+              const boundVc = (JSON.parse(adhocConfigs) as { adhocVcCode?: string }).adhocVcCode
+              await saveContent(sc, fileId, content, [], adhocConfigs)
               logOperation("integration setup", { ok: true })
               const kind = pipelineType === 1 ? "multi-table" : "whole-db"
               success(
-                { task_id: fileId, sync_type: syncType, tables, studio_url: studioUrl(sc, fileId) },
+                { task_id: fileId, sync_type: syncType, tables, ...(boundVc ? { vc: boundVc } : {}), studio_url: studioUrl(sc, fileId) },
                 {
                   format,
-                  aiMessage: `已创建${kind === "multi-table" ? "多表" : "整库"}同步任务（${jobsSpec.length} 张表）。集成任务执行需使用 INTEGRATION 类型的 vcluster。`,
+                  aiMessage: `已创建${kind === "multi-table" ? "多表" : "整库"}同步任务（${jobsSpec.length} 张表）。已绑定同步 VCluster：${boundVc}。`,
                 },
               )
               return

--- a/packages/cz-cli/test/integration-sync-vc.test.ts
+++ b/packages/cz-cli/test/integration-sync-vc.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const home = mkdtempSync(join(tmpdir(), "cz-cli-integration-vc-"))
+const profileDir = join(home, ".clickzetta")
+const profileFile = join(profileDir, "profiles.toml")
+
+const saveContentCalls: Array<Record<string, unknown>> = []
+let vclusters: Array<{ id: string; name: string; type: string }> = []
+
+const actualSdk = await import("@clickzetta/sdk")
+const actualResolver = await import("../src/resolver.ts")
+
+mock.module("@clickzetta/sdk", () => ({
+  ...actualSdk,
+  listVclusters: async () => vclusters,
+  resolveVclusterId: async (_c: unknown, name: string) =>
+    vclusters.find((v) => v.name === name || v.id === name)?.id,
+  saveTaskContent: async (_config: Record<string, unknown>, params: Record<string, unknown>) => {
+    saveContentCalls.push(params)
+    return { data: true }
+  },
+}))
+
+const actualStudioContext = await import("../src/commands/studio-context.ts")
+mock.module("../src/commands/studio-context.js", () => ({
+  ...actualStudioContext,
+  getStudioContext: async () => ({
+    projectId: 1417759,
+    workspaceId: 1,
+    userId: "studi_test_1",
+    instanceName: "tmwmzxzs",
+    workspaceName: "quick_start",
+    baseUrl: "https://api.example.com",
+  }),
+}))
+
+const actualDatasource = await import("../src/commands/datasource.ts")
+mock.module("../src/commands/datasource.js", () => ({
+  ...actualDatasource,
+  resolveDatasource: async (_c: unknown, nameOrId: string) =>
+    nameOrId === "mysql_src"
+      ? { id: 100, name: "mysql_src", dsType: 5 }
+      : { id: 200, name: "lakehouse_sink", dsType: 1 },
+}))
+
+mock.module("../src/resolver.js", () => ({
+  ...actualResolver,
+  resolveTaskId: async (_config: unknown, nameOrId: string) =>
+    nameOrId === "multi_task" ? 555001 : Number(nameOrId),
+}))
+
+mock.module("../src/logger.js", () => ({ logOperation: () => {} }))
+
+const actualStudioUrl = await import("../src/commands/studio-url.ts")
+mock.module("../src/commands/studio-url.js", () => ({
+  ...actualStudioUrl,
+  studioUrl: (_c: unknown, fileId: number) => `https://studio.example/task/${fileId}`,
+}))
+
+const { execute } = await import("../src/execute.ts")
+
+function firstJson(output: string) {
+  return JSON.parse(output.trim().split("\n")[0] ?? "{}") as Record<string, unknown>
+}
+
+beforeEach(() => {
+  saveContentCalls.length = 0
+  vclusters = [
+    { id: "vc-int-1", name: "SYNC_VC", type: "INTEGRATION" },
+    { id: "vc-gen-1", name: "GENERAL_VC", type: "GENERAL" },
+  ]
+  mkdirSync(profileDir, { recursive: true })
+  writeFileSync(profileFile, "[profiles.test]\npat = 'pat'\nworkspace = 'quick_start'\ninstance = 'tmwmzxzs'\n")
+  process.env.CLICKZETTA_TEST_HOME = home
+})
+
+afterAll(() => {
+  delete process.env.CLICKZETTA_TEST_HOME
+  rmSync(home, { recursive: true, force: true })
+})
+
+const BASE =
+  "task integration setup multi_task --sync-type multi " +
+  "--source-datasource mysql_src --source-schema db1 --source-tables t1,t2 " +
+  "--sink-datasource lakehouse_sink --sink-schema public --format json"
+
+describe("integration setup: sync VC persistence", () => {
+  test("persists adhocConfigs with adhocVcCode/adhocVcId for an INTEGRATION VC", async () => {
+    const result = await execute(`${BASE} --vc SYNC_VC`)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+
+    expect(saveContentCalls.length).toBe(1)
+    const saved = saveContentCalls[0]!
+    expect(saved.adhocConfigs).toBeDefined()
+    const adhoc = JSON.parse(String(saved.adhocConfigs)) as Record<string, unknown>
+    expect(adhoc).toMatchObject({
+      multiDataSource: [],
+      schema: "public",
+      adhocVcCode: "SYNC_VC",
+      adhocVcId: "vc-int-1",
+    })
+  })
+
+  test("rejects a non-INTEGRATION VC and lists available sync VCs", async () => {
+    const result = await execute(`${BASE} --vc GENERAL_VC`)
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toContain("INTEGRATION")
+    expect(result.output).toContain("SYNC_VC")
+    expect(saveContentCalls.length).toBe(0)
+  })
+
+  test("auto-picks the sole INTEGRATION VC when none is provided", async () => {
+    const result = await execute(BASE)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(saveContentCalls.length).toBe(1)
+    const adhoc = JSON.parse(String(saveContentCalls[0]!.adhocConfigs)) as Record<string, unknown>
+    expect(adhoc).toMatchObject({ adhocVcCode: "SYNC_VC", adhocVcId: "vc-int-1" })
+  })
+
+  test("errors when no INTEGRATION VC exists in the workspace", async () => {
+    vclusters = [{ id: "vc-gen-1", name: "GENERAL_VC", type: "GENERAL" }]
+    const result = await execute(BASE)
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toContain("INTEGRATION")
+    expect(saveContentCalls.length).toBe(0)
+  })
+
+  test("errors and lists options when multiple INTEGRATION VCs exist and none is chosen", async () => {
+    vclusters = [
+      { id: "vc-int-1", name: "SYNC_VC", type: "INTEGRATION" },
+      { id: "vc-int-2", name: "SYNC_VC_2", type: "INTEGRATION" },
+    ]
+    const result = await execute(BASE)
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toContain("SYNC_VC")
+    expect(result.output).toContain("SYNC_VC_2")
+    expect(saveContentCalls.length).toBe(0)
+  })
+
+  test("whole_db sync also persists the INTEGRATION sync VC", async () => {
+    const result = await execute(
+      "task integration setup multi_task --sync-type whole_db " +
+        "--source-datasource mysql_src --source-schema db1 --source-dbs db1,db2 " +
+        "--sink-datasource lakehouse_sink --sink-schema public --vc SYNC_VC --format json",
+    )
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    const adhoc = JSON.parse(String(saveContentCalls[0]!.adhocConfigs)) as Record<string, unknown>
+    expect(adhoc).toMatchObject({ adhocVcCode: "SYNC_VC", adhocVcId: "vc-int-1" })
+    const data = firstJson(result.output).data as Record<string, unknown>
+    expect(data.vc).toBe("SYNC_VC")
+  })
+})


### PR DESCRIPTION
## Summary
- 多表/整库离线同步任务保存时,之前不写 `adhocConfigs`,导致同步 VCluster 从未被持久化,ad-hoc 执行时找不到 VC。
- `integration setup` 现在会解析并持久化同步 VC:`--vc`(缺省回退到会话级 `--vcluster`)会被校验必须是 `INTEGRATION` 类型;不传时自动挑 workspace 里唯一的 INTEGRATION VC(零个 / 多个则报错)。
- 字面量 `default` 视为"未指定",触发自动挑;成功输出会回显绑定的 `vc`。

仅作用于 `--sync-type multi|whole_db`;单表(single)路径保持不变。

## Test plan
- [x] 新增 `packages/cz-cli/test/integration-sync-vc.test.ts`(6 用例):INTEGRATION VC 持久化 adhocConfigs、拒绝非 INTEGRATION VC 并列出可用 VC、无 VC 时自动挑唯一 INTEGRATION VC、零个报错、多个报歧义、whole_db 同样持久化。
- [x] `bun test ./test/integration-sync-vc.test.ts` 全绿(6/6)
- [x] `bun run typecheck` 通过
- [ ] 尚未在真实 Studio 后端端到端验证(测试中 SDK 为 mock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)