### PR TITLE
feat(integration): datasource type filter, source partitions, ES/Kafka sync

### DIFF
--- a/packages/cz-cli/src/commands/datasource.ts
+++ b/packages/cz-cli/src/commands/datasource.ts
@@ -2,7 +2,7 @@ import type { Argv } from "yargs"
 import { commandGroup } from "../command-group.js"
 import { studioRequest, listPgSlots, type StudioConfig } from "@clickzetta/sdk"
 import type { GlobalArgs } from "../cli.js"
-import { success, error, isHandledCliError } from "../output/index.js"
+import { success, error, handledError, isHandledCliError } from "../output/index.js"
 import { logOperation } from "../logger.js"
 import { getStudioContext } from "./studio-context.js"
 
@@ -19,7 +19,7 @@ const DS_TYPE_MAP: Record<string, number> = {
   aurora_mysql: 39, aurora_postgresql: 40, polardb_postgresql: 48,
 }
 
-const DS_TYPE_NAMES: Record<number, string> = {
+export const DS_TYPE_NAMES: Record<number, string> = {
   1: "LakeHouse", 2: "Kafka", 3: "Hive", 4: "ClickHouse", 5: "MySQL",
   7: "PostgreSQL", 8: "SqlServer", 9: "Oss", 10: "Hbase", 11: "Odps",
   12: "MongoDB", 13: "ElasticSearch7", 14: "Doris", 15: "StarRocks",
@@ -30,10 +30,15 @@ const DS_TYPE_NAMES: Record<number, string> = {
   51: "DynamoDB",
 }
 
-function parseDsType(value: string): number | undefined {
+export function parseDsType(value: string): number | undefined {
   const n = Number(value)
   if (Number.isFinite(n)) return n
   return DS_TYPE_MAP[value.toLowerCase()]
+}
+
+function dsTypeLabel(dsType: number | undefined): string {
+  if (dsType == null) return "unknown"
+  return DS_TYPE_NAMES[dsType] ?? String(dsType)
 }
 
 // ---------------------------------------------------------------------------
@@ -106,37 +111,99 @@ export interface ResolvedDatasource {
   connectionParams?: unknown
 }
 
-export async function resolveDatasource(sc: StudioConfig, nameOrId: string): Promise<ResolvedDatasource> {
-  const n = Number(nameOrId)
-  if (Number.isFinite(n) && n > 0) {
-    // Fetch detail by listing with no filter and finding by id
-    const resp = await apiList(sc, { pageSize: 100 })
+const DS_LIST_PAGE_SIZE = 100
+
+/** Page through the datasource list until fewer than a full page is returned. */
+async function listAllDatasources(
+  sc: StudioConfig,
+  opts: { dsName?: string; dsType?: number } = {},
+): Promise<Record<string, unknown>[]> {
+  const all: Record<string, unknown>[] = []
+  for (let page = 1; ; page++) {
+    const resp = await apiList(sc, { ...opts, page, pageSize: DS_LIST_PAGE_SIZE })
     const list = (resp.data as Record<string, unknown>)?.list as Record<string, unknown>[] | undefined
       ?? (Array.isArray(resp.data) ? resp.data as Record<string, unknown>[] : [])
+    all.push(...list)
+    if (list.length < DS_LIST_PAGE_SIZE) break
+  }
+  return all
+}
+
+function toResolved(ds: Record<string, unknown>, fallbackName: string): ResolvedDatasource {
+  return {
+    id: Number(ds.id ?? ds.dsId),
+    name: String(ds.dsName ?? ds.name ?? fallbackName),
+    dsType: ds.dsType as number | undefined,
+    connectionParams: ds.connectionParams,
+  }
+}
+
+/**
+ * Resolve a datasource by numeric id or name.
+ *
+ * When `expectedType` is given, only datasources of that dsType are considered — this
+ * disambiguates same/similar-named datasources across types (e.g. a Lakehouse and a
+ * MySQL both matching a fuzzy name). When resolving by name and no exact-name match
+ * exists among the candidates, we do NOT silently pick the first fuzzy hit: if more
+ * than one candidate remains, we throw an ambiguity error listing name/id/type so the
+ * caller can pick precisely (mirrors resolveTaskId's TASK_AMBIGUOUS behavior).
+ */
+export async function resolveDatasource(
+  sc: StudioConfig,
+  nameOrId: string,
+  expectedType?: number,
+): Promise<ResolvedDatasource> {
+  const typeMatches = (ds: Record<string, unknown>) =>
+    expectedType === undefined || Number(ds.dsType) === expectedType
+
+  const n = Number(nameOrId)
+  if (Number.isFinite(n) && n > 0) {
+    const list = await listAllDatasources(sc)
     const match = list.find((ds) => Number(ds.id ?? ds.dsId) === n)
     if (match) {
-      return {
-        id: n,
-        name: String(match.dsName ?? match.name ?? nameOrId),
-        dsType: match.dsType as number | undefined,
-        connectionParams: match.connectionParams,
+      if (!typeMatches(match)) {
+        handledError(
+          "DATASOURCE_TYPE_MISMATCH",
+          `Datasource id ${n} ('${match.dsName ?? match.name}') is type ${dsTypeLabel(match.dsType as number)}, but ${dsTypeLabel(expectedType)} was expected.`,
+        )
       }
+      return toResolved(match, nameOrId)
     }
+    // Id not found in listing (e.g. large/filtered account); trust the id as given.
     return { id: n, name: nameOrId }
   }
-  // Search by name
-  const resp = await apiList(sc, { dsName: nameOrId, pageSize: 50 })
-  const list = (resp.data as Record<string, unknown>)?.list as Record<string, unknown>[] | undefined
-    ?? (Array.isArray(resp.data) ? resp.data as Record<string, unknown>[] : [])
-  const exact = list.find((ds) => String(ds.dsName ?? ds.name ?? "") === nameOrId)
-  const match = exact ?? list[0]
-  if (!match) throw new Error(`Datasource '${nameOrId}' not found`)
-  return {
-    id: Number(match.id ?? match.dsId),
-    name: String(match.dsName ?? match.name ?? nameOrId),
-    dsType: match.dsType as number | undefined,
-    connectionParams: match.connectionParams,
+
+  // Search by name. Constrain to expectedType when provided.
+  const list = (await listAllDatasources(sc, { dsName: nameOrId, dsType: expectedType }))
+    .filter(typeMatches)
+
+  const exactMatches = list.filter((ds) => String(ds.dsName ?? ds.name ?? "") === nameOrId)
+  if (exactMatches.length === 1) return toResolved(exactMatches[0]!, nameOrId)
+  if (exactMatches.length > 1) {
+    handledError("DATASOURCE_AMBIGUOUS", ambiguityMessage(nameOrId, exactMatches, expectedType))
   }
+
+  // No exact name match.
+  if (list.length === 0) {
+    const typeNote = expectedType !== undefined ? ` of type ${dsTypeLabel(expectedType)}` : ""
+    handledError("DATASOURCE_NOT_FOUND", `Datasource '${nameOrId}'${typeNote} not found.`)
+  }
+  if (list.length === 1) return toResolved(list[0]!, nameOrId)
+  // Multiple fuzzy candidates, none exact — refuse to guess.
+  handledError("DATASOURCE_AMBIGUOUS", ambiguityMessage(nameOrId, list, expectedType))
+}
+
+function ambiguityMessage(
+  nameOrId: string,
+  candidates: Record<string, unknown>[],
+  expectedType?: number,
+): string {
+  const shown = candidates.slice(0, 10).map((ds) =>
+    `${ds.dsName ?? ds.name} (id=${ds.id ?? ds.dsId}, type=${dsTypeLabel(ds.dsType as number)})`,
+  ).join(", ")
+  const more = candidates.length > 10 ? ` (+${candidates.length - 10} more)` : ""
+  const typeNote = expectedType !== undefined ? ` of type ${dsTypeLabel(expectedType)}` : ""
+  return `Multiple datasources${typeNote} match '${nameOrId}': ${shown}${more}. Pass the exact numeric id, or narrow by --source-type/--sink-type.`
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cz-cli/src/commands/integration.ts
+++ b/packages/cz-cli/src/commands/integration.ts
@@ -300,6 +300,24 @@ function rewriteDdlTarget(ddl: string, sinkSchema: string, sinkTable: string): s
  *  Returns "exists" if the sink table was already present, "created" otherwise.
  *  When partitionColumn is given and the table is created, append PARTITIONED BY (col STRING). */
 const LAKEHOUSE_DS_TYPE = 1
+const ES_DS_TYPE = 13
+// Elasticsearch has no schema/database; Studio uses this placeholder in source namespace/params.
+const ES_NAMESPACE_PLACEHOLDER = "--"
+const ES_DEFAULT_BATCH_SIZE = 10
+// ES sink writes in bulk batches with a document-id rule instead of a SQL write mode.
+const ES_SINK_DEFAULT_BATCH_SIZE = 10000
+const ES_SINK_DEFAULT_ID_RULE = "NONE"
+// Kafka sink: messages are encoded with a codec; topic has no schema (uses "--" placeholder).
+const KAFKA_DS_TYPE = 2
+const KAFKA_SINK_DEFAULT_CODEC = "json"
+// Kafka source: consume by offset mode (with a groupId for group-offsets) and a codec.
+const KAFKA_SOURCE_DEFAULT_MODE = "group-offsets"
+const KAFKA_SOURCE_MODES = ["group-offsets", "earliest-offset", "latest-offset"] as const
+// Offline Kafka reads are bounded; endMode is the task-end strategy (e.g. "period").
+const KAFKA_SOURCE_DEFAULT_END_MODE = "period"
+// Sinks whose target (ES index / Kafka topic) is managed externally and cannot be
+// auto-created from here — setup only reads column metadata for these.
+const METADATA_ONLY_SINK_TYPES = new Set([ES_DS_TYPE, KAFKA_DS_TYPE])
 
 async function createSinkTableFromSource(
   sc: StudioConfig,
@@ -329,6 +347,27 @@ async function createSinkTableFromSource(
   // subset; the mirrored source PK conflicts with the appended partition column), then append.
   const finalDdl = partitionColumn ? appendPartitionedBy(stripPrimaryKey(rewritten), partitionColumn) : rewritten
   await executeDatasourceSql(sc, sink.id, finalDdl, execOptions)
+  return "created"
+}
+
+/** Create a Lakehouse sink table from typed column metadata (used when the source can't
+ *  produce a mirrorable DDL, e.g. Elasticsearch). No-op if the table already exists.
+ *  `columns` come from getColumnMapMeta's sinkMeta — each has a `name` and a Lakehouse `type`. */
+async function createLakehouseSinkFromColumns(
+  sc: StudioConfig,
+  sink: { id: number; dsType: number; schema: string; table: string },
+  columns: ColumnMeta[],
+  execOptions: Json,
+  partitionColumn?: string,
+): Promise<"exists" | "created" | "missing-columns"> {
+  if (await tableExists(sc, sink.id, sink.dsType, sink.schema, sink.table)) return "exists"
+  const defs = columns
+    .filter((c) => c && typeof c === "object" && colName(c) && !(c.partitionColumn === true))
+    .map((c) => `\`${colName(c)}\` ${c.type ?? "string"}`)
+  if (!defs.length) return "missing-columns"
+  let ddl = `CREATE TABLE IF NOT EXISTS \`${sink.schema}\`.\`${sink.table}\` (\n  ${defs.join(",\n  ")}\n)`
+  if (partitionColumn) ddl = appendPartitionedBy(ddl, partitionColumn)
+  await executeDatasourceSql(sc, sink.id, ddl, execOptions)
   return "created"
 }
 
@@ -550,8 +589,19 @@ export function generateSingleContent(opts: {
   partitions?: string[]
   sourcePartitions?: string[]
   dynamicPartition?: { column: string; sourceColumn: string }
+  esFilter?: string
+  esBatchSize?: number
+  esSinkBatchSize?: number
+  esSinkIdRule?: string
+  kafkaSourceMode?: string
+  kafkaSourceGroupId?: string
+  kafkaSourceEndMode?: string
 }): Json {
   const { source, sink } = opts
+  const isEsSource = source.dsType === ES_DS_TYPE
+  const isKafkaSource = source.dsType === KAFKA_DS_TYPE
+  const isEsSink = sink.dsType === ES_DS_TYPE
+  const isKafkaSink = sink.dsType === KAFKA_DS_TYPE
   const writeMode = opts.writeMode || "OVERWRITE"
   const outputMode = opts.outputMode || opts.writeMode || "OVERWRITE"
 
@@ -623,8 +673,83 @@ export function generateSingleContent(opts: {
       if (col && typeof col === "object" && partCols.has(colName(col) ?? "")) col.partitionColumn = true
     }
   }
-  const sourceParams: Json = { dsType: source.dsType, operatorType: "source", table: source.table, database: source.schema }
-  if (sourcePartitions.length) sourceParams.partitions = wrapPartitions(sourcePartitions)
+  // Elasticsearch and Kafka have no schema: namespace/database use the "--" placeholder.
+  const schemaless = isEsSource || isKafkaSource
+  const sourceNamespace = schemaless ? ES_NAMESPACE_PLACEHOLDER : source.schema
+  const sourceDatabase = schemaless ? ES_NAMESPACE_PLACEHOLDER : source.schema
+  let sourceParams: Json
+  if (isKafkaSource) {
+    // Kafka source consumes by offset mode; group-offsets also carries a consumer groupId.
+    const mode = opts.kafkaSourceMode ?? KAFKA_SOURCE_DEFAULT_MODE
+    // groupId is the Kafka consumer group; required for every offset mode.
+    sourceParams = {
+      dsType: source.dsType,
+      mode,
+      codec: KAFKA_SINK_DEFAULT_CODEC,
+      ...(opts.kafkaSourceGroupId ? { groupId: opts.kafkaSourceGroupId } : {}),
+      operatorType: "source",
+      table: source.table,
+      database: sourceDatabase,
+      endMode: opts.kafkaSourceEndMode ?? KAFKA_SOURCE_DEFAULT_END_MODE,
+    }
+  } else {
+    sourceParams = { dsType: source.dsType, operatorType: "source", table: source.table, database: sourceDatabase }
+    if (isEsSource) {
+      sourceParams.filter = opts.esFilter ?? ""
+      sourceParams.batchSize = opts.esBatchSize ?? ES_DEFAULT_BATCH_SIZE
+    }
+    if (sourcePartitions.length) sourceParams.partitions = wrapPartitions(sourcePartitions)
+  }
+
+  // Sink shape varies by target type:
+  //  - Elasticsearch: no namespace/database; bulk batchSize + idGenerateRule.
+  //  - Kafka: namespace/database "--" placeholder; message codec.
+  //  - relational/Lakehouse: schema-backed with writeMode/outputMode (+ optional partitions).
+  let sinkObj: Json
+  if (isEsSink) {
+    sinkObj = {
+      dataObject: sink.table,
+      params: {
+        dsType: sink.dsType,
+        batchSize: opts.esSinkBatchSize ?? ES_SINK_DEFAULT_BATCH_SIZE,
+        idGenerateRule: opts.esSinkIdRule ?? ES_SINK_DEFAULT_ID_RULE,
+        operatorType: "sink",
+        table: sink.table,
+        is_partition: false,
+      },
+      columns: finalSinkCols,
+    }
+  } else if (isKafkaSink) {
+    sinkObj = {
+      dataObject: sink.table,
+      namespace: ES_NAMESPACE_PLACEHOLDER,
+      params: {
+        dsType: sink.dsType,
+        codec: KAFKA_SINK_DEFAULT_CODEC,
+        operatorType: "sink",
+        table: sink.table,
+        database: ES_NAMESPACE_PLACEHOLDER,
+        is_partition: false,
+      },
+      columns: finalSinkCols,
+    }
+  } else {
+    sinkObj = {
+      dataObject: sink.table,
+      namespace: sink.schema,
+      params: {
+        dsType: sink.dsType,
+        operatorType: "sink",
+        table: sink.table,
+        database: sink.schema,
+        is_partition: false,
+        writeMode,
+        outputMode,
+        ...(opts.partitions && opts.partitions.length ? { partitions: wrapPartitions(opts.partitions) } : {}),
+      },
+      columns: finalSinkCols,
+    }
+  }
 
   return {
     templateKey: 1,
@@ -635,25 +760,11 @@ export function generateSingleContent(opts: {
       {
         source: {
           dataObject: source.table,
-          namespace: source.schema,
+          namespace: sourceNamespace,
           params: sourceParams,
           columns: finalSourceCols,
         },
-        sink: {
-          dataObject: sink.table,
-          namespace: sink.schema,
-          params: {
-            dsType: sink.dsType,
-            operatorType: "sink",
-            table: sink.table,
-            database: sink.schema,
-            is_partition: false,
-            writeMode,
-            outputMode,
-            ...(opts.partitions && opts.partitions.length ? { partitions: wrapPartitions(opts.partitions) } : {}),
-          },
-          columns: finalSinkCols,
-        },
+        sink: sinkObj,
         setting: { parallelism: 1, errorLimit: { maxCount: -1, collectDirtyData: true, record: -1 } },
         columnMapping,
       },
@@ -827,12 +938,14 @@ async function editAdhocConfigs(
 // Command registration
 // ---------------------------------------------------------------------------
 export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Argv<GlobalArgs> {
-  return taskYargs.command("integration", "Configure data integration (offline sync) task content", (yargs) => {
+  return taskYargs.command("integration", "Configure data integration (offline sync) task content across Lakehouse, relational (MySQL/PostgreSQL/…), Elasticsearch, and Kafka datasources", (yargs) => {
     yargs
       // ── setup ─────────────────────────────────────────────────────────
       .command(
         "setup <task>",
         "Configure an integration sync task's content (single-table / multi-table / whole-db). " +
+          "Single-table supports Lakehouse, relational (MySQL/PostgreSQL/…), Elasticsearch (--source-filter/--source-batch-size as source; --sink-batch-size/--sink-id-rule as sink), and Kafka (--source-mode/--source-group-id/--source-end-mode as source; codec-json as sink). " +
+          "Sink tables are auto-created only for Lakehouse targets (mirrored from the source, or built from column metadata for ES/Kafka sources); relational tables, ES indexes, and Kafka topics must be pre-created. " +
           "Create the task first with: cz-cli task create <name> --type INTEGRATION (single) or --type MULTI_DI (multi/whole_db).",
         (y) =>
           y
@@ -848,16 +961,23 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               describe: "[multi/whole_db] Sync VCluster name (INTEGRATION type) to bind to the task. Falls back to the session --vcluster. Required for the task to run.",
             })
             .option("source-datasource", { type: "string", demandOption: true, describe: "Source datasource name or ID" })
-            .option("source-type", { type: "string", describe: "Source datasource type (e.g. lakehouse, mysql, postgresql) to disambiguate same-named datasources" })
-            .option("source-schema", { type: "string", demandOption: true, describe: "Source schema/database" })
-            .option("source-table", { type: "string", describe: "[single] Source table name" })
+            .option("source-type", { type: "string", describe: "Source datasource type (e.g. lakehouse, mysql, postgresql, elasticsearch) to disambiguate same-named datasources" })
+            .option("source-schema", { type: "string", describe: "Source schema/database. Required for relational sources; ignored for Elasticsearch (no schema)." })
+            .option("source-table", { type: "string", describe: "[single] Source table name (Elasticsearch index name)" })
+            .option("source-filter", { type: "string", describe: "[single][Elasticsearch] Query filter applied when reading the ES index (default: none)" })
+            .option("source-batch-size", { type: "number", describe: "[single][Elasticsearch] Scroll batch size when reading the ES index (default: 10)" })
+            .option("source-mode", { type: "string", choices: ["group-offsets", "earliest-offset", "latest-offset"], describe: "[single][Kafka] Offset consume mode (default: group-offsets)" })
+            .option("source-group-id", { type: "string", describe: "[single][Kafka] Consumer group id (required for a Kafka source, all offset modes)" })
+            .option("source-end-mode", { type: "string", describe: "[single][Kafka] Task-end strategy for the bounded offline read (default: period)" })
             .option("source-tables", { type: "string", describe: "[multi] Comma-separated source table names within --source-schema" })
             .option("source-dbs", { type: "string", describe: "[whole_db] Comma-separated source schemas/databases to mirror" })
             .option("sink-datasource", { type: "string", demandOption: true, describe: "Sink datasource name or ID" })
-            .option("sink-type", { type: "string", describe: "Sink datasource type (e.g. lakehouse, mysql, postgresql) to disambiguate same-named datasources" })
-            .option("sink-schema", { type: "string", default: "public", describe: "Sink schema (default: public)" })
-            .option("sink-table", { type: "string", describe: "[single] Sink table name (default: source table name)" })
-            .option("write-mode", { type: "string", choices: ["OVERWRITE", "APPEND", "UPSERT"], default: "OVERWRITE", describe: "[single] Sink write mode (default: OVERWRITE)" })
+            .option("sink-type", { type: "string", describe: "Sink datasource type (e.g. lakehouse, mysql, postgresql, elasticsearch) to disambiguate same-named datasources" })
+            .option("sink-schema", { type: "string", default: "public", describe: "Sink schema (default: public). Ignored for Elasticsearch sinks." })
+            .option("sink-table", { type: "string", describe: "[single] Sink table name / Elasticsearch index name (default: source table name)" })
+            .option("write-mode", { type: "string", choices: ["OVERWRITE", "APPEND", "UPSERT"], default: "OVERWRITE", describe: "[single] Sink write mode (default: OVERWRITE). Ignored for Elasticsearch sinks." })
+            .option("sink-batch-size", { type: "number", describe: "[single][Elasticsearch sink] Bulk write batch size (default: 10000)" })
+            .option("sink-id-rule", { type: "string", describe: "[single][Elasticsearch sink] Document id generation rule (default: NONE)" })
             .option("partitions", { type: "string", describe: "[single] Comma-separated sink partition expressions, e.g. 'dt=${bizdate}'. When using scheduling date/time params, look up the correct Studio param syntax first (cz-cli ai-guide / docs)." })
             .option("source-partitions", { type: "string", describe: "[single] Read only these partitions from a partitioned SOURCE (e.g. Lakehouse). Comma-separated 'col=value', e.g. 'dt=${bizdate}' or 'dt=2026-08-04'. Values may use Studio scheduling params (declare them via --param-value-list). Look up the correct param syntax first (cz-cli ai-guide / docs) — do NOT invent formats." })
             .option("partitioned", { type: "boolean", describe: "[single] Declare the sink is a partition table. Required to auto-create a PARTITIONED BY sink table. Pair with --partitions (static) or --dynamic-partition." })
@@ -890,7 +1010,23 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               error("INVALID_DATASOURCE", "Could not resolve datasource type. Verify the datasource names/IDs.", { format })
               return
             }
-            const sourceSchema = String(argv["source-schema"])
+            const isEsSource = sourceDs.dsType === ES_DS_TYPE
+            const isKafkaSource = sourceDs.dsType === KAFKA_DS_TYPE
+            const schemalessSource = isEsSource || isKafkaSource
+            const isKafkaSink = sinkDs.dsType === KAFKA_DS_TYPE
+            const isMetadataOnlySink = sinkDs.dsType !== undefined && METADATA_ONLY_SINK_TYPES.has(sinkDs.dsType)
+            const sourceSchemaArg = argv["source-schema"] as string | undefined
+            if (!schemalessSource && !sourceSchemaArg) {
+              error("INVALID_ARGUMENTS", "--source-schema is required for this source type.", { format, exitCode: 2 }); return
+            }
+            // Elasticsearch/Kafka have no schema; force the "--" placeholder regardless of input.
+            const sourceSchema = schemalessSource ? ES_NAMESPACE_PLACEHOLDER : String(sourceSchemaArg)
+            // A Kafka source always needs a consumer group id, regardless of offset mode.
+            const kafkaSourceMode = (argv["source-mode"] as string | undefined) ?? (isKafkaSource ? KAFKA_SOURCE_DEFAULT_MODE : undefined)
+            const kafkaSourceGroupId = argv["source-group-id"] as string | undefined
+            if (isKafkaSource && !kafkaSourceGroupId) {
+              error("INVALID_ARGUMENTS", "--source-group-id is required for a Kafka source (the consumer group id). Pass --source-group-id <group>.", { format, exitCode: 2 }); return
+            }
             const sinkSchema = String(argv["sink-schema"])
 
             // ── multi-table / whole-db: build pipeline content, no table creation ──
@@ -958,23 +1094,64 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               ? (dynamicPartition?.column ?? staticPartitionColumn(partitionExprs) ?? DEFAULT_PARTITION_COLUMN)
               : undefined
 
-            // Ensure sink schema, then mirror the source table on the sink (PARTITIONED BY when declared).
             await ensureSchema(sc, sinkDs.id, sinkDs.dsType, sinkSchema, execOptions)
-            await createSinkTableFromSource(
-              sc,
-              { id: sourceDs.id, dsType: sourceDs.dsType, schema: sourceSchema, table: sourceTable },
-              { id: sinkDs.id, dsType: sinkDs.dsType, schema: sinkSchema, table: sinkTable },
-              execOptions,
-              partitionColumn,
-              format,
-            )
 
-            // Fetch column metadata and build a default position-based mapping.
-            const meta = await getColumnMapMeta(
-              sc,
-              { dsType: sourceDs.dsType, id: sourceDs.id, schema: sourceSchema, table: sourceTable },
-              { dsType: sinkDs.dsType, id: sinkDs.id, schema: sinkSchema, table: sinkTable },
-            )
+            let meta: { source: ColumnMeta[]; sink: ColumnMeta[] }
+            if (isMetadataOnlySink) {
+              // ES index / Kafka topic are managed externally and can't be created from here.
+              // Only fetch column metadata; do NOT attempt to build the target.
+              meta = await getColumnMapMeta(
+                sc,
+                { dsType: sourceDs.dsType, id: sourceDs.id, schema: sourceSchema, table: sourceTable },
+                { dsType: sinkDs.dsType, id: sinkDs.id, schema: sinkSchema, table: sinkTable },
+              )
+              if (!meta.sink.length) {
+                const { code, hint } = isKafkaSink
+                  ? { code: "SINK_TOPIC_REQUIRED", hint: `Kafka topic '${sinkTable}' was not found (no column metadata). Create the topic first, then re-run setup.` }
+                  : { code: "SINK_INDEX_REQUIRED", hint: `Elasticsearch index '${sinkTable}' was not found (no column metadata). Create the ES index with its mapping first, then re-run setup.` }
+                error(code, hint, { format, exitCode: 2 })
+                return
+              }
+            } else if (schemalessSource) {
+              // Elasticsearch/Kafka sources can't produce a mirrorable DDL. Fetch column
+              // metadata first (it returns the typed Lakehouse sink columns), then build the
+              // Lakehouse sink table from those columns.
+              meta = await getColumnMapMeta(
+                sc,
+                { dsType: sourceDs.dsType, id: sourceDs.id, schema: sourceSchema, table: sourceTable },
+                { dsType: sinkDs.dsType, id: sinkDs.id, schema: sinkSchema, table: sinkTable },
+              )
+              const result = await createLakehouseSinkFromColumns(
+                sc,
+                { id: sinkDs.id, dsType: sinkDs.dsType, schema: sinkSchema, table: sinkTable },
+                meta.sink,
+                execOptions,
+                partitionColumn,
+              )
+              if (result === "missing-columns") {
+                error(
+                  "SINK_TABLE_REQUIRED",
+                  `Sink table ${sinkSchema}.${sinkTable} does not exist and no column metadata was returned for the ${isKafkaSource ? "Kafka" : "Elasticsearch"} source, so it cannot be auto-created. Create the Lakehouse table first, then re-run setup.`,
+                  { format, exitCode: 2 },
+                )
+                return
+              }
+            } else {
+              // Relational/Lakehouse source: mirror the source table's DDL onto the sink.
+              await createSinkTableFromSource(
+                sc,
+                { id: sourceDs.id, dsType: sourceDs.dsType, schema: sourceSchema, table: sourceTable },
+                { id: sinkDs.id, dsType: sinkDs.dsType, schema: sinkSchema, table: sinkTable },
+                execOptions,
+                partitionColumn,
+                format,
+              )
+              meta = await getColumnMapMeta(
+                sc,
+                { dsType: sourceDs.dsType, id: sourceDs.id, schema: sourceSchema, table: sourceTable },
+                { dsType: sinkDs.dsType, id: sinkDs.id, schema: sinkSchema, table: sinkTable },
+              )
+            }
             // Dynamic partition: the routing source column must exist; otherwise ask the user to confirm it.
             if (dynamicPartition && !meta.source.some((c) => colName(c) === dynamicPartition.sourceColumn)) {
               error(
@@ -993,6 +1170,13 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               partitions: partitionExprs,
               sourcePartitions: sourcePartitionExprs,
               dynamicPartition,
+              esFilter: argv["source-filter"] as string | undefined,
+              esBatchSize: argv["source-batch-size"] as number | undefined,
+              esSinkBatchSize: argv["sink-batch-size"] as number | undefined,
+              esSinkIdRule: argv["sink-id-rule"] as string | undefined,
+              kafkaSourceMode,
+              kafkaSourceGroupId,
+              kafkaSourceEndMode: argv["source-end-mode"] as string | undefined,
             })
             const paramValueList = parseJsonArg<unknown[]>(argv["param-value-list"] as string | undefined, "param-value-list", format) ?? []
             const singleVcName = effectiveVcName(argv as Record<string, unknown>, conn)

--- a/packages/cz-cli/src/commands/integration.ts
+++ b/packages/cz-cli/src/commands/integration.ts
@@ -15,7 +15,7 @@ import { logOperation } from "../logger.js"
 import { getStudioContext } from "./studio-context.js"
 import { resolveTaskId } from "../resolver.js"
 import { studioUrl } from "./studio-url.js"
-import { resolveDatasource } from "./datasource.js"
+import { resolveDatasource, parseDsType } from "./datasource.js"
 import { resolveConnectionConfig } from "../connection/config.js"
 
 // ---------------------------------------------------------------------------
@@ -299,14 +299,29 @@ function rewriteDdlTarget(ddl: string, sinkSchema: string, sinkTable: string): s
 /** Create the sink table by mirroring the source table's DDL. No-op if it already exists.
  *  Returns "exists" if the sink table was already present, "created" otherwise.
  *  When partitionColumn is given and the table is created, append PARTITIONED BY (col STRING). */
+const LAKEHOUSE_DS_TYPE = 1
+
 async function createSinkTableFromSource(
   sc: StudioConfig,
   source: { id: number; dsType: number; schema: string; table: string },
   sink: { id: number; dsType: number; schema: string; table: string },
   execOptions: Json,
   partitionColumn?: string,
+  format?: string,
 ): Promise<"exists" | "created"> {
   if (await tableExists(sc, sink.id, sink.dsType, sink.schema, sink.table)) return "exists"
+  // Only Lakehouse sinks can be auto-created by mirroring the source DDL. Other targets
+  // (MySQL, PostgreSQL, …) don't support server-side DDL generation, so instead of hitting
+  // an opaque backend error ("... doesn't support generate ddl"), tell the user to create
+  // the target table first.
+  if (sink.dsType !== LAKEHOUSE_DS_TYPE) {
+    handledError(
+      "SINK_TABLE_REQUIRED",
+      `Sink table ${sink.schema}.${sink.table} does not exist, and non-Lakehouse targets (dsType=${sink.dsType}) cannot be auto-created. ` +
+        `Create it in the target datasource first (matching the source columns), then re-run setup.`,
+      { format, exitCode: 2 },
+    )
+  }
   const ddl = await getDatasourceDdl(sc, source, sink)
   if (!ddl) throw new Error(`Could not fetch DDL for source table ${source.schema}.${source.table}`)
   const rewritten = rewriteDdlTarget(ddl, sink.schema, sink.table)
@@ -533,6 +548,7 @@ export function generateSingleContent(opts: {
   writeMode?: string
   outputMode?: string
   partitions?: string[]
+  sourcePartitions?: string[]
   dynamicPartition?: { column: string; sourceColumn: string }
 }): Json {
   const { source, sink } = opts
@@ -596,6 +612,20 @@ export function generateSingleContent(opts: {
       columnMapping[dp.column] = dp.sourceColumn
     }
   }
+  // Source-side partitions: read only the given partition(s) from a partitioned source
+  // (e.g. Lakehouse). Written to source.params.partitions as [["col=value", ...]]. The
+  // partition columns are also flagged partitionColumn=true (the source metadata usually
+  // already marks them; this is a fallback so the flag is present when it isn't).
+  const sourcePartitions = opts.sourcePartitions ?? []
+  if (sourcePartitions.length) {
+    const partCols = new Set(sourcePartitions.map((e) => staticPartitionColumn([e])).filter(Boolean) as string[])
+    for (const col of finalSourceCols) {
+      if (col && typeof col === "object" && partCols.has(colName(col) ?? "")) col.partitionColumn = true
+    }
+  }
+  const sourceParams: Json = { dsType: source.dsType, operatorType: "source", table: source.table, database: source.schema }
+  if (sourcePartitions.length) sourceParams.partitions = wrapPartitions(sourcePartitions)
+
   return {
     templateKey: 1,
     userParams: {},
@@ -606,7 +636,7 @@ export function generateSingleContent(opts: {
         source: {
           dataObject: source.table,
           namespace: source.schema,
-          params: { dsType: source.dsType, operatorType: "source", table: source.table, database: source.schema },
+          params: sourceParams,
           columns: finalSourceCols,
         },
         sink: {
@@ -752,6 +782,47 @@ async function resolveSyncVcAdhocConfigs(
   })
 }
 
+// Resolve the effective sync-VC name from --vc, falling back to the session
+// --vcluster. A literal "default"/"DEFAULT" is the connection default, not a real
+// sync VC, so it is treated as "not provided" (lets the INTEGRATION auto-pick run).
+function effectiveVcName(argv: Record<string, unknown>, conn: { vcluster?: string }): string | undefined {
+  const vcArg = (argv.vc as string | undefined) ?? conn.vcluster
+  return vcArg && vcArg.toLowerCase() !== "default" ? vcArg : undefined
+}
+
+// Read the adhocConfigs JSON string already persisted on a task, if any, so an edit
+// that doesn't touch the VC preserves it instead of letting the backend clear it.
+async function existingAdhocConfigs(sc: StudioConfig, taskId: number): Promise<string | undefined> {
+  try {
+    const detail = await getTaskDetail(sc, taskId)
+    const data = (detail.data && typeof detail.data === "object" ? detail.data : {}) as Json
+    const raw = data.adhocConfigs
+    return typeof raw === "string" && raw.trim() ? raw : undefined
+  } catch {
+    return undefined
+  }
+}
+
+// Compute the adhocConfigs to persist on an edit save. When --vc is passed, resolve and
+// validate it as an INTEGRATION VC; otherwise preserve whatever the task already has so
+// the sync VC isn't dropped by a save that only touched mappings/params.
+async function editAdhocConfigs(
+  sc: StudioConfig,
+  argv: Record<string, unknown>,
+  conn: { vcluster?: string },
+  taskId: number,
+  content: Json,
+  format: string | undefined,
+): Promise<string | undefined> {
+  const vcName = argv.vc !== undefined ? effectiveVcName(argv, conn) : undefined
+  if (vcName) {
+    const sinkSchema =
+      (((content.jobs as Json[] | undefined)?.[0]?.sink as Json | undefined)?.namespace as string | undefined) ?? "public"
+    return resolveSyncVcAdhocConfigs(sc, vcName, sinkSchema, format)
+  }
+  return existingAdhocConfigs(sc, taskId)
+}
+
 // ---------------------------------------------------------------------------
 // Command registration
 // ---------------------------------------------------------------------------
@@ -777,15 +848,18 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               describe: "[multi/whole_db] Sync VCluster name (INTEGRATION type) to bind to the task. Falls back to the session --vcluster. Required for the task to run.",
             })
             .option("source-datasource", { type: "string", demandOption: true, describe: "Source datasource name or ID" })
+            .option("source-type", { type: "string", describe: "Source datasource type (e.g. lakehouse, mysql, postgresql) to disambiguate same-named datasources" })
             .option("source-schema", { type: "string", demandOption: true, describe: "Source schema/database" })
             .option("source-table", { type: "string", describe: "[single] Source table name" })
             .option("source-tables", { type: "string", describe: "[multi] Comma-separated source table names within --source-schema" })
             .option("source-dbs", { type: "string", describe: "[whole_db] Comma-separated source schemas/databases to mirror" })
             .option("sink-datasource", { type: "string", demandOption: true, describe: "Sink datasource name or ID" })
+            .option("sink-type", { type: "string", describe: "Sink datasource type (e.g. lakehouse, mysql, postgresql) to disambiguate same-named datasources" })
             .option("sink-schema", { type: "string", default: "public", describe: "Sink schema (default: public)" })
             .option("sink-table", { type: "string", describe: "[single] Sink table name (default: source table name)" })
             .option("write-mode", { type: "string", choices: ["OVERWRITE", "APPEND", "UPSERT"], default: "OVERWRITE", describe: "[single] Sink write mode (default: OVERWRITE)" })
             .option("partitions", { type: "string", describe: "[single] Comma-separated sink partition expressions, e.g. 'dt=${bizdate}'. When using scheduling date/time params, look up the correct Studio param syntax first (cz-cli ai-guide / docs)." })
+            .option("source-partitions", { type: "string", describe: "[single] Read only these partitions from a partitioned SOURCE (e.g. Lakehouse). Comma-separated 'col=value', e.g. 'dt=${bizdate}' or 'dt=2026-08-04'. Values may use Studio scheduling params (declare them via --param-value-list). Look up the correct param syntax first (cz-cli ai-guide / docs) — do NOT invent formats." })
             .option("partitioned", { type: "boolean", describe: "[single] Declare the sink is a partition table. Required to auto-create a PARTITIONED BY sink table. Pair with --partitions (static) or --dynamic-partition." })
             .option("dynamic-partition", { type: "string", describe: "[single] Dynamic partition routing: 'col:source_col' (col defaults to dt). Each row is routed to a partition by the source column's value. Mutually exclusive with --partitions." })
             .option("param-value-list", { type: "string", describe: "Scheduling parameter declarations as JSON, e.g. '[{\"paramKey\":\"bizdate\",\"paramValue\":\"$[yyyyMMdd-1]\"}]' (needed by partition/where expressions). Look up the correct Studio scheduling-param syntax first (cz-cli ai-guide / docs) — do NOT invent formats." }),
@@ -800,8 +874,18 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
             const fileId = await resolveTaskId(sc, argv.task as string, format)
             const syncType = String(argv["sync-type"])
 
-            const sourceDs = await resolveDatasource(sc, String(argv["source-datasource"]))
-            const sinkDs = await resolveDatasource(sc, String(argv["sink-datasource"]))
+            const sourceTypeArg = argv["source-type"] as string | undefined
+            const sinkTypeArg = argv["sink-type"] as string | undefined
+            const sourceType = sourceTypeArg ? parseDsType(sourceTypeArg) : undefined
+            const sinkType = sinkTypeArg ? parseDsType(sinkTypeArg) : undefined
+            if (sourceTypeArg && sourceType === undefined) {
+              error("INVALID_ARGUMENTS", `Unknown --source-type '${sourceTypeArg}'.`, { format, exitCode: 2 }); return
+            }
+            if (sinkTypeArg && sinkType === undefined) {
+              error("INVALID_ARGUMENTS", `Unknown --sink-type '${sinkTypeArg}'.`, { format, exitCode: 2 }); return
+            }
+            const sourceDs = await resolveDatasource(sc, String(argv["source-datasource"]), sourceType)
+            const sinkDs = await resolveDatasource(sc, String(argv["sink-datasource"]), sinkType)
             if (sourceDs.dsType === undefined || sinkDs.dsType === undefined) {
               error("INVALID_DATASOURCE", "Could not resolve datasource type. Verify the datasource names/IDs.", { format })
               return
@@ -831,10 +915,7 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
                 jobsSpec,
                 dbNamespaces,
               })
-              // A literal "default"/"DEFAULT" vcluster is the connection default, not a
-              // real sync VC — treat it as "not provided" so the auto-pick kicks in.
-              const vcArg = (argv.vc as string | undefined) ?? conn.vcluster
-              const vcName = vcArg && vcArg.toLowerCase() !== "default" ? vcArg : undefined
+              const vcName = effectiveVcName(argv as Record<string, unknown>, conn)
               const adhocConfigs = await resolveSyncVcAdhocConfigs(sc, vcName, sinkSchema, format)
               const boundVc = (JSON.parse(adhocConfigs) as { adhocVcCode?: string }).adhocVcCode
               await saveContent(sc, fileId, content, [], adhocConfigs)
@@ -862,6 +943,7 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
             // a plain mirror table is created and --partitions only fills sink.params.partitions.
             const dynamicPartitionArg = argv["dynamic-partition"] as string | undefined
             const partitionExprs = splitCsv(argv["partitions"] as string | undefined)
+            const sourcePartitionExprs = splitCsv(argv["source-partitions"] as string | undefined)
             const partitioned = Boolean(argv.partitioned) || dynamicPartitionArg !== undefined
             if (dynamicPartitionArg !== undefined && partitionExprs.length) {
               error("INVALID_ARGUMENTS", "--partitions and --dynamic-partition are mutually exclusive. Use --partitions for a fixed partition value, --dynamic-partition for per-row routing.", { format, exitCode: 2 })
@@ -884,6 +966,7 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               { id: sinkDs.id, dsType: sinkDs.dsType, schema: sinkSchema, table: sinkTable },
               execOptions,
               partitionColumn,
+              format,
             )
 
             // Fetch column metadata and build a default position-based mapping.
@@ -908,10 +991,14 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               sinkColumns: meta.sink,
               writeMode: argv["write-mode"] as string | undefined,
               partitions: partitionExprs,
+              sourcePartitions: sourcePartitionExprs,
               dynamicPartition,
             })
             const paramValueList = parseJsonArg<unknown[]>(argv["param-value-list"] as string | undefined, "param-value-list", format) ?? []
-            await saveContent(sc, fileId, content, paramValueList)
+            const singleVcName = effectiveVcName(argv as Record<string, unknown>, conn)
+            const singleAdhocConfigs = await resolveSyncVcAdhocConfigs(sc, singleVcName, sinkSchema, format)
+            const singleBoundVc = (JSON.parse(singleAdhocConfigs) as { adhocVcCode?: string }).adhocVcCode
+            await saveContent(sc, fileId, content, paramValueList, singleAdhocConfigs)
             const rows = mappingToRows((content.jobs as Json[])[0].columnMapping as Record<string, string>)
             logOperation("integration setup", { ok: true })
             success(
@@ -920,6 +1007,7 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
                 sync_type: "single",
                 source: `${sourceSchema}.${sourceTable}`,
                 sink: `${sinkSchema}.${sinkTable}`,
+                ...(singleBoundVc ? { vc: singleBoundVc } : {}),
                 column_mapping: rows,
                 ...(partitioned
                   ? {
@@ -933,7 +1021,7 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               {
                 format,
                 aiMessage:
-                  "已创建单表同步任务并生成默认字段映射。如需调整映射或同步参数，使用: cz-cli task integration edit <task>。集成任务执行需使用 INTEGRATION 类型的 vcluster。",
+                  `已创建单表同步任务并生成默认字段映射。已绑定同步 VCluster：${singleBoundVc}。如需调整映射或同步参数，使用: cz-cli task integration edit <task>。`,
               },
             )
           } catch (err) {
@@ -1020,6 +1108,10 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
         (y) =>
           y
             .positional("task", { type: "string", demandOption: true, describe: "Task name or ID" })
+            .option("vc", {
+              type: "string",
+              describe: "Sync VCluster name (INTEGRATION type) to (re)bind. When omitted, the task's existing bound VC is preserved.",
+            })
             // single-table
             .option("column-mapping", {
               type: "string",
@@ -1038,6 +1130,7 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
             .option("advanced-params", { type: "string", describe: "[single] Advanced params as JSON rows [{\"key\":\"k\",\"value\":\"v\"}] (replaces existing)" })
             .option("write-mode", { type: "string", choices: ["OVERWRITE", "APPEND", "UPSERT"], describe: "[single] Sink write mode: OVERWRITE | APPEND | UPSERT" })
             .option("partitions", { type: "string", describe: "[single] Comma-separated sink partition expressions (empty string clears), e.g. 'dt=${bizdate}'" })
+            .option("source-partitions", { type: "string", describe: "[single] Read only these partitions from a partitioned SOURCE (empty string clears). Comma-separated 'col=value', e.g. 'dt=${bizdate}'. Values may use Studio scheduling params (declare via --param-value-list). Look up the correct param syntax first (cz-cli ai-guide / docs)." })
             .option("dynamic-partition", { type: "string", describe: "[single] Dynamic partition routing: 'col:source_col' (col defaults to dt). Routes each row to a partition by the source column's value. Empty string clears it. Mutually exclusive with --partitions." })
             .option("param-value-list", { type: "string", describe: "Scheduling parameter declarations as JSON [{\"paramKey\":\"bizdate\",\"paramValue\":\"$[yyyyMMdd-1]\"}] (passed to save; needed by partition/where params). Look up the correct Studio scheduling-param syntax first (cz-cli ai-guide / docs) — do NOT invent formats." })
             // multi-table / whole-db
@@ -1056,6 +1149,7 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
           const format = argv.format
           try {
             const sc = await ctx(argv)
+            const conn = resolveConnectionConfig(argv as Record<string, unknown>)
             const fileId = await resolveTaskId(sc, argv.task as string, format)
             const content = (await loadIntegrationContent(sc, fileId)) ?? { jobs: [{ columnMapping: {} }] }
 
@@ -1081,6 +1175,7 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
 
               const hasChange =
                 tableMapping !== undefined ||
+                argv.vc !== undefined ||
                 [pkWriteMode, nonPkWriteMode, schemaRule, tableRule, parallelism, batchSize, connections].some(
                   (v) => v !== undefined,
                 )
@@ -1126,13 +1221,16 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
                 .map((j) => ({ schema: (j.source as Json).namespace as string, table: (j.source as Json).dataObject as string }))
               const warning = await pipelineCheckTables(sc, fileId, tableInfo, pipelineType)
 
-              await saveContent(sc, fileId, content)
+              const multiAdhocConfigs = await editAdhocConfigs(sc, argv as Record<string, unknown>, conn, fileId, content, format)
+              const multiBoundVc = multiAdhocConfigs ? (JSON.parse(multiAdhocConfigs) as { adhocVcCode?: string }).adhocVcCode : undefined
+              await saveContent(sc, fileId, content, [], multiAdhocConfigs)
               logOperation("integration edit", { ok: true })
               success(
                 {
                   task_id: fileId,
                   sync_type: pipelineType === 1 ? "multi" : "whole_db",
                   table_mapping: jobsToTableRows(content),
+                  ...(multiBoundVc ? { vc: multiBoundVc } : {}),
                   studio_url: studioUrl(sc, fileId),
                   ...(warning ? { validation_warning: warning } : {}),
                 },
@@ -1151,6 +1249,7 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
             const where = argv.where as string | undefined
             const writeMode = argv["write-mode"] as string | undefined
             const partitionsArg = argv["partitions"] as string | undefined
+            const sourcePartitionsArg = argv["source-partitions"] as string | undefined
             const dynamicPartitionArg = argv["dynamic-partition"] as string | undefined
             const paramValueList = parseJsonArg<unknown[]>(argv["param-value-list"] as string | undefined, "param-value-list", format)
 
@@ -1163,8 +1262,10 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               columnMapping !== undefined ||
               advancedParams !== undefined ||
               partitionsArg !== undefined ||
+              sourcePartitionsArg !== undefined ||
               dynamicPartitionArg !== undefined ||
               paramValueList !== undefined ||
+              argv.vc !== undefined ||
               [parallelism, errorLimit, mBytes, splitPk, where, writeMode].some((v) => v !== undefined)
             if (!hasChange) {
               error("INVALID_ARGUMENTS", "Provide at least one field to change. See 'cz-cli task integration edit --help'.", { format, exitCode: 2 })
@@ -1280,6 +1381,23 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
               if (where) sp.where = where
               else delete sp.where
             }
+            // source.params: read-partition selection (empty string clears it).
+            if (sourcePartitionsArg !== undefined) {
+              const exprs = splitCsv(sourcePartitionsArg)
+              const cols = (source.columns as ColumnMeta[] | undefined) ?? []
+              if (exprs.length) {
+                sp.partitions = wrapPartitions(exprs)
+                const partCols = new Set(exprs.map((e) => staticPartitionColumn([e])).filter(Boolean) as string[])
+                for (const c of cols) {
+                  if (c && typeof c === "object" && partCols.has(colName(c) ?? "")) c.partitionColumn = true
+                }
+              } else {
+                delete sp.partitions
+                for (const c of cols) {
+                  if (c && typeof c === "object" && c.partitionColumn === true) c.partitionColumn = false
+                }
+              }
+            }
 
             // sink.params: write mode + partitions
             const sinkParams = (sink.params && typeof sink.params === "object" ? sink.params : {}) as Json
@@ -1313,7 +1431,9 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
                 .map((r) => ({ key: r.key, value: r.value }))
             }
 
-            await saveContent(sc, fileId, content, paramValueList ?? [])
+            const singleEditAdhoc = await editAdhocConfigs(sc, argv as Record<string, unknown>, conn, fileId, content, format)
+            const singleEditVc = singleEditAdhoc ? (JSON.parse(singleEditAdhoc) as { adhocVcCode?: string }).adhocVcCode : undefined
+            await saveContent(sc, fileId, content, paramValueList ?? [], singleEditAdhoc)
             logOperation("integration edit", { ok: true })
             const finalPartCol = (sink.columns as ColumnMeta[]).find((c) => c.partitionColumn === true)
             const finalStatic = (sinkParams.partitions as unknown[] | undefined) ?? []
@@ -1322,6 +1442,7 @@ export function registerTaskIntegrationCommands(taskYargs: Argv<GlobalArgs>): Ar
                 task_id: fileId,
                 sync_type: "single",
                 column_mapping: mappingToRows(mapping),
+                ...(singleEditVc ? { vc: singleEditVc } : {}),
                 ...(finalPartCol
                   ? { partition_mode: "dynamic", partition_column: colName(finalPartCol), partition_source_column: mapping[colName(finalPartCol) ?? ""] }
                   : finalStatic.length

--- a/packages/cz-cli/test/datasource-resolve.test.ts
+++ b/packages/cz-cli/test/datasource-resolve.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+
+const actualSdk = await import("@clickzetta/sdk")
+
+// In-memory datasource catalog the mocked list endpoint serves.
+type DsRow = { id: number; dsName: string; dsType: number }
+let catalog: DsRow[] = []
+const listBodies: Array<Record<string, unknown>> = []
+
+// bun's mock.module is process-global and last-write-wins; re-installing in beforeEach
+// keeps this file's SDK mock authoritative even when another test file also mocks the SDK.
+function installSdkMock() {
+  mock.module("@clickzetta/sdk", () => ({
+    ...actualSdk,
+    studioRequest: async (_sc: unknown, path: string, body?: Record<string, unknown>) => {
+      if (path === "/ide-authority/v1/projectDataSources/list") {
+        listBodies.push(body ?? {})
+        const dsName = body?.dsName as string | undefined
+        const dsType = body?.dsType as number | undefined
+        const pageSize = Number(body?.pageSize ?? 100)
+        const pageIndex = Number(body?.pageIndex ?? body?.current ?? 1)
+        // Backend semantics: dsName is a fuzzy (substring) filter; dsType is exact.
+        let rows = catalog
+        if (dsName) rows = rows.filter((r) => r.dsName.includes(dsName))
+        if (dsType !== undefined) rows = rows.filter((r) => r.dsType === dsType)
+        const start = (pageIndex - 1) * pageSize
+        return { code: 200, data: { list: rows.slice(start, start + pageSize), total: rows.length } }
+      }
+      throw new Error(`unexpected path: ${path}`)
+    },
+  }))
+}
+installSdkMock()
+
+// We test the REAL resolveDatasource. Another test file globally mocks
+// "../src/commands/datasource.js" (bun mock.module is process-wide), which would clobber
+// the plain import. The "?real" query fetches an unmocked copy of the module; it still
+// imports the (mocked) SDK, so our list-endpoint mock above governs its behavior.
+const { resolveDatasource } = await import("../src/commands/datasource.ts?real")
+
+const sc = { projectId: 1, workspaceName: "ws" } as unknown as Parameters<typeof resolveDatasource>[0]
+
+beforeEach(() => {
+  installSdkMock()
+  catalog = []
+  listBodies.length = 0
+})
+
+describe("resolveDatasource", () => {
+  test("type filter picks the intended datasource among same-named different types", async () => {
+    // A Lakehouse and a MySQL share the exact name; without a type filter this is ambiguous.
+    catalog = [
+      { id: 1, dsName: "svw_data", dsType: 1 },  // lakehouse
+      { id: 2, dsName: "svw_data", dsType: 5 },  // mysql
+    ]
+    const lake = await resolveDatasource(sc, "svw_data", 1)
+    expect(lake).toMatchObject({ id: 1, dsType: 1 })
+    const mysql = await resolveDatasource(sc, "svw_data", 5)
+    expect(mysql).toMatchObject({ id: 2, dsType: 5 })
+  })
+
+  test("no exact name + multiple fuzzy candidates → ambiguity error, never silent list[0]", async () => {
+    catalog = [
+      { id: 10, dsName: "svw_vw_trip_report", dsType: 5 },
+      { id: 11, dsName: "svw_vw_energy", dsType: 1 },
+      { id: 12, dsName: "svw_vw_charging", dsType: 1 },
+    ]
+    // "svw_vw" matches all three, none is an exact name.
+    let err: unknown
+    try { await resolveDatasource(sc, "svw_vw") } catch (e) { err = e }
+    expect(String((err as { code?: string })?.code ?? err)).toContain("DATASOURCE_AMBIGUOUS")
+  })
+
+  test("exact name match wins even when fuzzy siblings exist", async () => {
+    catalog = [
+      { id: 20, dsName: "svw_vw", dsType: 1 },
+      { id: 21, dsName: "svw_vw_extra", dsType: 5 },
+    ]
+    const ds = await resolveDatasource(sc, "svw_vw")
+    expect(ds).toMatchObject({ id: 20, dsType: 1 })
+  })
+
+  test("type filter + fuzzy name narrows to a single candidate", async () => {
+    catalog = [
+      { id: 30, dsName: "svw_vw_charging", dsType: 5 },  // mysql
+      { id: 31, dsName: "svw_vw_charging_lake", dsType: 1 },  // lakehouse
+    ]
+    // Fuzzy "svw_vw_charging" matches both, but only one is lakehouse.
+    const ds = await resolveDatasource(sc, "svw_vw_charging", 1)
+    expect(ds).toMatchObject({ id: 31, dsType: 1 })
+    // The list request carried the dsType filter.
+    expect(listBodies.some((b) => b.dsType === 1)).toBe(true)
+  })
+
+  test("numeric id with mismatched expected type errors", async () => {
+    catalog = [{ id: 40, dsName: "the_mysql", dsType: 5 }]
+    let err: unknown
+    try { await resolveDatasource(sc, "40", 1) } catch (e) { err = e }
+    expect(String((err as { code?: string })?.code ?? err)).toContain("DATASOURCE_TYPE_MISMATCH")
+  })
+
+  test("pages through >100 results so an exact match on page 2 is still found", async () => {
+    catalog = Array.from({ length: 150 }, (_, i) => ({ id: 1000 + i, dsName: `svw_${i}`, dsType: 1 }))
+    // svw_149 is on the second page (fuzzy "svw_" returns all 150).
+    const ds = await resolveDatasource(sc, "svw_149")
+    expect(ds).toMatchObject({ id: 1149 })
+  })
+})

--- a/packages/cz-cli/test/integration-partition.test.ts
+++ b/packages/cz-cli/test/integration-partition.test.ts
@@ -149,3 +149,147 @@ describe("source-side partitions (lakehouse → mysql)", () => {
     expect(sourceParams.partitions).toBeUndefined()
   })
 })
+
+describe("elasticsearch source (es → lakehouse)", () => {
+  const ES_SRC = { id: 34444, name: "auto_elasticSearch", dsType: 13, schema: "ignored", table: "demo_es_source" }
+  const LAKE_SINK = { id: 26593, name: "LAKEHOUSE_smoke", dsType: 1, schema: "automated_test", table: "demo_es_sink" }
+  const esSrcCols = [{ name: "keyword", type: "text" }, { name: "long", type: "long" }]
+  const lakeSinkCols = [{ name: "keyword", type: "string" }, { name: "long", type: "bigint" }]
+
+  test("ES source sets namespace/database to '--' and writes filter + batchSize", () => {
+    const content = generateSingleContent({
+      source: ES_SRC, sink: LAKE_SINK, sourceColumns: esSrcCols, sinkColumns: lakeSinkCols,
+      writeMode: "OVERWRITE",
+    })
+    const j = job(content)
+    const src = j.source as Record<string, unknown>
+    expect(src.namespace).toBe("--")
+    const params = src.params as Record<string, unknown>
+    expect(params.database).toBe("--")
+    expect(params.filter).toBe("")
+    expect(params.batchSize).toBe(10)
+  })
+
+  test("ES filter + batchSize overrides are honored", () => {
+    const content = generateSingleContent({
+      source: ES_SRC, sink: LAKE_SINK, sourceColumns: esSrcCols, sinkColumns: lakeSinkCols,
+      esFilter: "status:active", esBatchSize: 500,
+    })
+    const params = (job(content).source as Record<string, unknown>).params as Record<string, unknown>
+    expect(params.filter).toBe("status:active")
+    expect(params.batchSize).toBe(500)
+  })
+
+  test("non-ES source has no filter/batchSize and keeps its real schema", () => {
+    const content = generateSingleContent({
+      source: SRC, sink: SINK, sourceColumns: sourceCols, sinkColumns: sinkCols,
+    })
+    const src = job(content).source as Record<string, unknown>
+    const params = src.params as Record<string, unknown>
+    expect(params.filter).toBeUndefined()
+    expect(params.batchSize).toBeUndefined()
+    expect(src.namespace).toBe("tc_demo")
+  })
+})
+
+describe("elasticsearch sink (lakehouse → es)", () => {
+  const LAKE_SRC = { id: 1418, name: "LAKEHOUSE_wanxin", dsType: 1, schema: "aaa", table: "complement_task" }
+  const ES_SINK = { id: 28366, name: "tianzhu_es", dsType: 13, schema: "public", table: "t1_entity_meta_1" }
+  const srcCols = [{ name: "id", type: "bigint" }, { name: "tenant_id", type: "bigint" }]
+  const esSinkCols = [{ name: "applyPermission", type: "nested" }, { name: "columnFilterInfo", type: "text" }]
+
+  test("ES sink omits namespace/database and writeMode, writes batchSize + idGenerateRule", () => {
+    const content = generateSingleContent({
+      source: LAKE_SRC, sink: ES_SINK, sourceColumns: srcCols, sinkColumns: esSinkCols,
+      writeMode: "OVERWRITE",
+    })
+    const sink = job(content).sink as Record<string, unknown>
+    expect(sink.namespace).toBeUndefined()
+    const params = sink.params as Record<string, unknown>
+    expect(params.database).toBeUndefined()
+    expect(params.writeMode).toBeUndefined()
+    expect(params.outputMode).toBeUndefined()
+    expect(params.batchSize).toBe(10000)
+    expect(params.idGenerateRule).toBe("NONE")
+    expect(params.is_partition).toBe(false)
+    // source side is a normal lakehouse source.
+    expect((job(content).source as Record<string, unknown>).namespace).toBe("aaa")
+  })
+
+  test("ES sink batchSize / idGenerateRule overrides are honored", () => {
+    const content = generateSingleContent({
+      source: LAKE_SRC, sink: ES_SINK, sourceColumns: srcCols, sinkColumns: esSinkCols,
+      esSinkBatchSize: 500, esSinkIdRule: "PRIMARY_KEY",
+    })
+    const params = (job(content).sink as Record<string, unknown>).params as Record<string, unknown>
+    expect(params.batchSize).toBe(500)
+    expect(params.idGenerateRule).toBe("PRIMARY_KEY")
+  })
+})
+
+describe("kafka sink (lakehouse → kafka)", () => {
+  const LAKE_SRC = { id: 1418, name: "LAKEHOUSE_wanxin", dsType: 1, schema: "aaa", table: "complement_task" }
+  const KAFKA_SINK = { id: 26590, name: "iol_event_hub", dsType: 2, schema: "public", table: "hotel-search-requests" }
+  const srcCols = [{ name: "id", type: "bigint" }, { name: "env", type: "string" }]
+  const kafkaSinkCols = [{ name: "id", type: "BIGINT" }, { name: "env", type: "STRING" }]
+
+  test("Kafka sink uses '--' namespace/database, json codec, no writeMode", () => {
+    const content = generateSingleContent({
+      source: LAKE_SRC, sink: KAFKA_SINK, sourceColumns: srcCols, sinkColumns: kafkaSinkCols,
+      writeMode: "OVERWRITE",
+    })
+    const sink = job(content).sink as Record<string, unknown>
+    expect(sink.namespace).toBe("--")
+    const params = sink.params as Record<string, unknown>
+    expect(params.database).toBe("--")
+    expect(params.codec).toBe("json")
+    expect(params.writeMode).toBeUndefined()
+    expect(params.outputMode).toBeUndefined()
+    expect(params.batchSize).toBeUndefined()
+    expect(params.is_partition).toBe(false)
+    // source side is a normal lakehouse source.
+    expect((job(content).source as Record<string, unknown>).namespace).toBe("aaa")
+  })
+})
+
+describe("kafka source (kafka → lakehouse)", () => {
+  const KAFKA_SRC = { id: 26590, name: "iol_event_hub", dsType: 2, schema: "public", table: "hotel-search-requests" }
+  const LAKE_SINK = { id: 1418, name: "LAKEHOUSE_wanxin", dsType: 1, schema: "aaa", table: "mn_01" }
+  const srcCols = [{ name: "__offset__", type: "LONG" }]
+  const lakeSinkCols = [{ name: "a", type: "int" }]
+
+  test("Kafka source uses '--' namespace, group-offsets mode with groupId + json codec", () => {
+    const content = generateSingleContent({
+      source: KAFKA_SRC, sink: LAKE_SINK, sourceColumns: srcCols, sinkColumns: lakeSinkCols,
+      kafkaSourceMode: "group-offsets", kafkaSourceGroupId: "test_01",
+    })
+    const src = job(content).source as Record<string, unknown>
+    expect(src.namespace).toBe("--")
+    const params = src.params as Record<string, unknown>
+    expect(params.database).toBe("--")
+    expect(params.mode).toBe("group-offsets")
+    expect(params.codec).toBe("json")
+    expect(params.groupId).toBe("test_01")
+    expect(params.endMode).toBe("period")  // default task-end strategy
+  })
+
+  test("earliest-offset mode still carries groupId (required for all modes)", () => {
+    const content = generateSingleContent({
+      source: KAFKA_SRC, sink: LAKE_SINK, sourceColumns: srcCols, sinkColumns: lakeSinkCols,
+      kafkaSourceMode: "earliest-offset", kafkaSourceGroupId: "lh_demo_group",
+    })
+    const params = (job(content).source as Record<string, unknown>).params as Record<string, unknown>
+    expect(params.mode).toBe("earliest-offset")
+    expect(params.groupId).toBe("lh_demo_group")
+    expect(params.endMode).toBe("period")
+  })
+
+  test("endMode override is honored", () => {
+    const content = generateSingleContent({
+      source: KAFKA_SRC, sink: LAKE_SINK, sourceColumns: srcCols, sinkColumns: lakeSinkCols,
+      kafkaSourceMode: "latest-offset", kafkaSourceGroupId: "g1", kafkaSourceEndMode: "latest",
+    })
+    const params = (job(content).source as Record<string, unknown>).params as Record<string, unknown>
+    expect(params.endMode).toBe("latest")
+  })
+})

--- a/packages/cz-cli/test/integration-partition.test.ts
+++ b/packages/cz-cli/test/integration-partition.test.ts
@@ -109,3 +109,43 @@ describe("generateSingleContent — dynamic partition (B semantics)", () => {
     expect(String(res.message)).toContain("nonexistent")
   })
 })
+
+describe("source-side partitions (lakehouse → mysql)", () => {
+  // Lakehouse source (dsType 1) → MySQL sink (dsType 5), with a partitioned source table.
+  const LAKE_SRC = { id: 1418, name: "LAKEHOUSE_wanxin_test_08", dsType: 1, schema: "ods", table: "employees" }
+  const MYSQL_SINK = { id: 20261, name: "xl_test_mysql8", dsType: 5, schema: "automated_test", table: "auto_mysql_sink" }
+  const srcCols = [{ name: "employee_id", type: "int" }, { name: "dt", type: "string" }]
+  const snkCols = [{ name: "employee_id", type: "INT" }, { name: "dt", type: "VARCHAR" }]
+
+  test("writes source.params.partitions as [[\"dt=...\"]] and flags the partition column", () => {
+    const content = generateSingleContent({
+      source: LAKE_SRC, sink: MYSQL_SINK, sourceColumns: srcCols, sinkColumns: snkCols,
+      writeMode: "APPEND", sourcePartitions: ["dt=2026-08-04"],
+    })
+    const j = job(content)
+    const sourceParams = (j.source as Record<string, unknown>).params as Record<string, unknown>
+    expect(sourceParams.partitions).toEqual([["dt=2026-08-04"]])
+    const cols = (j.source as Record<string, unknown>).columns as Record<string, unknown>[]
+    const dtCol = cols.find((c) => c.name === "dt")
+    expect(dtCol?.partitionColumn).toBe(true)
+    // sink params carry no source-side partitions.
+    expect(((j.sink as Record<string, unknown>).params as Record<string, unknown>).partitions).toBeUndefined()
+  })
+
+  test("supports a scheduling-param variable value (dt=${bizdate})", () => {
+    const content = generateSingleContent({
+      source: LAKE_SRC, sink: MYSQL_SINK, sourceColumns: srcCols, sinkColumns: snkCols,
+      sourcePartitions: ["dt=${bizdate}"],
+    })
+    const sourceParams = (job(content).source as Record<string, unknown>).params as Record<string, unknown>
+    expect(sourceParams.partitions).toEqual([["dt=${bizdate}"]])
+  })
+
+  test("no source partitions → source.params has no partitions key", () => {
+    const content = generateSingleContent({
+      source: LAKE_SRC, sink: MYSQL_SINK, sourceColumns: srcCols, sinkColumns: snkCols,
+    })
+    const sourceParams = (job(content).source as Record<string, unknown>).params as Record<string, unknown>
+    expect(sourceParams.partitions).toBeUndefined()
+  })
+})

--- a/packages/cz-cli/test/integration-sync-vc.test.ts
+++ b/packages/cz-cli/test/integration-sync-vc.test.ts
@@ -14,6 +14,9 @@ let existingTaskAdhoc: string | undefined
 // Controls single-table setup probing: whether the sink table exists, and getDdl call count.
 let sinkTableExists = true
 let getDdlCalls = 0
+// Sink columns returned by getColumnMapMeta, and CREATE TABLE SQLs executed against a sink.
+let metaSinkColumns: Array<Record<string, unknown>> = [{ name: "id" }]
+const createTableSqls: string[] = []
 
 const actualSdk = await import("@clickzetta/sdk")
 const actualResolver = await import("../src/resolver.ts")
@@ -43,13 +46,14 @@ function installSdkMock() {
   // Probe endpoints used by single-table setup: schema/table existence, DDL, column meta.
   studioRequest: async (_c: unknown, path: string, body?: Record<string, unknown>) => {
     if (path.includes("getColumnMapMeta")) {
-      return { data: { sourceMeta: { columns: [{ name: "id" }] }, sinkMeta: { columns: [{ name: "id" }] } } }
+      return { data: { sourceMeta: { columns: [{ name: "id" }] }, sinkMeta: { columns: metaSinkColumns } } }
     }
     if (path.includes("getDdl")) { getDdlCalls++; return { data: "CREATE TABLE db1.t1 (id BIGINT)" } }
     if (path.includes("ai/mcp/execute")) {
       const sql = String(body?.sql ?? "")
       // SHOW TABLES → controls whether the sink table "exists"; other execs (schema, create) are no-ops.
       if (/SHOW TABLES/i.test(sql)) return { data: { rows: sinkTableExists ? [["t1"]] : [] } }
+      if (/CREATE TABLE/i.test(sql)) createTableSqls.push(sql)
       return { data: { rows: [["dummy"]] } }
     }
     return { data: null }
@@ -77,6 +81,10 @@ const DS_BY_NAME: Record<string, { id: number; name: string; dsType: number }> =
   lakehouse_sink: { id: 200, name: "lakehouse_sink", dsType: 1 },
   lakehouse_src: { id: 300, name: "lakehouse_src", dsType: 1 },
   mysql_sink: { id: 400, name: "mysql_sink", dsType: 5 },
+  es_src: { id: 500, name: "es_src", dsType: 13 },
+  es_sink: { id: 600, name: "es_sink", dsType: 13 },
+  kafka_sink: { id: 700, name: "kafka_sink", dsType: 2 },
+  kafka_src: { id: 800, name: "kafka_src", dsType: 2 },
 }
 mock.module("../src/commands/datasource.js", () => ({
   ...actualDatasource,
@@ -110,6 +118,8 @@ beforeEach(() => {
   existingTaskAdhoc = undefined
   sinkTableExists = true
   getDdlCalls = 0
+  metaSinkColumns = [{ name: "id" }]
+  createTableSqls.length = 0
   vclusters = [
     { id: "vc-int-1", name: "SYNC_VC", type: "INTEGRATION" },
     { id: "vc-gen-1", name: "GENERAL_VC", type: "GENERAL" },
@@ -291,5 +301,190 @@ describe("integration edit: sync VC handling", () => {
     expect(result.exitCode).toBe(2)
     expect(result.output).toContain("INTEGRATION")
     expect(saveContentCalls.length).toBe(0)
+  })
+})
+
+describe("integration setup: elasticsearch → lakehouse", () => {
+  const ES_BASE =
+    "task integration setup 12345 --sync-type single " +
+    "--source-datasource es_src --source-table demo_es_index " +
+    "--sink-datasource lakehouse_sink --sink-schema automated_test --sink-table demo_es_sink " +
+    "--write-mode OVERWRITE --format json"
+
+  test("builds the Lakehouse sink from column metadata, never calls getDdl, saves ES source params", async () => {
+    sinkTableExists = false
+    metaSinkColumns = [{ name: "keyword", type: "string" }, { name: "long", type: "bigint" }]
+    const result = await execute(`${ES_BASE} --source-filter 'status:active' --source-batch-size 50`)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    // Sink table built from metadata columns, not a mirrored source DDL.
+    expect(getDdlCalls).toBe(0)
+    expect(createTableSqls.length).toBe(1)
+    expect(createTableSqls[0]).toContain("`keyword` string")
+    expect(createTableSqls[0]).toContain("`long` bigint")
+    // Saved content carries ES-shaped source.params.
+    expect(saveContentCalls.length).toBe(1)
+    const raw = saveContentCalls[0]!.dataFileContent
+    const content = (typeof raw === "string" ? JSON.parse(raw) : raw) as Record<string, unknown>
+    const job0 = (content.jobs as Record<string, unknown>[])[0]!
+    const params = (job0.source as Record<string, unknown>).params as Record<string, unknown>
+    expect(params.database).toBe("--")
+    expect(params.filter).toBe("status:active")
+    expect(params.batchSize).toBe(50)
+    expect((job0.source as Record<string, unknown>).namespace).toBe("--")
+  })
+
+  test("existing Lakehouse sink table skips creation", async () => {
+    sinkTableExists = true
+    metaSinkColumns = [{ name: "keyword", type: "string" }]
+    const result = await execute(ES_BASE)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(createTableSqls.length).toBe(0)
+    expect(saveContentCalls.length).toBe(1)
+  })
+
+  test("no sink column metadata → SINK_TABLE_REQUIRED", async () => {
+    sinkTableExists = false
+    metaSinkColumns = []
+    const result = await execute(ES_BASE)
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toContain("SINK_TABLE_REQUIRED")
+    expect(saveContentCalls.length).toBe(0)
+  })
+})
+
+describe("integration setup: lakehouse → elasticsearch", () => {
+  const LES_BASE =
+    "task integration setup 12345 --sync-type single " +
+    "--source-datasource lakehouse_src --source-schema aaa --source-table complement_task " +
+    "--sink-datasource es_sink --sink-table t1_entity_meta_1 " +
+    "--format json"
+
+  test("saves ES-shaped sink content and never builds a target table", async () => {
+    // ES sink metadata present → index exists.
+    metaSinkColumns = [{ name: "applyPermission", type: "nested" }, { name: "columnFilterInfo", type: "text" }]
+    const result = await execute(LES_BASE)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(getDdlCalls).toBe(0)
+    expect(createTableSqls.length).toBe(0)
+    expect(saveContentCalls.length).toBe(1)
+    const raw = saveContentCalls[0]!.dataFileContent
+    const content = (typeof raw === "string" ? JSON.parse(raw) : raw) as Record<string, unknown>
+    const sink = ((content.jobs as Record<string, unknown>[])[0]!.sink) as Record<string, unknown>
+    expect(sink.namespace).toBeUndefined()
+    const params = sink.params as Record<string, unknown>
+    expect(params.database).toBeUndefined()
+    expect(params.batchSize).toBe(10000)
+    expect(params.idGenerateRule).toBe("NONE")
+  })
+
+  test("--sink-batch-size / --sink-id-rule are honored", async () => {
+    metaSinkColumns = [{ name: "applyPermission", type: "nested" }]
+    const result = await execute(`${LES_BASE} --sink-batch-size 2000 --sink-id-rule PRIMARY_KEY`)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    const raw = saveContentCalls[0]!.dataFileContent
+    const content = (typeof raw === "string" ? JSON.parse(raw) : raw) as Record<string, unknown>
+    const params = (((content.jobs as Record<string, unknown>[])[0]!.sink) as Record<string, unknown>).params as Record<string, unknown>
+    expect(params.batchSize).toBe(2000)
+    expect(params.idGenerateRule).toBe("PRIMARY_KEY")
+  })
+
+  test("missing ES index (no sink columns) → SINK_INDEX_REQUIRED", async () => {
+    metaSinkColumns = []
+    const result = await execute(LES_BASE)
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toContain("SINK_INDEX_REQUIRED")
+    expect(saveContentCalls.length).toBe(0)
+  })
+})
+
+describe("integration setup: lakehouse → kafka", () => {
+  const LK_BASE =
+    "task integration setup 12345 --sync-type single " +
+    "--source-datasource lakehouse_src --source-schema aaa --source-table complement_task " +
+    "--sink-datasource kafka_sink --sink-table hotel-search-requests " +
+    "--format json"
+
+  test("saves Kafka-shaped sink content and never builds a topic", async () => {
+    metaSinkColumns = [{ name: "id", type: "BIGINT" }, { name: "env", type: "STRING" }]
+    const result = await execute(LK_BASE)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(getDdlCalls).toBe(0)
+    expect(createTableSqls.length).toBe(0)
+    expect(saveContentCalls.length).toBe(1)
+    const raw = saveContentCalls[0]!.dataFileContent
+    const content = (typeof raw === "string" ? JSON.parse(raw) : raw) as Record<string, unknown>
+    const sink = ((content.jobs as Record<string, unknown>[])[0]!.sink) as Record<string, unknown>
+    expect(sink.namespace).toBe("--")
+    const params = sink.params as Record<string, unknown>
+    expect(params.database).toBe("--")
+    expect(params.codec).toBe("json")
+    expect(params.writeMode).toBeUndefined()
+  })
+
+  test("missing Kafka topic (no sink columns) → SINK_TOPIC_REQUIRED", async () => {
+    metaSinkColumns = []
+    const result = await execute(LK_BASE)
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toContain("SINK_TOPIC_REQUIRED")
+    expect(saveContentCalls.length).toBe(0)
+  })
+})
+
+describe("integration setup: kafka → lakehouse", () => {
+  const KL_BASE =
+    "task integration setup 12345 --sync-type single " +
+    "--source-datasource kafka_src --source-table hotel-search-requests " +
+    "--sink-datasource lakehouse_sink --sink-schema aaa --sink-table mn_01 " +
+    "--format json"
+
+  test("group-offsets: builds Lakehouse sink from columns, never getDdl, saves Kafka source params", async () => {
+    sinkTableExists = false
+    metaSinkColumns = [{ name: "a", type: "int" }]
+    const result = await execute(`${KL_BASE} --source-mode group-offsets --source-group-id test_01`)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(getDdlCalls).toBe(0)
+    expect(createTableSqls.length).toBe(1)
+    expect(createTableSqls[0]).toContain("`a` int")
+    const raw = saveContentCalls[0]!.dataFileContent
+    const content = (typeof raw === "string" ? JSON.parse(raw) : raw) as Record<string, unknown>
+    const src = ((content.jobs as Record<string, unknown>[])[0]!.source) as Record<string, unknown>
+    expect(src.namespace).toBe("--")
+    const params = src.params as Record<string, unknown>
+    expect(params.mode).toBe("group-offsets")
+    expect(params.groupId).toBe("test_01")
+    expect(params.codec).toBe("json")
+    expect(params.endMode).toBe("period")
+  })
+
+  test("a Kafka source without --source-group-id errors (any mode)", async () => {
+    metaSinkColumns = [{ name: "a", type: "int" }]
+    const result = await execute(KL_BASE)  // defaults to group-offsets, no group id
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toContain("source-group-id")
+    expect(saveContentCalls.length).toBe(0)
+  })
+
+  test("earliest-offset also requires and carries a group id", async () => {
+    sinkTableExists = false
+    metaSinkColumns = [{ name: "a", type: "int" }]
+    // Without a group id it must error, even for earliest-offset.
+    const missing = await execute(`${KL_BASE} --source-mode earliest-offset`)
+    expect(missing.exitCode).toBe(2)
+    expect(missing.output).toContain("source-group-id")
+
+    const result = await execute(`${KL_BASE} --source-mode earliest-offset --source-group-id lh_demo_group`)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    const raw = saveContentCalls[0]!.dataFileContent
+    const content = (typeof raw === "string" ? JSON.parse(raw) : raw) as Record<string, unknown>
+    const params = (((content.jobs as Record<string, unknown>[])[0]!.source) as Record<string, unknown>).params as Record<string, unknown>
+    expect(params.mode).toBe("earliest-offset")
+    expect(params.groupId).toBe("lh_demo_group")
   })
 })

--- a/packages/cz-cli/test/integration-sync-vc.test.ts
+++ b/packages/cz-cli/test/integration-sync-vc.test.ts
@@ -9,11 +9,19 @@ const profileFile = join(profileDir, "profiles.toml")
 
 const saveContentCalls: Array<Record<string, unknown>> = []
 let vclusters: Array<{ id: string; name: string; type: string }> = []
+// adhocConfigs the mocked getTaskDetail reports as already persisted on the task (for edit).
+let existingTaskAdhoc: string | undefined
+// Controls single-table setup probing: whether the sink table exists, and getDdl call count.
+let sinkTableExists = true
+let getDdlCalls = 0
 
 const actualSdk = await import("@clickzetta/sdk")
 const actualResolver = await import("../src/resolver.ts")
 
-mock.module("@clickzetta/sdk", () => ({
+// bun's mock.module is process-global and last-write-wins; re-installing in beforeEach
+// keeps this file's SDK mock authoritative even when another test file also mocks the SDK.
+function installSdkMock() {
+  mock.module("@clickzetta/sdk", () => ({
   ...actualSdk,
   listVclusters: async () => vclusters,
   resolveVclusterId: async (_c: unknown, name: string) =>
@@ -22,7 +30,33 @@ mock.module("@clickzetta/sdk", () => ({
     saveContentCalls.push(params)
     return { data: true }
   },
-}))
+  // Task detail carries existing content (a single-table job) + any bound adhocConfigs.
+  getTaskDetail: async (_config: unknown, fileId: number) => ({
+    data: {
+      id: fileId,
+      ...(existingTaskAdhoc !== undefined && { adhocConfigs: existingTaskAdhoc }),
+      content: JSON.stringify({
+        jobs: [{ source: { dataObject: "t1", namespace: "db1" }, sink: { dataObject: "t1", namespace: "public" }, columnMapping: { id: "id" } }],
+      }),
+    },
+  }),
+  // Probe endpoints used by single-table setup: schema/table existence, DDL, column meta.
+  studioRequest: async (_c: unknown, path: string, body?: Record<string, unknown>) => {
+    if (path.includes("getColumnMapMeta")) {
+      return { data: { sourceMeta: { columns: [{ name: "id" }] }, sinkMeta: { columns: [{ name: "id" }] } } }
+    }
+    if (path.includes("getDdl")) { getDdlCalls++; return { data: "CREATE TABLE db1.t1 (id BIGINT)" } }
+    if (path.includes("ai/mcp/execute")) {
+      const sql = String(body?.sql ?? "")
+      // SHOW TABLES → controls whether the sink table "exists"; other execs (schema, create) are no-ops.
+      if (/SHOW TABLES/i.test(sql)) return { data: { rows: sinkTableExists ? [["t1"]] : [] } }
+      return { data: { rows: [["dummy"]] } }
+    }
+    return { data: null }
+  },
+  }))
+}
+installSdkMock()
 
 const actualStudioContext = await import("../src/commands/studio-context.ts")
 mock.module("../src/commands/studio-context.js", () => ({
@@ -38,12 +72,16 @@ mock.module("../src/commands/studio-context.js", () => ({
 }))
 
 const actualDatasource = await import("../src/commands/datasource.ts")
+const DS_BY_NAME: Record<string, { id: number; name: string; dsType: number }> = {
+  mysql_src: { id: 100, name: "mysql_src", dsType: 5 },
+  lakehouse_sink: { id: 200, name: "lakehouse_sink", dsType: 1 },
+  lakehouse_src: { id: 300, name: "lakehouse_src", dsType: 1 },
+  mysql_sink: { id: 400, name: "mysql_sink", dsType: 5 },
+}
 mock.module("../src/commands/datasource.js", () => ({
   ...actualDatasource,
   resolveDatasource: async (_c: unknown, nameOrId: string) =>
-    nameOrId === "mysql_src"
-      ? { id: 100, name: "mysql_src", dsType: 5 }
-      : { id: 200, name: "lakehouse_sink", dsType: 1 },
+    DS_BY_NAME[nameOrId] ?? { id: 200, name: "lakehouse_sink", dsType: 1 },
 }))
 
 mock.module("../src/resolver.js", () => ({
@@ -67,7 +105,11 @@ function firstJson(output: string) {
 }
 
 beforeEach(() => {
+  installSdkMock()
   saveContentCalls.length = 0
+  existingTaskAdhoc = undefined
+  sinkTableExists = true
+  getDdlCalls = 0
   vclusters = [
     { id: "vc-int-1", name: "SYNC_VC", type: "INTEGRATION" },
     { id: "vc-gen-1", name: "GENERAL_VC", type: "GENERAL" },
@@ -154,5 +196,100 @@ describe("integration setup: sync VC persistence", () => {
     expect(adhoc).toMatchObject({ adhocVcCode: "SYNC_VC", adhocVcId: "vc-int-1" })
     const data = firstJson(result.output).data as Record<string, unknown>
     expect(data.vc).toBe("SYNC_VC")
+  })
+})
+
+const SINGLE_BASE =
+  "task integration setup 12345 --sync-type single " +
+  "--source-datasource lakehouse_src --source-schema db1 --source-table t1 " +
+  "--sink-datasource mysql_sink --sink-schema public --format json"
+
+describe("integration setup: single-table sync VC", () => {
+  test("single-table setup persists adhocConfigs (explicit --vc)", async () => {
+    const result = await execute(`${SINGLE_BASE} --vc SYNC_VC`)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(saveContentCalls.length).toBe(1)
+    const adhoc = JSON.parse(String(saveContentCalls[0]!.adhocConfigs)) as Record<string, unknown>
+    expect(adhoc).toMatchObject({ adhocVcCode: "SYNC_VC", adhocVcId: "vc-int-1" })
+  })
+
+  test("single-table setup auto-picks the sole INTEGRATION VC", async () => {
+    const result = await execute(SINGLE_BASE)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    const adhoc = JSON.parse(String(saveContentCalls[0]!.adhocConfigs)) as Record<string, unknown>
+    expect(adhoc.adhocVcCode).toBe("SYNC_VC")
+  })
+
+  test("single-table setup rejects a non-INTEGRATION VC", async () => {
+    const result = await execute(`${SINGLE_BASE} --vc GENERAL_VC`)
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toContain("INTEGRATION")
+    expect(saveContentCalls.length).toBe(0)
+  })
+})
+
+describe("integration setup: sink table auto-create guard", () => {
+  // Lakehouse source → Lakehouse sink; auto-create is allowed.
+  const LAKE_TO_LAKE =
+    "task integration setup 12345 --sync-type single " +
+    "--source-datasource lakehouse_src --source-schema db1 --source-table t1 " +
+    "--sink-datasource lakehouse_sink --sink-schema public --sink-table t1 --format json"
+
+  test("non-Lakehouse sink with missing table errors and does NOT call getDdl", async () => {
+    sinkTableExists = false
+    // SINGLE_BASE sink is mysql_sink (dsType 5).
+    const result = await execute(SINGLE_BASE)
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toContain("SINK_TABLE_REQUIRED")
+    expect(getDdlCalls).toBe(0)
+    expect(saveContentCalls.length).toBe(0)
+  })
+
+  test("Lakehouse sink with missing table auto-creates via getDdl", async () => {
+    sinkTableExists = false
+    const result = await execute(LAKE_TO_LAKE)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(getDdlCalls).toBe(1)
+    expect(saveContentCalls.length).toBe(1)
+  })
+
+  test("non-Lakehouse sink with existing table skips creation and succeeds", async () => {
+    sinkTableExists = true
+    const result = await execute(SINGLE_BASE)
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(getDdlCalls).toBe(0)
+    expect(saveContentCalls.length).toBe(1)
+  })
+})
+
+describe("integration edit: sync VC handling", () => {
+  test("edit preserves the existing bound VC when --vc is omitted", async () => {
+    existingTaskAdhoc = JSON.stringify({ multiDataSource: [], schema: "public", adhocVcCode: "SYNC_VC", adhocVcId: "vc-int-1" })
+    const result = await execute("task integration edit 12345 --parallelism 2 --format json")
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    expect(saveContentCalls.length).toBe(1)
+    // The previously bound VC is carried through unchanged.
+    expect(saveContentCalls[0]!.adhocConfigs).toBe(existingTaskAdhoc)
+  })
+
+  test("edit --vc overrides the bound VC (validated as INTEGRATION)", async () => {
+    existingTaskAdhoc = JSON.stringify({ adhocVcCode: "OLD_VC" })
+    const result = await execute("task integration edit 12345 --vc SYNC_VC --format json")
+    if (result.exitCode !== 0) console.log(result.output)
+    expect(result.exitCode).toBe(0)
+    const adhoc = JSON.parse(String(saveContentCalls[0]!.adhocConfigs)) as Record<string, unknown>
+    expect(adhoc).toMatchObject({ adhocVcCode: "SYNC_VC", adhocVcId: "vc-int-1" })
+  })
+
+  test("edit --vc rejects a non-INTEGRATION VC", async () => {
+    const result = await execute("task integration edit 12345 --vc GENERAL_VC --format json")
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toContain("INTEGRATION")
+    expect(saveContentCalls.length).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
两个提交,围绕 `cz-cli task integration setup` 单表离线同步扩展:

**1. 数据源解析 + 源分区 + sink 建表保护 (dab93056a)**
- `resolveDatasource` 新增可选类型过滤,按名字查时翻页拉全(消除 pageSize:50 截断),无精确同名却命中多条时报歧义而非静默取第一条。
- `integration setup` 新增 `--source-type` / `--sink-type`,把源/汇解析限定在期望类型内(修复 lakehouse 名字被解析到同名 MySQL 的问题)。
- 新增 `--source-partitions`:写入 `source.params.partitions` 并标记分区列,支持只读某分区。
- sink 建表保护:只有 Lakehouse 目标自动镜像源 DDL 建表;非 Lakehouse(MySQL 等)缺表报 `SINK_TABLE_REQUIRED`,不再撞后端 "doesn't support generate ddl"。

**2. Elasticsearch 与 Kafka 单表同步 (81b28dde8)**
- ES 源:`filter` + `batchSize`,`--` 占位;ES 汇:`batchSize` + `idGenerateRule`。
- Kafka 源:`mode`(group-offsets/earliest-offset/latest-offset)+ `codec` + `groupId`(所有 mode 必填)+ `endMode`(任务结束策略,默认 period);Kafka 汇:`codec`。
- ES/Kafka 源 → Lakehouse 汇:从列元数据建 Lakehouse 表(无法镜像源 DDL)。ES 索引 / Kafka topic 从不自动创建,缺失时报 `SINK_INDEX_REQUIRED` / `SINK_TOPIC_REQUIRED`。
- 更新 integration/setup 命令描述。

## Test plan
- [x] 新增 `test/datasource-resolve.test.ts`(类型过滤 / 歧义 / 翻页)
- [x] 扩展 `test/integration-partition.test.ts`(源分区、ES/Kafka 源汇的纯函数结构)
- [x] 扩展 `test/integration-sync-vc.test.ts`(六个方向的 CLI 流程 + 建表保护 + groupId 校验)
- [x] `bun test` 相关套件全绿(52 用例,两种加载顺序都过)
- [x] `bun run typecheck` 通过
- [x] e2e help 99/99
- [ ] 尚未对真实 Studio 后端做端到端验证(测试中 SDK 为 mock);ES/Kafka 依赖后端 getColumnMapMeta 返回目标字段元数据的假设,建议 --debug 实跑确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)