### PR TITLE
fix(otel): build trajectory spans from the events the runtime publishes

### DIFF
--- a/packages/cz-cli/src/opencode-plugin/otel/context.ts
+++ b/packages/cz-cli/src/opencode-plugin/otel/context.ts
@@ -1,12 +1,43 @@
 import { context, trace, TraceFlags, type Span, type SpanContext } from "@opentelemetry/api"
 import { serializeTraceparent } from "./traceparent"
 
+//: Per-session turn spans, so a consumer that knows its sessionID gets its own trace
+//: rather than whichever session happened to fill the single slot below first.
+const sessionSpanContexts = new Map<string, SpanContext>()
 let currentSessionSpanContext: SpanContext | undefined
 let currentLlmSpan: Span | undefined
 let rawRequestCaptureEnabled = true
 
 export function setCurrentSessionSpanContext(spanContext: SpanContext | undefined) {
   currentSessionSpanContext = spanContext
+}
+
+export function setSessionSpanContext(sessionID: string, spanContext: SpanContext | undefined) {
+  if (!sessionID) return
+  if (spanContext) sessionSpanContexts.set(sessionID, spanContext)
+  else sessionSpanContexts.delete(sessionID)
+}
+
+function serialize(spanContext: SpanContext) {
+  return serializeTraceparent({
+    version: "00",
+    traceId: spanContext.traceId,
+    spanId: spanContext.spanId,
+    flags: spanContext.traceFlags === TraceFlags.SAMPLED ? "01" : "00",
+  })
+}
+
+/**
+ * Traceparent for a named session, falling back to the process-wide slot only when the
+ * caller has no sessionID — the pty paths, where a missing parent is the honest answer.
+ * Everything else (`chat.headers`, `shell.env` from the shell and task tools) does know
+ * its session, and handing it another session's trace is worse than handing it none.
+ */
+export function getSessionTraceparent(sessionID?: string): string | undefined {
+  const own = sessionID ? sessionSpanContexts.get(sessionID) : undefined
+  if (own) return serialize(own)
+  if (sessionID) return undefined
+  return currentSessionSpanContext ? serialize(currentSessionSpanContext) : undefined
 }
 
 export function setCurrentLlmSpan(span: Span | undefined) {
@@ -50,14 +81,8 @@ export function getSessionSpanRef(): { traceId: string; spanId: string } | undef
   return { traceId: currentSessionSpanContext.traceId, spanId: currentSessionSpanContext.spanId }
 }
 
-export function getCurrentSessionTraceparent(): string | undefined {
-  if (!currentSessionSpanContext) return undefined
-  return serializeTraceparent({
-    version: "00",
-    traceId: currentSessionSpanContext.traceId,
-    spanId: currentSessionSpanContext.spanId,
-    flags: currentSessionSpanContext.traceFlags === TraceFlags.SAMPLED ? "01" : "00",
-  })
+export function clearSessionSpanContexts() {
+  sessionSpanContexts.clear()
 }
 
 export function getSessionOtelContext() {

--- a/packages/cz-cli/src/opencode-plugin/otel/handlers.ts
+++ b/packages/cz-cli/src/opencode-plugin/otel/handlers.ts
@@ -1,15 +1,103 @@
-import { SpanKind, trace, SpanStatusCode, type Span } from "@opentelemetry/api"
+import { context, SpanKind, trace, SpanStatusCode, type Span } from "@opentelemetry/api"
 import { SeverityNumber, type Logger } from "@opentelemetry/api-logs"
 import {
   clearCurrentLlmSpan,
   getSessionOtelContext,
   setCurrentLlmSpan,
+  clearSessionSpanContexts,
   setCurrentSessionSpanContext,
   setRawRequestCaptureEnabled,
+  setSessionSpanContext,
 } from "./context"
 import * as m from "./metrics"
+import type { Event } from "@opencode-ai/sdk"
+import { isSensitiveKey, isSensitiveValue } from "../../telemetry.js"
+import { redactSql } from "../../logger.js"
 
 const tracer = trace.getTracer("opencode")
+
+/**
+ * Cap for the two attributes that carry tool content. A whole-file `read` output or a
+ * long `bash` transcript otherwise becomes one attribute, and collectors commonly drop or
+ * truncate a span past their attribute-size limit — losing the span, not just the text.
+ * Upstream truncates tool output for the model in the same spirit (message-v2.ts:51).
+ */
+const CONTENT_MAX_CHARS = 8_000
+
+/**
+ * Prompt and completion content gets the limit the pre-rebaseline handler used, 32KB, not
+ * the tool cap above: an input-messages attribute is a whole conversation and 8k would
+ * truncate almost all of it. Collectors reject well before this, hence the cap at all.
+ */
+const PROMPT_MAX_CHARS = 32 * 1024
+
+/**
+ * Tool and prompt content goes through the redactor this repo already has —
+ * `isSensitiveKey` and `redactSql`, the predicates the CLI's argv telemetry uses, which
+ * exist because plaintext credentials reached `_positional` once already.
+ *
+ * `isSensitiveValue` alone was not enough: it only fires on a bare `KEY=VALUE` token, so a
+ * credential written the way config files and flags actually write them survived —
+ * `pat = "…"` in profiles.toml (spaces, and double quotes that `redactSql` does not touch),
+ * `--password hunter2`, `token: abc` in YAML. All three are assignments, so the shape is
+ * what gets matched, and only the value is replaced so the key stays readable.
+ *
+ * It is a redactor, not a secret scanner. A credential with no assignment shape and no PEM
+ * envelope — a bare positional, `-H "Authorization: Bearer …"` (whose key is `Authorization`
+ * so it IS caught, but `Bearer x` alone is not) — still gets through. Content recording is
+ * off entirely under OPENCODE_OTEL_RECORD_CONTENT=0.
+ */
+const PEM_BLOCK = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g
+//: `key = "value"` / `key: value` / `KEY=value`, as config files and env files write them.
+const ASSIGNMENT = /([A-Za-z_][\w.-]{1,40})(\s*[:=]\s*)("[^"]*"|'[^']*'|`[^`]*`|[^\s,;)}\]]+)/g
+//: `--password hunter2` / `-p hunter2`, the whitespace-separated flag spelling.
+const FLAG_VALUE = /(--?[A-Za-z][\w-]{0,40})(\s+)("[^"]*"|'[^']*'|[^\s]+)/g
+
+function redactText(value: string): string {
+  let out = value.replace(PEM_BLOCK, "<redacted:private-key>")
+  out = out.replace(ASSIGNMENT, (whole, key: string, sep: string) =>
+    isSensitiveKey(key) ? `${key}${sep}<redacted>` : whole,
+  )
+  out = out.replace(FLAG_VALUE, (whole, flag: string, sep: string) =>
+    isSensitiveKey(flag.replace(/^-+/, "")) ? `${flag}${sep}<redacted>` : whole,
+  )
+  return redactSql(out)
+}
+
+/**
+ * Depth- and cycle-guarded: this walk runs before `safeStringify`, so a self-referential
+ * payload would overflow the stack where `safeStringify`'s own catch could not absorb it.
+ */
+function redactDeep(value: unknown, limit: number, depth = 0, seen = new WeakSet<object>()): unknown {
+  // Truncated at the leaf, before redaction: a `write` body or a `read` result is where the
+  // large payloads are, and redacting text that the cap is about to discard is pure work on
+  // the event-bus path.
+  if (typeof value === "string") return redactText(capTo(value, limit))
+  if (!value || typeof value !== "object") return value
+  if (depth >= 12) return "<redacted:too-deep>"
+  if (seen.has(value)) return "<redacted:cycle>"
+  seen.add(value)
+  if (Array.isArray(value)) return value.map((item) => redactDeep(item, limit, depth + 1, seen))
+  const out: Record<string, unknown> = {}
+  for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = isSensitiveKey(key) ? "<redacted>" : redactDeep(inner, limit, depth + 1, seen)
+  }
+  return out
+}
+
+function capTo(text: string, limit: number): string {
+  if (text.length <= limit) return text
+  return `${text.slice(0, limit)}\n[truncated ${text.length - limit} chars]`
+}
+
+function cap(text: string): string {
+  return capTo(text, CONTENT_MAX_CHARS)
+}
+
+/** Prompt/completion content: redacted like tool content, capped at the historical limit. */
+function promptAttr(value: unknown): string {
+  return capTo(safeStringify(redactDeep(value, PROMPT_MAX_CHARS)), PROMPT_MAX_CHARS)
+}
 
 function safeStringify(value: unknown): string {
   try {
@@ -17,20 +105,6 @@ function safeStringify(value: unknown): string {
   } catch {
     return String(value)
   }
-}
-
-function buildOutputMessages(p: Record<string, any>): string | undefined {
-  const parts: Array<Record<string, unknown>> = []
-  if (p.responseText) {
-    parts.push({ type: "text", content: p.responseText })
-  }
-  if (p.toolCalls?.length) {
-    for (const tc of p.toolCalls) {
-      parts.push({ type: "tool_call", id: tc.id, name: tc.name, arguments: tc.arguments })
-    }
-  }
-  if (parts.length === 0) return undefined
-  return JSON.stringify([{ role: "assistant", parts, finish_reason: p.finishReason ?? "unknown" }])
 }
 
 // Parse OPENCODE_DISABLE_TRACES once. Value is comma-separated categories,
@@ -44,12 +118,92 @@ function tracingEnabled(category: string): boolean {
 }
 
 let _logger: Logger | undefined
-let promptSpan: Span | undefined
-let preflightSpan: Span | undefined
 let _recordContent = true
-const stepSpans = new Map<string, Span>()
-const toolSpans = new Map<string, Span>()
+
+interface Model {
+  modelID: string
+  providerID: string
+  agent: string
+}
+
+//: Turn state, per session. `serve` drives several sessions at once and a subagent
+//: nests a second one inside the first, so a single module-level turn span would
+//: attribute one session's steps to another and close on whichever went idle first.
+const turnSpans = new Map<string, Span>()
+const turnEnriched = new Set<string>()
+//: Sessions with a turn actually running, driven by `session.status`. Deliberately not
+//: `turnSpans`: it must survive OPENCODE_DISABLE_TRACES=prompt, because it also gates
+//: metrics and logs. Part events are replayable — `Session.fork` republishes every
+//: historical part through `updatePart` (session.ts:716-727) and `compaction.prune`
+//: republishes settled tool parts (compaction.ts:282-286) — and both happen outside any
+//: busy window, so without this a fork re-records the whole history's tokens and spans.
+const liveTurns = new Set<string>()
+//: The last error published in the current turn, if it has not been superseded. See
+//: turnFailed.
+const pendingErrors = new Map<string, string>()
+//: The session-span slot in ./context is one global slot by design — SQL and
+//: raw-request capture attach to "the" current session — so remember who filled it
+//: and only that session may clear it.
+let contextOwner: string | undefined
+
+const stepSpans = new Map<string, { span: Span; sessionID: string }>()
+const toolSpans = new Map<string, { span: Span; sessionID: string }>()
+//: Keyed `sessionID|callID`, not by callID alone: a callID is provider-generated and
+//: `Session.fork` copies it across sessions, so a bare key can collide between a live call
+//: and a replayed one.
+//: Tool calls already counted, and the session each belongs to. A call surfaces once
+//: per state transition, so without this the metric counts it again on every update
+//: whenever tool tracing is off and no span is there to dedupe on. The session is what
+//: lets a call that never settles be cleaned up with its turn instead of being held for
+//: the life of the process.
+const countedTools = new Map<string, string>()
+//: Tool calls whose settled state has already been recorded. The runtime republishes
+//: settled tool parts — `compaction.prune` stamps `time.compacted` on completed parts and
+//: writes them back, and it is forked off the run loop so it can land before idle — and a
+//: second settle would double the counter, the duration histogram and the log record.
+const settledTools = new Set<string>()
+//: Step start times, kept outside `stepSpans` so a measured duration survives
+//: OPENCODE_DISABLE_TRACES=llm: this file's contract is that gates never affect metrics
+//: or logs, and a step part carries no timings of its own.
+const stepStartMs = new Map<string, { sessionID: string; startedMs: number }>()
+//: Child -> parent session, from `session.created`. A subagent runs in its own session
+//: (task.ts:145 creates it with `parentID`), so without this its whole trajectory becomes
+//: a detached trace and the parent turn shows an `execute_tool task` span with nothing
+//: under it.
+const sessionParents = new Map<string, string>()
+//: Provider/model per session, needed before a turn's first step because a span's
+//: name is fixed when it starts. Both sources are real: an assistant `message.updated`
+//: carries the provider that actually served the message (flat `modelID`/`providerID`,
+//: the same fields active-model.ts reads), and `session.next.model.switched` carries a
+//: `Model.Ref` on an explicit switch.
+const sessionModels = new Map<string, Model>()
+//: Prompt content per session, captured from the transform hooks. Both fire per step, just
+//: before the LLM call and therefore before the `step-start` part, so the chat span can
+//: carry them from the moment it opens — which is what the pre-rebaseline handler did with
+//: the `inputMessages`/`systemInstructions` its own upstream patch put on the step event.
+const sessionInput = new Map<string, string>()
+const sessionSystem = new Map<string, string>()
+//: Assistant output accumulated per message, to rebuild `gen_ai.output.messages` at
+//: step-finish. The old event carried `responseText`/`toolCalls`; on the message surface the
+//: same content arrives as text and tool parts. Keyed by part id inside the message so a
+//: streaming part updates in place and insertion order stays the order they were produced.
+const messageOutput = new Map<string, Map<string, Record<string, unknown>>>()
 const sessionStartMs = new Map<string, number>()
+
+/** Remember a `Model.Ref{id}` — what `session.next.model.switched` carries. */
+function rememberModelRef(sessionID: string, ref: any) {
+  if (!sessionID || !ref?.id) return
+  rememberModel(sessionID, { modelID: ref.id, providerID: ref.providerID ?? "" })
+}
+
+function rememberModel(sessionID: string, model: { modelID?: string; providerID?: string; agent?: string }) {
+  if (!sessionID || !model.modelID) return
+  sessionModels.set(sessionID, {
+    modelID: model.modelID,
+    providerID: model.providerID ?? "",
+    agent: model.agent ?? sessionModels.get(sessionID)?.agent ?? "",
+  })
+}
 
 export function initHandlers(logger: Logger, recordContent?: boolean) {
   _logger = logger
@@ -72,6 +226,7 @@ function emitLog(input: {
   severityText: string
   body: string
   eventName: string
+  sessionID?: string
   attributes?: Record<string, string | number | boolean>
 }) {
   _logger?.emit({
@@ -82,49 +237,278 @@ function emitLog(input: {
       "event.name": input.eventName,
       ...input.attributes,
     },
-    context: getSessionOtelContext(),
+    context: turnContext(input.sessionID),
   })
 }
 
-function endPromptSpan() {
-  if (!promptSpan) return
-  promptSpan.end()
-  promptSpan = undefined
+/**
+ * The turn span. It used to open on `session.turn.started`, an event no runtime
+ * publishes any more.
+ *
+ * It opens on `session.status` busy — the first signal of a turn on the v1 path
+ * (prompt.ts:1192) — rather than on the first step, so that a failure published inside the
+ * run loop but before any step (prompt.ts:322) still gets a span and an `error` outcome.
+ * busy is re-published mid-run (processor.ts:973), so the guard below is what makes it
+ * idempotent.
+ *
+ * Failures published even earlier — agent and model resolution at prompt.ts:625, :663 and
+ * the command paths at :1469, :1530 — happen before busy and throw without an idle, so
+ * they get no turn span at all. That is deliberate: there is no event pair to bound a span
+ * with, and inventing one from an error alone would report a turn that never started.
+ */
+function openTurnSpan(sessionID: string) {
+  if (!sessionID || turnSpans.has(sessionID) || !tracingEnabled("prompt")) return
+  const parentID = sessionParents.get(sessionID)
+  const parentTurn = parentID ? turnSpans.get(parentID) : undefined
+  const span = tracer.startSpan(
+    "prompt",
+    {
+      attributes: {
+        "opencode.session.id": sessionID,
+        ...(parentID ? { "opencode.session.parent.id": parentID } : {}),
+      },
+    },
+    parentTurn ? trace.setSpan(context.active(), parentTurn) : undefined,
+  )
+  turnSpans.set(sessionID, span)
+  turnEnriched.delete(sessionID)
+  setSessionSpanContext(sessionID, span.spanContext())
+  if (!contextOwner) {
+    // This slot goes live for the first time with this PR — its only previous writer was
+    // one of the dead branches. It is a single process-wide slot in ./context, read by
+    // `getCurrentSessionTraceparent` for outbound gateway headers and by
+    // CLICKZETTA_TRACEPARENT for spawned shells, neither of which knows a sessionID at
+    // its call site. Narrowing those needs session plumbing through outbound-headers.ts
+    // and the shell hook, so it stays first-writer-wins for now: under `serve` a second
+    // concurrent session's gateway calls carry the first session's traceparent. Log
+    // records do NOT go through it — emitLog resolves the session's own turn.
+    contextOwner = sessionID
+    setCurrentSessionSpanContext(span.spanContext())
+  }
 }
 
-function endPreflightSpan() {
-  if (!preflightSpan) return
-  preflightSpan.end()
-  preflightSpan = undefined
+/** Model and message are only known once the turn reaches its first step. */
+function enrichTurnSpan(sessionID: string, messageID: string, model?: Model) {
+  const span = turnSpans.get(sessionID)
+  if (!span || turnEnriched.has(sessionID)) return
+  // Latched on the model being known, not on having been called: latching early would
+  // leave the turn permanently anonymous when the first step runs before the model is,
+  // which is the same silent failure as the `chat unknown` regression.
+  if (model?.modelID) turnEnriched.add(sessionID)
+  span.setAttributes({
+    ...(messageID ? { "opencode.message.id": messageID } : {}),
+    ...(model?.modelID ? { "gen_ai.request.model": model.modelID } : {}),
+    ...(model?.agent ? { "opencode.agent.name": model.agent } : {}),
+  })
 }
 
-export function handleEvent(event: { type: string; properties: Record<string, any> }) {
+/**
+ * Whether a turn failed, for `opencode.turn.outcome`.
+ *
+ * `session.error` alone is not evidence of failure: a `ContextOverflowError` is published
+ * and then recovered from by compacting within the same turn (processor.ts:932-936), so
+ * counting every error event as terminal reports successful turns as failures.
+ *
+ * The assistant message is the runtime's own verdict, but it cannot be used: on both
+ * terminal paths `halt` publishes the error and sets the session idle
+ * (processor.ts:926-931, :952-957), and the message carrying `error` is only published
+ * afterwards by the `ensuring(cleanup())` finalizer (processor.ts:913, :1027) — after the
+ * turn has already closed.
+ *
+ * What is observable before idle is whether the turn *continued*. A recovered error is
+ * followed by another LLM round trip; a terminal one is followed by idle. So an error is
+ * recorded as pending and cleared when the next step starts.
+ */
+function recordTurnError(sessionID: string, message: string) {
+  if (!sessionID) return
+  // Some failures are published before `status.set(busy)` and throw without an idle
+  // (prompt.ts:470, :625, :663, :1469, :1530), so there is no turn to attach them to and
+  // none coming. Holding one would hand its message to whichever later turn happens to
+  // close without a step of its own.
+  if (!liveTurns.has(sessionID)) return
+  pendingErrors.set(sessionID, message)
+}
+
+function clearTurnError(sessionID: string) {
+  pendingErrors.delete(sessionID)
+}
+
+/**
+ * Parent for a session's spans and log records: its own turn span, or nothing.
+ *
+ * A named session with no open turn deliberately does NOT fall back to the process-wide
+ * slot — that slot belongs to whichever session opened a turn first, so falling back is
+ * how one session's telemetry ends up under another's trace. Only a caller with no session
+ * at all consults it.
+ */
+function turnContext(sessionID?: string) {
+  const turn = sessionID ? turnSpans.get(sessionID) : undefined
+  if (turn) return trace.setSpan(context.active(), turn)
+  return sessionID ? context.active() : getSessionOtelContext()
+}
+
+/** Give up on tool spans a previous turn left open without ever settling. */
+function discardUnsettledTools(sessionID: string) {
+  for (const [key, entry] of toolSpans) {
+    if (entry.sessionID !== sessionID) continue
+    // An unset status reads as OK in every backend, which would make a call that never
+    // settled indistinguishable from one that completed with empty output.
+    entry.span.setStatus({ code: SpanStatusCode.ERROR, message: "tool call never settled" })
+    entry.span.end()
+    toolSpans.delete(key)
+  }
+  for (const [key, owner] of countedTools) {
+    if (owner !== sessionID) continue
+    countedTools.delete(key)
+    settledTools.delete(key)
+  }
+}
+
+/**
+ * Close a session's turn. Step spans still open belong to a turn that was aborted rather
+ * than settled, so they close with it — a step cannot settle later. Tool spans can: on
+ * abort, `cleanup()` republishes every running call as `Tool execution aborted` only after
+ * `halt` has set the session idle (processor.ts:885-910, and `ensuring` being outermost at
+ * :1026-1027), so closing them here would report an interrupted tool as a successful one.
+ */
+function endTurn(sessionID: string) {
+  if (!sessionID) return
+  liveTurns.delete(sessionID)
+  for (const [key, entry] of stepSpans) {
+    if (entry.sessionID !== sessionID) continue
+    entry.span.end()
+    clearCurrentLlmSpan(entry.span)
+    stepSpans.delete(key)
+  }
+  // Iterated separately from stepSpans on purpose: with OPENCODE_DISABLE_TRACES=llm there
+  // are no step spans, so a loop keyed off them would never reclaim these.
+  for (const [key, started] of stepStartMs) if (started.sessionID === sessionID) stepStartMs.delete(key)
+  const failure = pendingErrors.get(sessionID)
+  const span = turnSpans.get(sessionID)
+  if (span) {
+    if (failure) span.setStatus({ code: SpanStatusCode.ERROR, message: failure })
+    span.setAttribute("opencode.turn.outcome", failure ? "error" : "completed")
+    span.end()
+    turnSpans.delete(sessionID)
+  }
+  pendingErrors.delete(sessionID)
+  turnEnriched.delete(sessionID)
+  setSessionSpanContext(sessionID, undefined)
+  if (contextOwner !== sessionID) return
+  // Cleared rather than handed to another open turn. The slot is read by emitLog, by
+  // CLICKZETTA_TRACEPARENT for spawned shells and by raw-request capture, and under
+  // `serve` the next open turn is an unrelated session — attributing to it would turn a
+  // missing parent into a wrong one, which is far harder to notice downstream.
+  contextOwner = undefined
+  setCurrentSessionSpanContext(undefined)
+}
+
+/** One v1 message part, in the shape the pre-rebaseline serializer used. */
+function serializePart(part: Record<string, any>): Record<string, unknown> | undefined {
+  switch (part?.type) {
+    case "text":
+      return { type: "text", content: part.text ?? "" }
+    case "reasoning":
+      return { type: "reasoning", content: part.text ?? "" }
+    case "tool":
+      return {
+        type: "tool_call",
+        id: part.callID,
+        name: part.tool,
+        ...(part.state?.input != null ? { arguments: part.state.input } : {}),
+        ...(part.state?.status === "completed" ? { result: part.state.output } : {}),
+        ...(part.state?.status === "error" ? { error: part.state.error } : {}),
+      }
+    case "file":
+      return { type: "file", mediaType: part.mime, ...(part.filename ? { filename: part.filename } : {}) }
+    case "step-start":
+    case "step-finish":
+    case "snapshot":
+    case "patch":
+      return undefined
+    default:
+      return { type: String(part?.type ?? "unknown") }
+  }
+}
+
+/**
+ * `experimental.chat.messages.transform` (prompt.ts:1357) — the conversation as it is about
+ * to be sent. The hook carries no sessionID, so it comes off the messages themselves.
+ */
+export function recordInputMessages(messages: Array<{ info?: Record<string, any>; parts?: Record<string, any>[] }>) {
+  if (!_recordContent || !messages?.length) return
+  const sessionID = messages.find((m) => m.info?.sessionID)?.info?.sessionID
+  if (!sessionID) return
+  const serialized = messages.map((m) => ({
+    role: m.info?.role ?? "unknown",
+    parts: (m.parts ?? []).map(serializePart).filter(Boolean),
+  }))
+  sessionInput.set(sessionID, promptAttr(serialized))
+}
+
+/** `experimental.chat.system.transform` (llm/request.ts:70), which does pass a sessionID. */
+export function recordSystemInstructions(sessionID: string | undefined, system: string[]) {
+  if (!_recordContent || !sessionID || !system?.length) return
+  const parts = system.filter(Boolean).map((content) => ({ type: "text", content }))
+  if (!parts.length) return
+  sessionSystem.set(sessionID, promptAttr(parts))
+}
+
+/**
+ * The published hook type is a discriminated union (`Event` in @opencode-ai/sdk). Annotating
+ * this parameter as `{ type: string }` is what let `case "v2.step.started"` compile for
+ * months, so the union's own `type` is used instead and a subscription to a name outside it
+ * is now a type error rather than dead code. `properties` stays loose: narrowing it per case
+ * would not have caught that bug, and this file reads it defensively anyway.
+ *
+ * `session.next.model.switched` is admitted explicitly because it is the one event this
+ * handler needs that sits OUTSIDE the v1 union — it belongs to the durable bus, and the
+ * runtime delivers it to a v1-path plugin anyway (published from prompt.ts:712). Naming it
+ * here is the point: it is the single documented exception, and adding another means writing
+ * it down next to this comment.
+ */
+type SubscribedEvent = {
+  type: Event["type"] | "session.next.model.switched"
+  properties: Record<string, any>
+}
+
+export function handleEvent(event: SubscribedEvent) {
   try {
     const p = event.properties
     switch (event.type) {
       case "session.created":
         m.sessionCounter.add(1)
         if (p.sessionID) sessionStartMs.set(p.sessionID, Date.now())
+        if (p.sessionID && p.info?.parentID) sessionParents.set(p.sessionID, p.info.parentID)
         emitLog({
           severityNumber: SeverityNumber.INFO,
           severityText: "INFO",
           body: "session.created",
           eventName: "opencode.session.created",
+          sessionID: p.sessionID ?? "",
           attributes: sessionAttributes(p.sessionID),
         })
         break
 
       case "session.deleted": {
-        endPromptSpan()
-        setCurrentSessionSpanContext(undefined)
+        endTurn(p.sessionID ?? "")
         const startMs = p.sessionID ? sessionStartMs.get(p.sessionID) : undefined
         const durationMs = startMs ? Date.now() - startMs : undefined
-        if (p.sessionID) sessionStartMs.delete(p.sessionID)
+        if (p.sessionID) {
+          sessionStartMs.delete(p.sessionID)
+          // The model must outlive individual turns, so this is the only place it can go.
+          sessionModels.delete(p.sessionID)
+          sessionParents.delete(p.sessionID)
+          sessionInput.delete(p.sessionID)
+          sessionSystem.delete(p.sessionID)
+          discardUnsettledTools(p.sessionID)
+        }
         emitLog({
           severityNumber: SeverityNumber.INFO,
           severityText: "INFO",
           body: "session.deleted",
           eventName: "opencode.session.deleted",
+          sessionID: p.sessionID ?? "",
           attributes: sessionAttributes(p.sessionID, {
             ...(durationMs != null ? { "opencode.session.duration_ms": durationMs } : {}),
           }),
@@ -135,11 +519,20 @@ export function handleEvent(event: { type: string; properties: Record<string, an
       case "session.status": {
         const statusType = p.status?.type
         if (statusType === "busy") {
+          if (p.sessionID) liveTurns.add(p.sessionID)
+          // Outside openTurnSpan on purpose: that function returns early under
+          // OPENCODE_DISABLE_TRACES=prompt, and this is the only reclamation path for the
+          // tool maps outside `session.deleted`. Tool spans are deliberately left open
+          // across idle (see the gate in message.part.updated) so a late settlement can
+          // land; a new turn is where the ones that never settled are given up on.
+          discardUnsettledTools(p.sessionID ?? "")
+          openTurnSpan(p.sessionID ?? "")
           emitLog({
             severityNumber: SeverityNumber.INFO,
             severityText: "INFO",
             body: "session.prompt.started",
             eventName: "opencode.session.prompt.started",
+            sessionID: p.sessionID ?? "",
             attributes: sessionAttributes(p.sessionID, {
               "gen_ai.conversation.id": p.sessionID ?? "",
               "gen_ai.operation.name": "chat",
@@ -147,97 +540,9 @@ export function handleEvent(event: { type: string; properties: Record<string, an
           })
           break
         }
-        if (statusType === "idle") endPromptSpan()
+        if (statusType === "idle") endTurn(p.sessionID ?? "")
         break
       }
-
-      case "session.turn.started": {
-        endPromptSpan()
-        endPreflightSpan()
-        if (tracingEnabled("prompt")) {
-          const span = tracer.startSpan("prompt", {
-            attributes: {
-              "opencode.session.id": p.sessionID ?? "",
-              "opencode.message.id": p.messageID ?? "",
-              "opencode.agent.name": p.agent ?? "",
-              ...(p.model ? { "gen_ai.request.model": p.model } : {}),
-              "opencode.turn.parts": p.parts ?? 0,
-            },
-          })
-          promptSpan = span
-          setCurrentSessionSpanContext(span.spanContext())
-        }
-        emitLog({
-          severityNumber: SeverityNumber.INFO,
-          severityText: "INFO",
-          body: "session.turn.started",
-          eventName: "opencode.session.turn.started",
-          attributes: sessionAttributes(p.sessionID, {
-            "opencode.message.id": p.messageID ?? "",
-            "opencode.agent.name": p.agent ?? "",
-            ...(p.model ? { "gen_ai.request.model": p.model } : {}),
-            "opencode.turn.parts": p.parts ?? 0,
-          }),
-        })
-        break
-      }
-
-      case "session.turn.finished":
-        emitLog({
-          severityNumber: SeverityNumber.INFO,
-          severityText: "INFO",
-          body: "session.turn.finished",
-          eventName: "opencode.session.turn.finished",
-          attributes: sessionAttributes(p.sessionID, {
-            "opencode.message.id": p.messageID ?? "",
-            "opencode.turn.outcome": p.outcome ?? "unknown",
-          }),
-        })
-        if (promptSpan) promptSpan.setAttribute("opencode.turn.outcome", p.outcome ?? "unknown")
-        endPreflightSpan()
-        endPromptSpan()
-        setCurrentSessionSpanContext(undefined)
-        break
-
-      case "session.preflight.started":
-        endPreflightSpan()
-        if (tracingEnabled("prompt")) {
-          preflightSpan = tracer.startSpan(
-            "preflight",
-            {
-              attributes: {
-                "opencode.session.id": p.sessionID ?? "",
-                "opencode.message.id": p.messageID ?? "",
-              },
-            },
-            getSessionOtelContext(),
-          )
-        }
-        emitLog({
-          severityNumber: SeverityNumber.INFO,
-          severityText: "INFO",
-          body: "session.preflight.started",
-          eventName: "opencode.session.preflight.started",
-          attributes: sessionAttributes(p.sessionID, {
-            "opencode.message.id": p.messageID ?? "",
-          }),
-        })
-        break
-
-      case "session.preflight.finished":
-        emitLog({
-          severityNumber: SeverityNumber.INFO,
-          severityText: "INFO",
-          body: "session.preflight.finished",
-          eventName: "opencode.session.preflight.finished",
-          attributes: sessionAttributes(p.sessionID, {
-            "opencode.message.id": p.messageID ?? "",
-            "opencode.preflight.outcome": p.outcome ?? "unknown",
-          }),
-        })
-        if (preflightSpan) preflightSpan.setAttribute("opencode.preflight.outcome", p.outcome ?? "unknown")
-        endPreflightSpan()
-        break
 
       case "session.error": {
         const name = p.error?.name ?? "UnknownError"
@@ -245,13 +550,13 @@ export function handleEvent(event: { type: string; properties: Record<string, an
           (p.error?.data && typeof p.error.data === "object" && "message" in p.error.data
             ? String((p.error.data as Record<string, unknown>).message ?? "")
             : "") || name
-        promptSpan?.setStatus({ code: SpanStatusCode.ERROR, message })
-        preflightSpan?.setStatus({ code: SpanStatusCode.ERROR, message })
+        recordTurnError(p.sessionID ?? "", message)
         emitLog({
           severityNumber: SeverityNumber.ERROR,
           severityText: "ERROR",
           body: "session.error",
           eventName: "opencode.session.error",
+          sessionID: p.sessionID ?? "",
           attributes: sessionAttributes(p.sessionID, {
             "error.name": name,
             "error.message": message,
@@ -261,143 +566,327 @@ export function handleEvent(event: { type: string; properties: Record<string, an
       }
 
       case "session.idle":
-        endPromptSpan()
-        endPreflightSpan()
+        endTurn(p.sessionID ?? "")
         emitLog({
           severityNumber: SeverityNumber.INFO,
           severityText: "INFO",
           body: "session.idle",
           eventName: "opencode.session.idle",
+          sessionID: p.sessionID ?? "",
           attributes: sessionAttributes(p.sessionID),
         })
         break
 
-      // LLM step started: open a "chat {model}" span per GenAI spec
-      case "v2.step.started": {
-        if (!tracingEnabled("llm")) break
-        const spanName = `chat ${p.model ?? "unknown"}`
-        const span = tracer.startSpan(spanName, {
-          kind: SpanKind.CLIENT,
-          attributes: {
-            "gen_ai.operation.name": "chat",
-            "gen_ai.provider.name": p.providerID ?? "",
-            "gen_ai.request.model": p.model ?? "",
-            "gen_ai.conversation.id": p.sessionID ?? "",
-            "opencode.session.id": p.sessionID ?? "",
-            "langfuse.session.id": p.sessionID ?? "",
-            ...(p.inputMessages && _recordContent ? { "gen_ai.input.messages": p.inputMessages } : {}),
-            ...(p.systemInstructions && _recordContent
-              ? { "gen_ai.system_instructions": p.systemInstructions }
-              : {}),
-          },
-        }, getSessionOtelContext())
-        stepSpans.set(p.stepId, span)
-        setCurrentLlmSpan(span)
+      /**
+       * Model identity for the turn, from the two events that carry it. A span's name is
+       * fixed when it starts, so this has to be known before the turn's first step.
+       *
+       * `message.updated` is the authoritative one: an assistant message names the
+       * provider that actually served it, and it arrives on the same v1 surface as the
+       * parts below. Its fields are FLAT (`modelID`/`providerID`/`agent`, see
+       * SessionV1.Assistant) — reading a nested `model` object off it is what made an
+       * earlier revision of this handler name every span `chat unknown`.
+       * active-model.ts reads the same two events for the same reason.
+       */
+      case "session.next.model.switched":
+        rememberModelRef(p.sessionID ?? "", p.model)
+        break
+
+      case "message.updated": {
+        const info = p.info ?? {}
+        if (info.role !== "assistant") break
+        const sessionID = p.sessionID ?? info.sessionID ?? ""
+        rememberModel(sessionID, {
+          modelID: info.modelID,
+          providerID: info.providerID,
+          agent: info.agent,
+        })
         break
       }
 
-      // LLM step finished: close span, emit log, record metrics
-      case "v2.step.ended": {
-        const span = stepSpans.get(p.stepId)
-        if (span) {
-          const outputMessages = buildOutputMessages(p)
-          span.setAttributes({
-            "gen_ai.response.model": p.model ?? "",
-            "gen_ai.response.finish_reasons": [p.finishReason ?? "unknown"],
-            "gen_ai.usage.input_tokens": p.tokens?.input ?? 0,
-            "gen_ai.usage.output_tokens": p.tokens?.output ?? 0,
-            "gen_ai.usage.cache_read.input_tokens": p.tokens?.cache?.read ?? 0,
-            "gen_ai.usage.cache_creation.input_tokens": p.tokens?.cache?.write ?? 0,
-            "gen_ai.usage.reasoning.output_tokens": p.tokens?.reasoning ?? 0,
-            ...(outputMessages && _recordContent ? { "gen_ai.output.messages": outputMessages } : {}),
-          })
-          span.end()
-          stepSpans.delete(p.stepId)
-          clearCurrentLlmSpan(span)
+      /**
+       * Where the trajectory actually comes from.
+       *
+       * The handler used to build spans from `v2.step.*` / `v2.tool.*`, names nothing
+       * publishes: the durable bus calls them `session.next.*` (packages/schema
+       * session-event.ts). Renaming the subscriptions would not have been enough on its
+       * own, because those events come from the core session runner while cz runs the v1
+       * session (packages/opencode/src/session/session.ts), whose plugin surface is the
+       * message one — `message.part.updated`, `message.part.delta`, `message.updated`,
+       * `session.status`, `session.created`, `session.idle`. Every span-creating branch
+       * had therefore been dead code for as long as the rename, and telemetry carried
+       * session lifecycle records with no trajectory under them.
+       *
+       * There is one route that would deliver them: with OPENCODE_EXPERIMENTAL_EVENT_SYSTEM
+       * set, the v1 processor mirrors real `session.next.step.*` / `session.next.tool.*`
+       * lifecycle events (processor.ts:129 gates `mirrorAssistant`). Those are lifecycle,
+       * not state replication, so they would need none of the replay guards below. It is
+       * deliberately not taken: it is an experimental flag that also switches on v2
+       * assistant-message mirroring, and telemetry that only works when an upstream
+       * experiment is enabled is worse than telemetry built on the surface that is always
+       * there. If that flag ever becomes the default, this handler should move to it.
+       *
+       * Message parts carry what the GenAI spans need, so the span names and attributes
+       * below are the ones the old branches would have written:
+       *   step-start / step-finish  ->  `chat {model}`, usage + cost on close
+       *   tool                      ->  `execute_tool {tool}`, arguments + result
+       */
+      case "message.part.updated": {
+        // (accumulator defined below, after sessionID/messageID are known)
+        const part = p.part ?? {}
+        const sessionID = p.sessionID ?? part.sessionID ?? ""
+        // Parts are replayed outside any turn — see liveTurns. Everything below this line
+        // would otherwise re-record a forked session's entire history. The exception is a
+        // tool call this session already opened: its settlement legitimately arrives after
+        // idle on the abort path, and a call we watched start cannot be a replay.
+        const openCall =
+          part.type === "tool" && countedTools.get(`${sessionID}|${part.callID ?? part.id ?? ""}`) === sessionID
+        if (!liveTurns.has(sessionID) && !openCall) break
+        const messageID = part.messageID ?? ""
+        const model = sessionModels.get(sessionID)
+        const rememberOutput = () => {
+          if (!_recordContent || !messageID) return
+          const serialized = serializePart(part)
+          if (!serialized || !part.id) return
+          const acc = messageOutput.get(messageID) ?? new Map<string, Record<string, unknown>>()
+          acc.set(part.id, serialized)
+          messageOutput.set(messageID, acc)
         }
-        const tokens = p.tokens ?? {}
-        if (tokens.input) m.tokenUsage.record(tokens.input, { "gen_ai.token.type": "input", "gen_ai.provider.name": p.providerID ?? "", "gen_ai.request.model": p.model ?? "" })
-        if (tokens.output) m.tokenUsage.record(tokens.output, { "gen_ai.token.type": "output", "gen_ai.provider.name": p.providerID ?? "", "gen_ai.request.model": p.model ?? "" })
-        if (p.durationMs) m.operationDuration.record(p.durationMs / 1000, { "gen_ai.operation.name": "chat", "gen_ai.provider.name": p.providerID ?? "", "gen_ai.request.model": p.model ?? "" })
-        emitLog({
-          severityNumber: SeverityNumber.INFO,
-          severityText: "INFO",
-          body: "llm.step.finished",
-          eventName: "opencode.llm.step.finished",
-          attributes: sessionAttributes(p.sessionID, {
-            "gen_ai.provider.name": p.providerID ?? "",
-            "gen_ai.request.model": p.model ?? "",
-            "gen_ai.response.finish_reasons": p.finishReason ?? "unknown",
+
+        if (part.type === "text" || part.type === "reasoning") {
+          rememberOutput()
+          break
+        }
+
+        if (part.type === "step-start") {
+          // Both of these sit outside the `llm` gate below: disabling LLM traces must not
+          // strip the turn span's model attributes, drop the duration metric, or change
+          // what the turn's outcome is.
+          enrichTurnSpan(sessionID, messageID, model)
+          stepStartMs.set(messageID, { sessionID, startedMs: Date.now() })
+          // The turn continued past whatever error was published, so that error was not
+          // terminal — see recordTurnError.
+          clearTurnError(sessionID)
+          if (!tracingEnabled("llm")) break
+          // A message holds one step per LLM round trip, written in order, and
+          // step-start and step-finish share only the messageID — so that is the key.
+          // An open span under the same key belongs to a step that never finished.
+          const key = messageID
+          const stale = stepSpans.get(key)
+          if (stale) {
+            stale.span.end()
+            clearCurrentLlmSpan(stale.span)
+          }
+          const modelID = model?.modelID ?? "unknown"
+          const span = tracer.startSpan(`chat ${modelID}`, {
+            kind: SpanKind.CLIENT,
+            attributes: {
+              "gen_ai.operation.name": "chat",
+              "gen_ai.provider.name": model?.providerID ?? "",
+              "gen_ai.request.model": modelID,
+              "gen_ai.conversation.id": sessionID,
+              "opencode.session.id": sessionID,
+              "langfuse.session.id": sessionID,
+              ...(model?.agent ? { "gen_ai.agent.name": model.agent } : {}),
+              // Restored to parity with the pre-rebaseline handler, which carried these on
+              // the step event its own upstream patch published. Same attribute names, so
+              // the historical rows and the new ones line up.
+              ...(sessionInput.has(sessionID) ? { "gen_ai.input.messages": sessionInput.get(sessionID)! } : {}),
+              ...(sessionSystem.has(sessionID)
+                ? { "gen_ai.system_instructions": sessionSystem.get(sessionID)! }
+                : {}),
+            },
+          }, turnContext(sessionID))
+          stepSpans.set(key, { span, sessionID })
+          setCurrentLlmSpan(span)
+          break
+        }
+
+        if (part.type === "step-finish") {
+          const key = messageID
+          const entry = stepSpans.get(key)
+          const tokens = part.tokens ?? {}
+          const usage = {
             "gen_ai.usage.input_tokens": tokens.input ?? 0,
             "gen_ai.usage.output_tokens": tokens.output ?? 0,
+            "gen_ai.usage.reasoning.output_tokens": tokens.reasoning ?? 0,
             "gen_ai.usage.cache_read.input_tokens": tokens.cache?.read ?? 0,
             "gen_ai.usage.cache_creation.input_tokens": tokens.cache?.write ?? 0,
-            "gen_ai.usage.reasoning.output_tokens": tokens.reasoning ?? 0,
-            "opencode.llm.cost": p.cost ?? 0,
-            "opencode.llm.duration_ms": p.durationMs ?? 0,
-          }),
-        })
-        break
-      }
-
-      // Tool call started: open "execute_tool {name}" span per GenAI spec
-      case "v2.tool.called": {
-        m.toolCallCounter.add(1, { "gen_ai.tool.name": p.name ?? "unknown" })
-        if (!tracingEnabled("tool")) break
-        const toolInput = _recordContent && p.input != null ? safeStringify(p.input) : undefined
-        const span = tracer.startSpan(`execute_tool ${p.name ?? "unknown"}`, {
-          attributes: {
-            "gen_ai.operation.name": "execute_tool",
-            "gen_ai.tool.name": p.name ?? "",
-            "gen_ai.tool.call.id": p.id ?? "",
-            "opencode.session.id": p.sessionID ?? "",
-            ...(toolInput ? { "gen_ai.tool.call.arguments": toolInput } : {}),
-          },
-        }, getSessionOtelContext())
-        toolSpans.set(p.id, span)
-        break
-      }
-
-      // Tool call finished (success or error)
-      case "v2.tool.ended": {
-        const span = toolSpans.get(p.id)
-        if (span) {
-          if (!p.success) {
-            span.setStatus({ code: SpanStatusCode.ERROR, message: p.error ?? "unknown" })
-            m.errorCounter.add(1, { source: "tool", "gen_ai.tool.name": p.name ?? "unknown" })
           }
-          if (_recordContent && p.output) span.setAttribute("gen_ai.tool.call.result", p.output)
-          if (p.error) span.setAttribute("error.message", p.error)
-          span.end()
-          toolSpans.delete(p.id)
+          const started = stepStartMs.get(key)
+          stepStartMs.delete(key)
+          const durationMs = started ? Date.now() - started.startedMs : undefined
+          const output = messageOutput.get(key)
+          messageOutput.delete(key)
+          const outputMessages =
+            _recordContent && output?.size
+              ? promptAttr([{ role: "assistant", parts: [...output.values()], finish_reason: part.reason ?? "unknown" }])
+              : undefined
+          if (entry) {
+            entry.span.setAttributes({
+              "gen_ai.response.model": model?.modelID ?? "",
+              "gen_ai.response.finish_reasons": [part.reason ?? "unknown"],
+              ...usage,
+              ...(outputMessages ? { "gen_ai.output.messages": outputMessages } : {}),
+            })
+            entry.span.end()
+            stepSpans.delete(key)
+            clearCurrentLlmSpan(entry.span)
+          }
+          const modelAttrs = {
+            "gen_ai.provider.name": model?.providerID ?? "",
+            "gen_ai.request.model": model?.modelID ?? "",
+          }
+          if (tokens.input) m.tokenUsage.record(tokens.input, { "gen_ai.token.type": "input", ...modelAttrs })
+          if (tokens.output) m.tokenUsage.record(tokens.output, { "gen_ai.token.type": "output", ...modelAttrs })
+          if (durationMs != null) m.operationDuration.record(durationMs / 1000, { "gen_ai.operation.name": "chat", ...modelAttrs })
+          emitLog({
+            severityNumber: SeverityNumber.INFO,
+            severityText: "INFO",
+            body: "llm.step.finished",
+            eventName: "opencode.llm.step.finished",
+            sessionID: sessionID ?? "",
+            attributes: sessionAttributes(sessionID, {
+              ...modelAttrs,
+              "gen_ai.response.finish_reasons": part.reason ?? "unknown",
+              ...usage,
+              "opencode.llm.cost": part.cost ?? 0,
+              ...(durationMs != null ? { "opencode.llm.duration_ms": durationMs } : {}),
+            }),
+          })
+          break
         }
-        if (p.durationMs) m.toolCallDuration.record(p.durationMs / 1000, { "gen_ai.tool.name": p.name ?? "unknown" })
-        emitLog({
-          severityNumber: p.success ? SeverityNumber.INFO : SeverityNumber.ERROR,
-          severityText: p.success ? "INFO" : "ERROR",
-          body: p.success ? "tool.call.completed" : "tool.call.failed",
-          eventName: "opencode.tool.finished",
-          attributes: sessionAttributes(p.sessionID, {
-            "gen_ai.tool.name": p.name ?? "",
-            "gen_ai.tool.call.id": p.id ?? "",
-            "opencode.tool.duration_ms": p.durationMs ?? 0,
-            ...(p.error ? { "error.message": p.error } : {}),
-          }),
-        })
+
+        if (part.type === "tool") {
+          const state = part.state ?? {}
+          const status = state.status ?? ""
+          const toolName = part.tool ?? "unknown"
+          const callID = part.callID ?? part.id ?? ""
+          if (!callID) break
+          const key = `${sessionID}|${callID}`
+          // `compaction.prune` rewrites completed tool parts from turns that already ended
+          // (it skips the two most recent, compaction.ts:264) and stamps `time.compacted`
+          // on exactly what it rewrites (compaction.ts:284). Those callIDs left the dedupe
+          // sets when their turn ended, so the marker is what identifies them; a live
+          // settle never carries it.
+          if (state.time?.compacted != null) break
+          rememberOutput()
+
+          // A call surfaces once per state transition (pending -> running -> settled), so
+          // the counter is guarded by callID and not by the span, which is absent when
+          // tool tracing is off.
+          if (!countedTools.has(key)) {
+            countedTools.set(key, sessionID)
+            m.toolCallCounter.add(1, { "gen_ai.tool.name": toolName })
+          }
+
+          const settled = status === "completed" || status === "error"
+          if (!settled) {
+            const args =
+              _recordContent && state.input != null
+                ? cap(safeStringify(redactDeep(state.input, CONTENT_MAX_CHARS)))
+                : undefined
+            const open = toolSpans.get(key)
+            if (open) {
+              // The first state a call surfaces in is always `pending`, whose input is an
+              // empty object (processor.ts:333). The real arguments arrive with the
+              // `running` transition (processor.ts:503-514), so this event refreshes the
+              // attribute instead of being dropped — otherwise every span shipped `{}`.
+              if (args) open.span.setAttribute("gen_ai.tool.call.arguments", args)
+              break
+            }
+            if (!tracingEnabled("tool")) break
+            const span = tracer.startSpan(`execute_tool ${toolName}`, {
+              attributes: {
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": toolName,
+                // Recommended by the convention and previously missing; these tools run
+                // in this process, so `function`.
+                "gen_ai.tool.type": "function",
+                "gen_ai.tool.call.id": callID,
+                "opencode.session.id": sessionID,
+                ...(args ? { "gen_ai.tool.call.arguments": args } : {}),
+              },
+            }, turnContext(sessionID))
+            toolSpans.set(key, { span, sessionID })
+            break
+          }
+
+          if (settledTools.has(key)) break
+          settledTools.add(key)
+          const failed = status === "error"
+          // `ToolStateError.error` is a plain string in the v1 schema.
+          const message = failed ? String(state.error || "unknown") : ""
+          // Settled tool states carry their own start/end, so the duration is the
+          // runtime's own rather than one measured around the event.
+          const durationMs =
+            typeof state.time?.end === "number" && typeof state.time?.start === "number"
+              ? state.time.end - state.time.start
+              : undefined
+          const entry = toolSpans.get(key)
+          if (entry) {
+            if (failed) {
+              entry.span.setStatus({ code: SpanStatusCode.ERROR, message })
+              entry.span.setAttribute("error.message", message)
+            } else if (_recordContent && state.output) {
+              entry.span.setAttribute(
+                "gen_ai.tool.call.result",
+                cap(redactText(capTo(String(state.output), CONTENT_MAX_CHARS))),
+              )
+            }
+            entry.span.end()
+            toolSpans.delete(key)
+          }
+          if (failed) m.errorCounter.add(1, { source: "tool", "gen_ai.tool.name": toolName })
+          if (durationMs != null) m.toolCallDuration.record(durationMs / 1000, { "gen_ai.tool.name": toolName })
+          emitLog({
+            severityNumber: failed ? SeverityNumber.ERROR : SeverityNumber.INFO,
+            severityText: failed ? "ERROR" : "INFO",
+            body: failed ? "tool.call.failed" : "tool.call.completed",
+            eventName: "opencode.tool.finished",
+            sessionID: sessionID ?? "",
+            attributes: sessionAttributes(sessionID, {
+              "gen_ai.tool.name": toolName,
+              "gen_ai.tool.call.id": callID,
+              ...(durationMs != null ? { "opencode.tool.duration_ms": durationMs } : {}),
+              ...(failed ? { "error.message": message } : {}),
+            }),
+          })
+        }
         break
       }
     }
-  } catch {}
+  } catch {
+    // Never let telemetry break a turn — but do not let it fail invisibly either. A silent
+    // catch is how the original bug survived; this counter is the runtime signal that the
+    // payload shapes this handler reads have drifted again.
+    try {
+      m.errorCounter.add(1, { source: "otel_handler" })
+    } catch {}
+  }
 }
 
 export function shutdown() {
-  endPromptSpan()
-  endPreflightSpan()
+  for (const sessionID of [...turnSpans.keys()]) endTurn(sessionID)
+  clearSessionSpanContexts()
   setCurrentLlmSpan(undefined)
-  for (const span of stepSpans.values()) span.end()
-  for (const span of toolSpans.values()) span.end()
+  for (const entry of stepSpans.values()) entry.span.end()
+  for (const entry of toolSpans.values()) entry.span.end()
   stepSpans.clear()
   toolSpans.clear()
+  countedTools.clear()
+  settledTools.clear()
+  stepStartMs.clear()
+  turnSpans.clear()
+  turnEnriched.clear()
+  liveTurns.clear()
+  pendingErrors.clear()
+  sessionModels.clear()
+  sessionParents.clear()
+  sessionInput.clear()
+  sessionSystem.clear()
+  messageOutput.clear()
   sessionStartMs.clear()
+  contextOwner = undefined
   setCurrentSessionSpanContext(undefined)
 }

--- a/packages/cz-cli/src/opencode-plugin/otel/index.ts
+++ b/packages/cz-cli/src/opencode-plugin/otel/index.ts
@@ -1,7 +1,14 @@
 import type { Plugin } from "@opencode-ai/plugin"
+import type { Event } from "@opencode-ai/sdk"
 import { initOtelSdk, type OtelSdk } from "./setup"
-import { handleEvent, initHandlers, shutdown as shutdownHandlers } from "./handlers"
-import { getCurrentSessionTraceparent } from "./context"
+import {
+  handleEvent,
+  initHandlers,
+  recordInputMessages,
+  recordSystemInstructions,
+  shutdown as shutdownHandlers,
+} from "./handlers"
+import { getSessionTraceparent } from "./context"
 import { createTraceparent } from "./traceparent"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -50,7 +57,21 @@ export const OtelPlugin: Plugin = Object.assign(
 
     if (sdk) {
       initHandlers(sdk.logger, process.env.OPENCODE_OTEL_RECORD_CONTENT !== "0")
-      const flush = () => sdk!.shutdown().catch(() => {})
+      // End the spans still open before the SDK stops accepting them: without this the
+      // turn, step and tool spans live at exit are dropped rather than exported late.
+      // One-shot: `flush` now wipes handler state as well as stopping the SDK, and
+      // `beforeExit` can fire more than once because this handler itself schedules async
+      // work. A second run would leave spans being created against a shut-down SDK and
+      // silently dropped.
+      let flushed: Promise<void> | undefined
+      const flush = () => {
+        if (flushed) return flushed
+        try {
+          shutdownHandlers()
+        } catch {}
+        flushed = sdk!.shutdown().catch(() => {})
+        return flushed
+      }
       globalFlush = flush
       ;(globalThis as any).__otelFlush = flush
       process.on("beforeExit", flush)
@@ -59,11 +80,33 @@ export const OtelPlugin: Plugin = Object.assign(
     }
 
     return {
-      async event({ event }: { event: { type: string; properties: Record<string, any> } }) {
+      // Typed from the published union rather than widened to `{ type: string }`, which is
+      // what allowed a subscription to a nonexistent event name to compile.
+      async event({ event }: { event: Event }) {
         handleEvent(event)
       },
-      async "shell.env"(_input: unknown, output: { env: Record<string, string> }) {
-        const sessionTp = getCurrentSessionTraceparent()
+      // The prompt as it is about to be sent. Both hooks fire per step, before the LLM
+      // call, so the `chat` span can carry the content from the moment it opens. This is
+      // the channel the pre-rebaseline handler got from an upstream patch on llm.ts; these
+      // hooks make it a cz-layer read instead.
+      async "experimental.chat.messages.transform"(
+        _input: unknown,
+        output: { messages: Array<{ info?: Record<string, any>; parts?: Record<string, any>[] }> },
+      ) {
+        recordInputMessages(output?.messages ?? [])
+      },
+      async "experimental.chat.system.transform"(
+        input: { sessionID?: string; model?: unknown },
+        output: { system: string[] },
+      ) {
+        recordSystemInstructions(input?.sessionID, output?.system ?? [])
+      },
+      async "shell.env"(
+        input: { cwd: string; sessionID?: string; callID?: string },
+        output: { env: Record<string, string> },
+      ) {
+        // The shell and task tools both supply sessionID; only the pty paths omit it.
+        const sessionTp = getSessionTraceparent(input?.sessionID)
         if (sessionTp) output.env.CLICKZETTA_TRACEPARENT = createTraceparent(sessionTp)
       },
     }

--- a/packages/cz-cli/src/opencode-plugin/outbound-headers.ts
+++ b/packages/cz-cli/src/opencode-plugin/outbound-headers.ts
@@ -6,6 +6,7 @@ export const ClickzettaOutboundHeadersPlugin: Plugin = async (_input: PluginInpu
   "chat.headers": async (input, output) => {
     const baseURL = typeof input.provider?.options?.["baseURL"] === "string" ? input.provider.options["baseURL"] : undefined
     if (!isClickzettaGatewayUrl(baseURL)) return
-    output.headers.traceparent = currentTraceparent()
+    // `sessionID` is required on this hook, so the header carries this session own trace.
+    output.headers.traceparent = currentTraceparent(input.sessionID)
   },
 })

--- a/packages/cz-cli/src/opencode-plugin/traceparent.ts
+++ b/packages/cz-cli/src/opencode-plugin/traceparent.ts
@@ -1,6 +1,6 @@
 import { context, trace, TraceFlags } from "@opentelemetry/api"
 import { createTraceparent } from "@clickzetta/sdk"
-import { getCurrentSessionTraceparent } from "./otel/context.js"
+import { getSessionTraceparent } from "./otel/context.js"
 
 function activeTraceparent() {
   const span = trace.getSpan(context.active())
@@ -10,6 +10,11 @@ function activeTraceparent() {
   return `00-${spanContext.traceId}-${spanContext.spanId}-${spanContext.traceFlags === TraceFlags.SAMPLED ? "01" : "00"}`
 }
 
-export function currentTraceparent() {
-  return createTraceparent(activeTraceparent() ?? getCurrentSessionTraceparent() ?? process.env.CLICKZETTA_TRACEPARENT)
+/**
+ * `sessionID` is optional only for callers that genuinely lack one (the pty paths). Pass it
+ * whenever it is available: without it the fallback is the process-wide slot, which under
+ * `serve` belongs to whichever session opened a turn first.
+ */
+export function currentTraceparent(sessionID?: string) {
+  return createTraceparent(activeTraceparent() ?? getSessionTraceparent(sessionID) ?? process.env.CLICKZETTA_TRACEPARENT)
 }

--- a/packages/cz-cli/src/telemetry.ts
+++ b/packages/cz-cli/src/telemetry.ts
@@ -46,7 +46,7 @@ export const SENSITIVE_KEYS: ReadonlySet<string> = new Set([
  * `X-Api-Key=…` are the same hazard as `Cookie=…`. `eqIdx > 0` keeps a SQL statement
  * intact — in `select * from t where id=1` the part before `=` is not a credential name.
  */
-function isSensitiveValue(value: string): boolean {
+export function isSensitiveValue(value: string): boolean {
   const eqIdx = value.indexOf("=")
   return eqIdx > 0 && isSensitiveKey(value.slice(0, eqIdx).trim())
 }

--- a/packages/cz-cli/test/otel-event-contract.test.ts
+++ b/packages/cz-cli/test/otel-event-contract.test.ts
@@ -1,0 +1,108 @@
+import { expect, test, describe } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+/**
+ * The OTel handler subscribes to runtime events by string. Nothing links those
+ * strings to the schema that defines them, so when the runtime renamed
+ * `v2.tool.called` to `session.next.tool.called` the handler kept compiling, kept
+ * loading, and simply stopped receiving tool and step events. Agent trajectory spans
+ * disappeared from telemetry for days without a single failure anywhere: every
+ * span-creating branch had quietly become dead code.
+ *
+ * These tests are the missing link. A rename now fails here instead of silently
+ * draining the trace.
+ */
+
+const ROOT = join(import.meta.dir, "..", "..", "..")
+const HANDLERS = join(ROOT, "packages/cz-cli/src/opencode-plugin/otel/handlers.ts")
+const SCHEMAS = [
+  "packages/schema/src/session-event.ts",
+  "packages/schema/src/session-v1.ts",
+  "packages/schema/src/session-status-event.ts",
+].map((p) => join(ROOT, p))
+
+/**
+ * Only the `case` labels inside `handleEvent` are event subscriptions. The file has other
+ * switches — `serializePart` dispatches on message part types — and scanning the whole
+ * source counted those as subscribed events.
+ */
+function subscribedEvents(): string[] {
+  const source = readFileSync(HANDLERS, "utf-8")
+  const start = source.indexOf("export function handleEvent(")
+  expect(start).toBeGreaterThan(-1)
+  const end = source.indexOf("} catch {}", start)
+  expect(end).toBeGreaterThan(start)
+  const body = source.slice(start, end)
+  return [...body.matchAll(/case\s+"([a-z0-9._]+)"/g)].map((m) => m[1]!)
+}
+
+/**
+ * Event names the schema defines. The file list is fixed on purpose: it is the set of
+ * surfaces a plugin can receive, so a subscription to something outside it is the very
+ * mistake this guards. A legitimate new surface means adding the file here.
+ */
+function publishedEvents(): Set<string> {
+  const names = new Set<string>()
+  for (const file of SCHEMAS) {
+    const source = readFileSync(file, "utf-8")
+    for (const m of source.matchAll(/type:\s*"([a-z0-9._]+)"/g)) names.add(m[1]!)
+  }
+  return names
+}
+
+/**
+ * The surface a plugin is actually delivered, measured by instrumenting the hook on
+ * 2026-08-24. "Defined in the schema" is a weaker property than "delivered here": the
+ * `session.next.*` events are all real schema entries, published from the core session
+ * runner, and a v1-path plugin never sees them — which is the failure this suite exists
+ * for. So subscriptions are checked against this list, not only against the schema.
+ */
+const DELIVERED = new Set([
+  "session.created",
+  "session.deleted",
+  "session.status",
+  "session.idle",
+  "session.error",
+  "message.updated",
+  "message.part.updated",
+  "message.part.delta",
+  // The one `session.next.*` name that reaches a v1-path plugin. Published from the v1
+  // prompt path at prompt.ts:712, but only when the resolved model differs from the
+  // session's (the guard at :707-711) — so it is a supplement, never the primary source of
+  // model identity. That is `message.updated`, which fires for every assistant message.
+  "session.next.model.switched",
+])
+
+describe("otel handler event contract", () => {
+  test("subscribes to at least the events it needs to build a trajectory", () => {
+    const subscribed = subscribedEvents()
+    // Measured by instrumenting the hook on 2026-08-24: a plugin receives the v1
+    // message surface, not the durable `session.next.*` bus. Spans are therefore
+    // built from message parts, and losing either of these silently empties the
+    // trace of every `chat` and `execute_tool` span — the state that went unnoticed
+    // for days after the runtime renamed its internal events.
+    // session.status is the turn anchor: it is the first signal of a turn on the v1 path,
+    // and several failures are published before any part exists.
+    for (const required of ["session.status", "message.part.updated", "message.updated"]) {
+      expect(subscribed).toContain(required)
+    }
+  })
+
+  test("every subscribed event is one the schema actually defines", () => {
+    const published = publishedEvents()
+    expect(published.size).toBeGreaterThan(20)
+    const orphans = subscribedEvents().filter((name) => !published.has(name))
+    expect(orphans).toEqual([])
+  })
+
+  test("every subscribed event is one this path actually delivers", () => {
+    const undelivered = subscribedEvents().filter((name) => !DELIVERED.has(name))
+    expect(undelivered).toEqual([])
+  })
+
+  test("no v2.* subscriptions survive", () => {
+    const stale = subscribedEvents().filter((name) => name.startsWith("v2."))
+    expect(stale).toEqual([])
+  })
+})

--- a/packages/cz-cli/test/otel-span-build.test.ts
+++ b/packages/cz-cli/test/otel-span-build.test.ts
@@ -1,0 +1,874 @@
+import { expect, test, describe, beforeEach } from "bun:test"
+import { InMemorySpanExporter, SimpleSpanProcessor, BasicTracerProvider } from "@opentelemetry/sdk-trace-base"
+import { trace } from "@opentelemetry/api"
+
+/**
+ * Spans built from real event payloads.
+ *
+ * The contract test next door compares subscribed event NAMES against the schema. It
+ * cannot see the other half of the same bug: a branch that subscribes to a live event
+ * and then reads a field the payload does not have. That is how `chat unknown` shipped
+ * — the handler read `info.model.modelID` while SessionV1.Assistant carries a flat
+ * `modelID`. Nothing failed, the span was just anonymous.
+ *
+ * So these drive the payload shapes from packages/schema/src/session-v1.ts through
+ * handleEvent and assert on what came out.
+ */
+const exporter = new InMemorySpanExporter()
+const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] })
+trace.setGlobalTracerProvider(provider)
+
+const { handleEvent, initHandlers, shutdown } = await import("../src/opencode-plugin/otel/handlers")
+
+const SESSION = "ses_test"
+const MESSAGE = "msg_test"
+
+/**
+ * Log records are captured too. Some duplicate-emission bugs never touch a span — a
+ * republished settled tool part has no span left to end, so the only visible damage is a
+ * second log record and a second metric sample.
+ */
+const records: Array<Record<string, any>> = []
+const logger = { emit: (record: Record<string, any>) => records.push(record) }
+
+function emitted(eventName: string) {
+  return records.filter((r) => r.attributes?.["event.name"] === eventName)
+}
+
+function send(type: string, properties: Record<string, any>) {
+  handleEvent({ type, properties })
+}
+
+/** An assistant message as the v1 session publishes it: model fields are flat. */
+function assistantMessage(modelID = "claude-opus-5", providerID = "clickzetta") {
+  send("message.updated", {
+    sessionID: SESSION,
+    info: { role: "assistant", sessionID: SESSION, id: MESSAGE, modelID, providerID, agent: "data_engineer" },
+  })
+}
+
+/** A turn begins when the session goes busy, before any message or part exists. */
+function busy(sessionID = SESSION) {
+  send("session.status", { sessionID, status: { type: "busy" } })
+}
+
+function part(partial: Record<string, any>) {
+  send("message.part.updated", {
+    sessionID: SESSION,
+    part: { sessionID: SESSION, messageID: MESSAGE, ...partial },
+  })
+}
+
+function named(name: string) {
+  return exporter.getFinishedSpans().filter((s) => s.name === name)
+}
+
+beforeEach(() => {
+  shutdown()
+  exporter.reset()
+  records.length = 0
+  initHandlers(logger as any, true)
+})
+
+describe("spans built from v1 message parts", () => {
+  test("a step names the model the assistant message reported", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    part({
+      id: "prt_2",
+      type: "step-finish",
+      reason: "stop",
+      cost: 0.01,
+      tokens: { input: 100, output: 20, reasoning: 0, cache: { read: 5, write: 6 } },
+    })
+    send("session.idle", { sessionID: SESSION })
+
+    const [chat] = named("chat claude-opus-5")
+    expect(chat).toBeDefined()
+    expect(chat!.attributes["gen_ai.provider.name"]).toBe("clickzetta")
+    expect(chat!.attributes["gen_ai.usage.input_tokens"]).toBe(100)
+    expect(chat!.attributes["gen_ai.usage.cache_read.input_tokens"]).toBe(5)
+    expect(chat!.attributes["gen_ai.usage.cache_creation.input_tokens"]).toBe(6)
+    expect(named("chat unknown")).toHaveLength(0)
+  })
+
+  test("an explicit model switch also names the span", () => {
+    busy()
+    send("session.next.model.switched", {
+      sessionID: SESSION,
+      model: { id: "claude-sonnet-5", providerID: "clickzetta" },
+    })
+    part({ id: "prt_1", type: "step-start" })
+    send("session.idle", { sessionID: SESSION })
+    expect(named("chat claude-sonnet-5")).toHaveLength(1)
+  })
+
+  test("a tool call becomes one span with arguments, result and the runtime's duration", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    // The runtime always publishes `pending` with an empty input first, and the real
+    // arguments only with the `running` transition.
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: { status: "pending", input: {}, raw: "" },
+    })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: { status: "running", input: { command: "ls" }, time: { start: 1000 } },
+    })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: {
+        status: "completed",
+        input: { command: "ls" },
+        output: "a.ts",
+        title: "ls",
+        metadata: {},
+        time: { start: 1000, end: 3500 },
+      },
+    })
+    send("session.idle", { sessionID: SESSION })
+
+    const [tool] = named("execute_tool bash")
+    expect(tool).toBeDefined()
+    expect(tool!.attributes["gen_ai.tool.call.arguments"]).toBe(JSON.stringify({ command: "ls" }))
+    expect(tool!.attributes["gen_ai.tool.call.result"]).toBe("a.ts")
+    expect(tool!.attributes["gen_ai.tool.call.id"]).toBe("call_1")
+  })
+
+  test("a failed tool is recorded on the tool span without failing the turn", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: { status: "pending", input: {}, raw: "" },
+    })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: { status: "error", input: {}, error: "exit 1", time: { start: 1, end: 2 } },
+    })
+    send("session.idle", { sessionID: SESSION })
+
+    const [tool] = named("execute_tool bash")
+    expect(tool!.attributes["error.message"]).toBe("exit 1")
+    // The agent usually recovers from a tool error; the turn's own verdict comes from
+    // the assistant message, so a recovered turn must not be reported as failed.
+    expect(named("prompt")[0]!.attributes["opencode.turn.outcome"]).toBe("completed")
+  })
+
+  test("a session error is not reported as a completed turn", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    send("session.error", { sessionID: SESSION, error: { name: "APIError", data: { message: "boom" } } })
+    send("session.idle", { sessionID: SESSION })
+    expect(named("prompt")[0]!.attributes["opencode.turn.outcome"]).toBe("error")
+  })
+
+  test("a turn that dies before its first step still produces a span", () => {
+    // prompt.ts publishes session.error from model resolution and permission paths that
+    // run before any part is written, so the turn cannot be anchored on the first step.
+    busy()
+    send("session.error", { sessionID: SESSION, error: { name: "ProviderAuthError", data: { message: "no key" } } })
+    send("session.idle", { sessionID: SESSION })
+    const [turn] = named("prompt")
+    expect(turn).toBeDefined()
+    expect(turn!.attributes["opencode.turn.outcome"]).toBe("error")
+  })
+
+  test("a turn that recovers by compacting is not reported as failed", () => {
+    // processor.ts publishes ContextOverflowError and then compacts and continues in the
+    // same turn, so that error event on its own is not a verdict.
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    send("session.error", { sessionID: SESSION, error: { name: "ContextOverflowError", data: { message: "too long" } } })
+    // Compaction re-runs the turn: another step start is what marks it as continuing.
+    part({ id: "prt_1b", type: "step-start" })
+    part({
+      id: "prt_2",
+      type: "step-finish",
+      reason: "stop",
+      cost: 0,
+      tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+    })
+    send("session.idle", { sessionID: SESSION })
+    expect(named("prompt")[0]!.attributes["opencode.turn.outcome"]).toBe("completed")
+  })
+
+  test("a terminal overflow fails the turn, in the order the runtime emits it", () => {
+    // With auto-compaction off, halt publishes the error and goes idle; the message that
+    // carries `error` is only published afterwards by the cleanup finalizer, so the
+    // verdict has to come from the error not being followed by another step.
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    send("session.error", { sessionID: SESSION, error: { name: "ContextOverflowError", data: { message: "too long" } } })
+    send("session.idle", { sessionID: SESSION })
+    send("message.updated", {
+      sessionID: SESSION,
+      info: {
+        role: "assistant",
+        sessionID: SESSION,
+        id: MESSAGE,
+        modelID: "claude-opus-5",
+        providerID: "clickzetta",
+        agent: "data_engineer",
+        finish: "error",
+        error: { name: "ContextOverflowError", data: { message: "too long" } },
+      },
+    })
+    const [turn] = named("prompt")
+    expect(turn!.attributes["opencode.turn.outcome"]).toBe("error")
+    expect(turn!.status.code).toBe(2)
+  })
+
+  test("a late error message does not bleed into the next turn", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    send("session.error", { sessionID: SESSION, error: { name: "APIError", data: { message: "boom" } } })
+    send("session.idle", { sessionID: SESSION })
+    busy()
+    part({ id: "prt_2", type: "step-start" })
+    send("session.idle", { sessionID: SESSION })
+    const turns = named("prompt")
+    expect(turns.map((t) => t.attributes["opencode.turn.outcome"])).toEqual(["error", "completed"])
+  })
+
+  test("the turn carries the model once its first step lands", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    send("session.idle", { sessionID: SESSION })
+    const [turn] = named("prompt")
+    expect(turn!.attributes["gen_ai.request.model"]).toBe("claude-opus-5")
+    expect(turn!.attributes["opencode.agent.name"]).toBe("data_engineer")
+  })
+
+  test("steps and tools hang under their own session's turn", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    send("session.idle", { sessionID: SESSION })
+    const [turn] = named("prompt")
+    const [chat] = named("chat claude-opus-5")
+    expect(chat!.parentSpanContext?.spanId).toBe(turn!.spanContext().spanId)
+  })
+
+  test("a concurrent session gets its own turn, and one going idle does not close the other", () => {
+    const OTHER = "ses_other"
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    busy(OTHER)
+    send("message.updated", {
+      sessionID: OTHER,
+      info: { role: "assistant", sessionID: OTHER, id: "msg_other", modelID: "m2", providerID: "p2", agent: "x" },
+    })
+    send("message.part.updated", {
+      sessionID: OTHER,
+      part: { sessionID: OTHER, messageID: "msg_other", id: "prt_o", type: "step-start" },
+    })
+    send("session.idle", { sessionID: SESSION })
+
+    const turns = named("prompt")
+    expect(turns).toHaveLength(1)
+    expect(turns[0]!.attributes["opencode.session.id"]).toBe(SESSION)
+
+    send("session.idle", { sessionID: OTHER })
+    const both = named("prompt")
+    expect(both).toHaveLength(2)
+    expect(both[1]!.attributes["opencode.session.id"]).toBe(OTHER)
+    expect(named("chat m2")[0]!.attributes["opencode.session.id"]).toBe(OTHER)
+  })
+
+  test("an aborted turn does not leave its step span open", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    send("session.idle", { sessionID: SESSION })
+    expect(named("chat claude-opus-5")).toHaveLength(1)
+  })
+})
+
+describe("the process-wide session slot", () => {
+  test("is cleared by its owner rather than handed to an unrelated session", async () => {
+    const { getSessionSpanRef } = await import("../src/opencode-plugin/otel/context")
+    const OTHER = "ses_other"
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    busy(OTHER)
+    send("message.updated", {
+      sessionID: OTHER,
+      info: { role: "assistant", sessionID: OTHER, id: "msg_o", modelID: "m2", providerID: "p2", agent: "x" },
+    })
+    send("message.part.updated", {
+      sessionID: OTHER,
+      part: { sessionID: OTHER, messageID: "msg_o", id: "prt_o", type: "step-start" },
+    })
+    expect(getSessionSpanRef()).toBeDefined()
+    send("session.idle", { sessionID: SESSION })
+    // Under `serve` the remaining turn belongs to an unrelated session; attributing
+    // shells and log records to it would be worse than attributing to nothing.
+    expect(getSessionSpanRef()).toBeUndefined()
+  })
+})
+
+describe("replayed parts", () => {
+  test("a forked session's history produces no spans, metrics or logs", () => {
+    // Session.fork republishes every historical part through updatePart, outside any busy
+    // window. Without the gate this re-records the whole history.
+    send("message.updated", {
+      sessionID: "ses_fork",
+      info: { role: "assistant", sessionID: "ses_fork", id: "msg_h", modelID: "m", providerID: "p", agent: "a" },
+    })
+    send("message.part.updated", {
+      sessionID: "ses_fork",
+      part: { sessionID: "ses_fork", messageID: "msg_h", id: "prt_h1", type: "step-start" },
+    })
+    send("message.part.updated", {
+      sessionID: "ses_fork",
+      part: {
+        sessionID: "ses_fork",
+        messageID: "msg_h",
+        id: "prt_h2",
+        type: "step-finish",
+        reason: "stop",
+        cost: 1,
+        tokens: { input: 9999, output: 9999, reasoning: 0, cache: { read: 0, write: 0 } },
+      },
+    })
+    expect(exporter.getFinishedSpans()).toHaveLength(0)
+    expect(emitted("opencode.llm.step.finished")).toHaveLength(0)
+  })
+
+  test("a settled tool republished by prune is recorded once, even a turn later", () => {
+    // prune skips the two most recent turns, so what it rewrites belongs to a turn whose
+    // dedupe keys were already purged — the compacted marker is what identifies it.
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    const settled = {
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: {
+        status: "completed",
+        input: { command: "ls" },
+        output: "a.ts",
+        title: "ls",
+        metadata: {},
+        time: { start: 1000, end: 2000 },
+      },
+    }
+    part({ ...settled, state: { status: "pending", input: {}, raw: "" } })
+    part(settled)
+    send("session.idle", { sessionID: SESSION })
+
+    // A later turn is live when prune's rewrite lands.
+    busy()
+    part({ id: "prt_3", type: "step-start" })
+    part({ ...settled, state: { ...settled.state, time: { start: 1000, end: 2000, compacted: 3000 } } })
+    send("session.idle", { sessionID: SESSION })
+
+    expect(named("execute_tool bash")).toHaveLength(1)
+    // The replay has no span left to close, so the log record is where a second settle
+    // shows up — along with the counter and duration histogram beside it.
+    expect(emitted("opencode.tool.finished")).toHaveLength(1)
+  })
+})
+
+describe("subagent sessions", () => {
+  test("a child turn hangs under its parent's turn instead of starting a detached trace", () => {
+    const CHILD = "ses_child"
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    // task.ts creates the subagent session with parentID set.
+    send("session.created", { sessionID: CHILD, info: { id: CHILD, parentID: SESSION } })
+    busy(CHILD)
+    send("message.updated", {
+      sessionID: CHILD,
+      info: { role: "assistant", sessionID: CHILD, id: "msg_c", modelID: "m2", providerID: "p2", agent: "sub" },
+    })
+    send("message.part.updated", {
+      sessionID: CHILD,
+      part: { sessionID: CHILD, messageID: "msg_c", id: "prt_c", type: "step-start" },
+    })
+    send("session.idle", { sessionID: CHILD })
+    send("session.idle", { sessionID: SESSION })
+
+    const turns = named("prompt")
+    const child = turns.find((t) => t.attributes["opencode.session.id"] === CHILD)!
+    const parent = turns.find((t) => t.attributes["opencode.session.id"] === SESSION)!
+    expect(child.attributes["opencode.session.parent.id"]).toBe(SESSION)
+    expect(child.parentSpanContext?.spanId).toBe(parent.spanContext().spanId)
+    expect(child.spanContext().traceId).toBe(parent.spanContext().traceId)
+  })
+
+  test("a turn whose model arrives late still gets it", () => {
+    // The latch must key on the model being known, not on having been called once.
+    busy()
+    part({ id: "prt_1", type: "step-start" })
+    assistantMessage()
+    part({ id: "prt_2", type: "step-start" })
+    send("session.idle", { sessionID: SESSION })
+    expect(named("prompt")[0]!.attributes["gen_ai.request.model"]).toBe("claude-opus-5")
+  })
+})
+
+describe("tool content", () => {
+  test("is capped so an oversized attribute cannot cost the span", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    const huge = "x".repeat(20_000)
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "read",
+      state: { status: "running", input: { file: huge }, time: { start: 1 } },
+    })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "read",
+      state: {
+        status: "completed",
+        input: { file: huge },
+        output: huge,
+        title: "read",
+        metadata: {},
+        time: { start: 1, end: 2 },
+      },
+    })
+    send("session.idle", { sessionID: SESSION })
+    const [tool] = named("execute_tool read")
+    for (const key of ["gen_ai.tool.call.arguments", "gen_ai.tool.call.result"]) {
+      const value = String(tool!.attributes[key])
+      expect(value.length).toBeLessThan(9_000)
+      expect(value).toContain("[truncated")
+    }
+  })
+})
+
+describe("log records", () => {
+  test("follow their own session's turn, not whichever session got there first", () => {
+    const OTHER = "ses_other"
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    busy(OTHER)
+    send("message.updated", {
+      sessionID: OTHER,
+      info: { role: "assistant", sessionID: OTHER, id: "msg_o", modelID: "m2", providerID: "p2", agent: "x" },
+    })
+    send("message.part.updated", {
+      sessionID: OTHER,
+      part: { sessionID: OTHER, messageID: "msg_o", id: "prt_o", type: "step-start" },
+    })
+    send("session.error", { sessionID: OTHER, error: { name: "APIError", data: { message: "boom" } } })
+    send("session.idle", { sessionID: OTHER })
+    send("session.idle", { sessionID: SESSION })
+
+    const turns = named("prompt")
+    const other = turns.find((t) => t.attributes["opencode.session.id"] === OTHER)!
+    const [record] = emitted("opencode.session.error")
+    // The first session owns the process-wide slot; the record must still land under the
+    // turn of the session it describes.
+    const parent = trace.getSpanContext(record!.context)
+    expect(parent?.spanId).toBe(other.spanContext().spanId)
+  })
+})
+
+describe("an interrupted tool", () => {
+  test("still reports its error, though the settlement lands after idle", () => {
+    // On abort, `halt` sets the session idle and only then does `cleanup()` republish every
+    // running call as "Tool execution aborted" — `ensuring` is the outermost stage of the
+    // pipeline. A gate that only admits parts during a live turn discards exactly this.
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: { status: "pending", input: {}, raw: "" },
+    })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: { status: "running", input: { command: "sleep 100" }, time: { start: 1000 } },
+    })
+    send("session.idle", { sessionID: SESSION })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: {
+        status: "error",
+        input: { command: "sleep 100" },
+        error: "Tool execution aborted",
+        metadata: { interrupted: true },
+        time: { start: 1000, end: 2000 },
+      },
+    })
+
+    const [tool] = named("execute_tool bash")
+    expect(tool).toBeDefined()
+    expect(tool!.status.code).toBe(2)
+    expect(tool!.attributes["error.message"]).toBe("Tool execution aborted")
+    expect(tool!.attributes["gen_ai.tool.call.arguments"]).toBe(JSON.stringify({ command: "sleep 100" }))
+    expect(emitted("opencode.tool.finished")).toHaveLength(1)
+  })
+
+  test("is given up on if a later turn starts without it ever settling", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: { status: "running", input: { command: "x" }, time: { start: 1 } },
+    })
+    send("session.idle", { sessionID: SESSION })
+    expect(named("execute_tool bash")).toHaveLength(0)
+    busy()
+    expect(named("execute_tool bash")).toHaveLength(1)
+    expect(emitted("opencode.tool.finished")).toHaveLength(0)
+  })
+})
+
+describe("outbound traceparent", () => {
+  test("names the calling session, not whichever session owns the global slot", async () => {
+    const { getSessionTraceparent } = await import("../src/opencode-plugin/otel/context")
+    const OTHER = "ses_other"
+    busy()
+    part({ id: "prt_1", type: "step-start" })
+    busy(OTHER)
+    send("message.part.updated", {
+      sessionID: OTHER,
+      part: { sessionID: OTHER, messageID: "msg_o", id: "prt_o", type: "step-start" },
+    })
+    // Both turns are open here; SESSION acquired the process-wide slot first.
+    const mine = getSessionTraceparent(SESSION)
+    const theirs = getSessionTraceparent(OTHER)
+    expect(mine).toBeDefined()
+    expect(theirs).toBeDefined()
+    expect(theirs).not.toBe(mine)
+    // The case that actually goes wrong: a session with no turn of its own must get nothing
+    // rather than the trace of whichever session filled the process-wide slot.
+    expect(getSessionTraceparent("ses_no_turn")).toBeUndefined()
+
+    send("session.idle", { sessionID: SESSION })
+    send("session.idle", { sessionID: OTHER })
+
+    const turns = named("prompt")
+    const spanOf = (id: string) => turns.find((t) => t.attributes["opencode.session.id"] === id)!.spanContext()
+    expect(theirs).toContain(spanOf(OTHER).spanId)
+    expect(mine).toContain(spanOf(SESSION).spanId)
+    // A closed turn is not a parent any more, and a caller with no session gets nothing
+    // rather than someone else's trace.
+    expect(getSessionTraceparent(OTHER)).toBeUndefined()
+    expect(getSessionTraceparent(undefined)).toBeUndefined()
+  })
+})
+
+describe("errors outside a turn", () => {
+  test("do not mislabel a later turn", () => {
+    // prompt.ts:625/:663/:1469/:1530 publish before status.set(busy) and throw with no idle.
+    send("session.error", { sessionID: SESSION, error: { name: "ModelNotFound", data: { message: "gone" } } })
+    expect(named("prompt")).toHaveLength(0)
+    busy()
+    send("session.idle", { sessionID: SESSION })
+    expect(named("prompt")[0]!.attributes["opencode.turn.outcome"]).toBe("completed")
+  })
+})
+
+describe("tool content redaction", () => {
+  test("reuses the CLI's own redactor for inline credentials", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: { status: "pending", input: {}, raw: "" },
+    })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: {
+        status: "running",
+        input: { command: "deploy --to prod TOKEN=abcd1234secret", password: "hunter2" },
+        time: { start: 1 },
+      },
+    })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: {
+        status: "completed",
+        input: { command: "deploy --to prod TOKEN=abcd1234secret", password: "hunter2" },
+        output: "ok, used APIKEY=zzzz9999private",
+        title: "bash",
+        metadata: {},
+        time: { start: 1, end: 2 },
+      },
+    })
+    send("session.idle", { sessionID: SESSION })
+    const [span] = named("execute_tool bash")
+    const result = String(span!.attributes["gen_ai.tool.call.result"])
+    expect(result).not.toContain("zzzz9999private")
+    expect(result).toContain("<redacted>")
+    const args = String(span!.attributes["gen_ai.tool.call.arguments"])
+    expect(args).not.toContain("abcd1234secret")
+    expect(args).not.toContain("hunter2")
+    expect(args).toContain("<redacted>")
+    // Non-secret parts of the command survive, or the attribute would be useless.
+    expect(args).toContain("deploy")
+  })
+})
+
+describe("a call given up on", () => {
+  test("is not exported as a successful one", () => {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: { status: "running", input: { command: "x" }, time: { start: 1 } },
+    })
+    send("session.idle", { sessionID: SESSION })
+    busy()
+    const [tool] = named("execute_tool bash")
+    expect(tool!.status.code).toBe(2)
+    expect(tool!.status.message).toBe("tool call never settled")
+  })
+})
+
+describe("log records for a session with no turn", () => {
+  test("carry no parent rather than another session's", () => {
+    const OTHER = "ses_other"
+    busy()
+    part({ id: "prt_1", type: "step-start" })
+    // OTHER never opened a turn, and SESSION owns the process-wide slot.
+    send("session.created", { sessionID: OTHER, info: { id: OTHER } })
+    const [record] = emitted("opencode.session.created")
+    expect(trace.getSpanContext(record!.context)).toBeUndefined()
+    send("session.idle", { sessionID: SESSION })
+  })
+})
+
+describe("prompt and completion content", () => {
+  test("a chat span carries input, system and output messages", async () => {
+    const { recordInputMessages, recordSystemInstructions } = await import(
+      "../src/opencode-plugin/otel/handlers"
+    )
+    busy()
+    assistantMessage()
+    // Both transform hooks fire before the step, which is why the span can carry them.
+    recordSystemInstructions(SESSION, ["You are a data engineer.", "Prefer SQL."])
+    recordInputMessages([
+      {
+        info: { role: "user", sessionID: SESSION, id: "msg_u" },
+        parts: [{ id: "p1", type: "text", text: "how many rows in orders?" }],
+      },
+    ])
+    part({ id: "prt_1", type: "step-start" })
+    part({ id: "prt_t", type: "text", text: "Let me check." })
+    part({
+      id: "prt_tool",
+      type: "tool",
+      callID: "call_1",
+      tool: "sql",
+      state: {
+        status: "completed",
+        input: { statement: "select count(*) from orders" },
+        output: "42",
+        title: "sql",
+        metadata: {},
+        time: { start: 1, end: 2 },
+      },
+    })
+    part({
+      id: "prt_2",
+      type: "step-finish",
+      reason: "stop",
+      cost: 0.01,
+      tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+    })
+    send("session.idle", { sessionID: SESSION })
+
+    const [chat] = named("chat claude-opus-5")
+    const input = String(chat!.attributes["gen_ai.input.messages"])
+    expect(input).toContain("how many rows in orders?")
+    expect(JSON.parse(input)[0].role).toBe("user")
+
+    const system = String(chat!.attributes["gen_ai.system_instructions"])
+    expect(system).toContain("data engineer")
+    expect(JSON.parse(system)[0].type).toBe("text")
+
+    const out = JSON.parse(String(chat!.attributes["gen_ai.output.messages"]))
+    expect(out[0].role).toBe("assistant")
+    expect(out[0].finish_reason).toBe("stop")
+    expect(out[0].parts[0]).toEqual({ type: "text", content: "Let me check." })
+    expect(out[0].parts[1].type).toBe("tool_call")
+    expect(out[0].parts[1].name).toBe("sql")
+  })
+
+  test("content is redacted and honours OPENCODE_OTEL_RECORD_CONTENT=0", async () => {
+    const { recordInputMessages, initHandlers: init } = await import(
+      "../src/opencode-plugin/otel/handlers"
+    )
+    busy()
+    assistantMessage()
+    recordInputMessages([
+      {
+        info: { role: "user", sessionID: SESSION, id: "msg_u" },
+        parts: [{ id: "p1", type: "text", text: "use PASSWORD=hunter2 to connect" }],
+      },
+    ])
+    part({ id: "prt_1", type: "step-start" })
+    send("session.idle", { sessionID: SESSION })
+    const input = String(named("chat claude-opus-5")[0]!.attributes["gen_ai.input.messages"])
+    expect(input).not.toContain("hunter2")
+    expect(input).toContain("<redacted>")
+
+    // With content off, nothing is captured in the first place.
+    shutdown()
+    exporter.reset()
+    records.length = 0
+    init(logger as any, false)
+    busy()
+    assistantMessage()
+    recordInputMessages([
+      { info: { role: "user", sessionID: SESSION, id: "m" }, parts: [{ id: "p", type: "text", text: "secret plan" }] },
+    ])
+    part({ id: "prt_1", type: "step-start" })
+    part({ id: "prt_t", type: "text", text: "reply text" })
+    part({
+      id: "prt_2",
+      type: "step-finish",
+      reason: "stop",
+      cost: 0,
+      tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+    })
+    send("session.idle", { sessionID: SESSION })
+    const off = named("chat claude-opus-5")[0]!
+    expect(off.attributes["gen_ai.input.messages"]).toBeUndefined()
+    expect(off.attributes["gen_ai.output.messages"]).toBeUndefined()
+  })
+})
+
+describe("the credential shapes that leaked", () => {
+  function toolCall(tool: string, input: Record<string, any>, output: string) {
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    part({ id: "prt_2", type: "tool", callID: "c1", tool, state: { status: "pending", input: {}, raw: "" } })
+    part({ id: "prt_2", type: "tool", callID: "c1", tool, state: { status: "running", input, time: { start: 1 } } })
+    part({
+      id: "prt_2",
+      type: "tool",
+      callID: "c1",
+      tool,
+      state: { status: "completed", input, output, title: tool, metadata: {}, time: { start: 1, end: 2 } },
+    })
+    send("session.idle", { sessionID: SESSION })
+    const span = named(`execute_tool ${tool}`)[0]!
+    return {
+      args: String(span.attributes["gen_ai.tool.call.arguments"]),
+      result: String(span.attributes["gen_ai.tool.call.result"]),
+    }
+  }
+
+  test("a TOML credential file read does not export the PAT", () => {
+    // profiles.toml uses `pat = "…"` — spaces around `=` and double quotes, which the
+    // KEY=VALUE predicate and redactSql's single-quote matching both miss.
+    const { result } = toolCall("read", { filePath: "~/.clickzetta/profiles.toml" },
+      '[default]\npat = "czpat_liveSecretValue"\npassword = "hunter2"\nworkspace = "ws1"\n')
+    expect(result).not.toContain("czpat_liveSecretValue")
+    expect(result).not.toContain("hunter2")
+    expect(result).toContain("<redacted>")
+    // Non-secret config still survives, or the attribute is useless.
+    expect(result).toContain("ws1")
+  })
+
+  test("a .env body being written does not export its secrets", () => {
+    const { args } = toolCall("write", { filePath: ".env", content: "TOKEN=abc123xyz\nAPI_KEY=k-999\nPORT=8080" }, "ok")
+    expect(args).not.toContain("abc123xyz")
+    expect(args).toContain("PORT=8080")
+  })
+
+  test("whitespace-separated flag spellings are covered", () => {
+    const { args } = toolCall("bash", { command: "cz auth login x --password hunter2 --account-name acme" }, "ok")
+    expect(args).not.toContain("hunter2")
+    expect(args).toContain("acme")
+  })
+
+  test("a YAML-style credential is covered", () => {
+    const { result } = toolCall("read", { filePath: "cfg.yaml" }, "token: sk-live-9999\nregion: cn-shanghai\n")
+    expect(result).not.toContain("sk-live-9999")
+    expect(result).toContain("cn-shanghai")
+  })
+
+  test("a private key block is replaced whole", () => {
+    const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEabcdefg\n-----END RSA PRIVATE KEY-----"
+    const { result } = toolCall("read", { filePath: "id_rsa" }, pem)
+    expect(result).not.toContain("MIIEabcdefg")
+    expect(result).toContain("<redacted:private-key>")
+  })
+
+  test("a cyclic tool input does not blow the stack", () => {
+    const cyclic: Record<string, any> = { name: "x" }
+    cyclic.self = cyclic
+    busy()
+    assistantMessage()
+    part({ id: "prt_1", type: "step-start" })
+    part({ id: "prt_2", type: "tool", callID: "c1", tool: "odd", state: { status: "pending", input: {}, raw: "" } })
+    part({ id: "prt_2", type: "tool", callID: "c1", tool: "odd", state: { status: "running", input: cyclic, time: { start: 1 } } })
+    send("session.idle", { sessionID: SESSION })
+    busy()
+    const args = String(named("execute_tool odd")[0]!.attributes["gen_ai.tool.call.arguments"])
+    expect(args).toContain("<redacted:cycle>")
+  })
+})


### PR DESCRIPTION
## What was broken

The OTel plugin subscribed to six events that nothing publishes:

| subscribed | published by anything? |
|---|---|
| `session.turn.started` / `session.turn.finished` | no |
| `session.preflight.started` / `session.preflight.finished` | no |
| `v2.step.started` / `v2.step.ended` | no |
| `v2.tool.called` / `v2.tool.ended` | no |

`packages/schema/src/session-event.ts` defines the durable bus as `session.next.*`, and those are published from the core session runner (`packages/core/src/session/runner/publish-llm-event.ts`). cz runs the v1 session (`packages/opencode/src/session/session.ts`), so a plugin receives its message surface — `message.part.updated`, `message.part.delta`, `message.updated`, `session.status`, `session.created`, `session.idle`. Renaming the subscriptions would not have helped.

Subscribing by string fails silently in both directions: TypeScript sees a `string`, the runtime registers the subscription, the exporter keeps working. So every span-creating branch was dead code while session lifecycle records kept landing in the lake. Externally it looked like a sampling or exporter problem — sessions present, `otel_traces` empty of `chat` and `execute_tool` spans.

`origin/main` had it too; this is not re-baseline drift.

## What this does

Spans are rebuilt from `message.part.updated`, keeping the names and attributes the dead branches would have written:

- `step-start` / `step-finish` → `chat {model}`, usage + cost on close
- `tool` → `execute_tool {tool}`, arguments + result

Model identity comes from the two events that carry it: assistant `message.updated` (flat `modelID` / `providerID` / `agent` — the same fields `active-model.ts` already reads) and `session.next.model.switched` on an explicit switch.

The turn span is anchored on `session.status` busy — the first signal of a turn — rather than on the first LLM step, because `prompt.ts` publishes `session.error` from model resolution and permission paths that run before any part exists. `opencode.turn.outcome` cannot be taken from error events alone — a `ContextOverflowError` is published and then compacted away within the same turn — nor from the assistant message, which is published by a cleanup finalizer only after the turn has closed. It is derived from whether the turn continued: an error is pending until the next step starts, and a pending error at idle is a failed turn.

Part events are a replayable stream. `Session.fork` republishes every historical part and `compaction.prune` rewrites settled tool parts, so all part-derived spans, metrics and logs are gated on the session having a live turn (tracked from `session.status`, separately from the spans so trace gates don't affect metrics), and settling a tool is idempotent for the prune case that can land before idle.

Turn state is per session. `serve` drives several sessions at once and a subagent nests a second inside the first, so one module-level span attributed one session's steps to another and closed on whichever went idle first. Steps and tools now parent to their own session's turn; a turn that ends closes what it left open; and the process-wide session slot in `otel/context.ts` is cleared by its owner rather than handed to another open turn — under `serve` that next turn belongs to an unrelated session, so a handoff would replace a missing parent with a wrong one. A subagent's turn is parented to its parent session's turn (`session.created` carries `parentID`), so a subagent's trajectory stays in the same trace instead of becoming a detached one.

Smaller corrections along the way:

- The turn span opens outside the `llm` trace gate: disabling LLM traces must not delete the turn as well.
- A failed tool does not fail the turn. The error stays on the tool span, where the agent recovering from it does not erase it.
- Tool durations come from the settled state's own `time.start`/`time.end` instead of being measured around the event.
- The tool-call counter is deduped by callID. A call surfaces once per state transition, so with tool tracing off and no span to dedupe against it counted the same call repeatedly.

## Tests

Two files, for the two halves of this failure mode.

`otel-event-contract.test.ts` checks subscribed event names against the schema — a rename fails here instead of draining the trace.

`otel-span-build.test.ts` drives real v1 payload shapes through `handleEvent` and asserts on the exported spans. This is the half a name check cannot see: a branch can subscribe to a live event and read a field the payload lacks. That happened here — an earlier revision read a nested `info.model` off the assistant message and named every span `chat unknown`, silently.

Both were mutation-checked: reverting each fix turns specific tests red.

## Verification

- `bun run typecheck` clean
- `bun test` in `packages/cz-cli`: 1164 pass, 65 skip, 0 fail — run in a clean worktree off `origin/main` with its own `node_modules`
- Every fix is mutation-checked: reverting it turns exactly its own test red

## Content exposure this makes live

Worth stating plainly, because the branches that wrote these were dead: tool arguments and results now really are exported. `gen_ai.tool.call.arguments` carries `state.input` — for `bash` that is the whole command line, which routinely contains tokens and connection strings — and `gen_ai.tool.call.result` carries `state.output`, which for `read`/`grep`/`webfetch` is file or page content.

Content is redacted by assignment shape, using this repo's own `isSensitiveKey`/`redactSql`: `pat = "…"` (TOML), `token: …` (YAML), `KEY=…` (env), `--password …` (flags), plus PEM envelopes replaced whole. Only the value is replaced, so keys stay readable and non-secret content survives. The `KEY=VALUE`-token predicate alone was NOT enough — `read` of profiles.toml would have exported a PAT verbatim and `write` of a `.env` its body — which is why the shape is matched rather than the token. It is still a redactor, not a secret scanner: a credential with neither an assignment shape nor a PEM envelope gets through.

Prompt content is capped at 32KB (the pre-re-baseline limit) and tool content at 8KB, truncated at each string leaf before redaction runs.

Note that `otel-defaults.ts` forces `OPENCODE_OTEL_RECORD_CONTENT=1` when `~/.clickzetta/profiles.toml` is absent, and `agent` does not require a profile, so a fresh install running on a user-added LLM provider is inside that default.

This stays behind the existing `OPENCODE_OTEL_RECORD_CONTENT` switch, which is opt-out (on unless set to `0`), and the default is deliberately unchanged in this PR: the trajectory is the point of the fix, and turning it off silently would deliver spans without the content that makes them useful. Both attributes are capped at 8k chars, since a whole-file `read` otherwise becomes one oversized attribute and collectors drop or truncate the span rather than the text.

If the exposure is not acceptable for a given deployment, `OPENCODE_OTEL_RECORD_CONTENT=0` turns both off and leaves spans, timings, token counts, tool names and errors intact.

## Restored to pre-re-baseline parity

`git log -S` shows these events were never upstream's: cz patched `packages/opencode` to publish them (`feat(otel): trace session turn lifecycle`, 2026-06-08), and the re-baseline onto pure upstream v1.17.11 dropped the publishers while keeping this subscriber. The pre-re-baseline handler also exported `gen_ai.input.messages`, `gen_ai.system_instructions` and `gen_ai.output.messages`, so those are restored here under the same attribute names — sourced from the `experimental.chat.messages.transform` and `experimental.chat.system.transform` hooks rather than an upstream patch, which keeps the change inside `packages/cz-cli`. Two things are deliberately not restored: `opencode.turn.parts` (no equivalent source on the message surface) and the `preflight` span (its event was cz's own and no v1 boundary corresponds to it).

Outbound `traceparent` on gateway requests and `CLICKZETTA_TRACEPARENT` for spawned shells go from effectively absent to present, since the process-wide slot's only writer was one of the dead branches. That is the point — it makes gateway-side spans joinable to the trajectory.

## Not addressed here

`chat` spans still carry no `gen_ai.input.messages`, `gen_ai.output.messages` or `gen_ai.system_instructions`, so prompts and completions themselves are still absent from traces. The v1 text parts could supply them; that is a separate change with the same privacy surface as above.

The step-duration metric's independence from `OPENCODE_DISABLE_TRACES` is not covered by a test: the variable is parsed once at module load, so a same-process test cannot flip it, and a test-only seam in the handler was not worth adding.
