### PR TITLE
refactor(auth): resolve every credential through a TokenSource

### DIFF
--- a/openspec/specs/oauth-login/spec.md
+++ b/openspec/specs/oauth-login/spec.md
@@ -55,6 +55,37 @@ When the cached token is judged expired per `EXPIRED_FACTOR = 0.8` and a `refres
 - **THEN** the CLI clears the invalid cache and performs a full portal login as a fallback
 - **AND** ultimately returns the new token obtained via the fallback login
 
+### Requirement: Credentials are obtained from a TokenSource, never held as a token string
+
+Authentication is a capability of the transport, not data passed around by callers. Every authenticated request MUST obtain its credential from a `TokenSource` (`get()` before the request, `rotate()` once on a 401), and no context, config, or helper may carry a token string for later reuse. `ClientOptions.tokens` and `StudioConfig.tokens` are required, so a request cannot be constructed without naming how it authenticates.
+
+An identity with no rotation path is a *kind of source* — `staticTokenSource` for a token a login flow just minted or a profile `[agent]` block, and cz-cli's `profileTokenSource` for a cookie-pinned profile whose Cookie is the real credential — and its `rotate()` reports that. It is never a flag on individual requests.
+
+This shape is the standard one (`oauth2.TokenSource` in Go, `TokenCredential` in the Azure SDK, `AuthorizedSession` in google-auth) and is adopted for the reason it exists: a token handed to a caller is a snapshot, so each caller then needs its own copy of "how to replace this". That is exactly how `sql` came to self-heal on an expired token while `task`/`job`/`runs`/`schema` surfaced a bare `401 token is invalid`, and why the first fix (PR #84) had to be written a second time inside one more command.
+
+Refresh is proactive first: `get()` rotates a credential already past `EXPIRED_FACTOR`, so an expired token never reaches the wire. The 401 path exists for what the clock cannot predict — early revocation, clock skew, server-side invalidation.
+
+#### Scenario: A stale credential is refreshed before the request
+
+- **WHEN** a Studio request is issued and the persisted token is past its expiry factor
+- **THEN** the source refreshes first and the request carries the rotated token
+- **AND** no 401 round-trip occurs
+
+#### Scenario: A credential the server rejects is rotated once and retried
+
+- **WHEN** the credential is still valid by the clock but the server answers 401
+- **THEN** the transport asks the same source to rotate, retries once with the new credential, and the caller observes success
+
+#### Scenario: A source with no rotation path lets the 401 stand (boundary)
+
+- **WHEN** the request authenticates through a static or cookie-backed source and the server answers 401
+- **THEN** no rotation is attempted, the request is not resent, and the 401 reaches the caller
+
+#### Scenario: A dead session fails before issuing the request (exception)
+
+- **WHEN** the refresh token is dead and no fallback credential exists
+- **THEN** `get()` raises `SESSION_EXPIRED` naming `cz-cli auth login`, and no request is sent
+
 ### Requirement: Query UserInfo
 
 The CLI should be able to call `GET /oauth2/userinfo` with `Authorization: Bearer <access_token>` to obtain the current user's information and parse the returned fields; during processing and display it must not output sensitive fields such as `access_token` or `refresh_token`.

--- a/packages/clickzetta-sdk/src/agent/chat.ts
+++ b/packages/clickzetta-sdk/src/agent/chat.ts
@@ -1,4 +1,5 @@
 import { request, type ClientOptions } from "../client.js"
+import { anonymous, staticTokenSource } from "../auth/token.js"
 
 export interface AgentIdentity {
   user_id: string
@@ -15,8 +16,8 @@ export async function agentHealth(baseUrl: string, token?: string): Promise<Reco
   try {
     const opts: ClientOptions = {
       baseUrl,
+      tokens: token ? staticTokenSource({ token, instanceId: 0, userId: 0 }) : anonymous(),
       timeout: 10000,
-      ...(token ? { customHeaders: { "x-clickzetta-token": token } } : {}),
     }
     const resp = await request<Record<string, unknown>>(opts, "/ai/health", undefined, "GET")
     return resp.data ?? (resp as unknown as Record<string, unknown>)
@@ -33,7 +34,7 @@ export async function createConversation(
 ): Promise<string> {
   const opts: ClientOptions = {
     baseUrl,
-    customHeaders: { "x-clickzetta-token": token },
+    tokens: staticTokenSource({ token, instanceId: 0, userId: 0 }),
     timeout: 300000,
   }
   const payload: Record<string, unknown> = { identity }
@@ -55,7 +56,7 @@ export async function chat(
 ): Promise<string> {
   const opts: ClientOptions = {
     baseUrl,
-    customHeaders: { "x-clickzetta-token": token },
+    tokens: staticTokenSource({ token, instanceId: 0, userId: 0 }),
     timeout: 300000,
   }
   const resp = await request<{ answer: string }>(

--- a/packages/clickzetta-sdk/src/auth/token.ts
+++ b/packages/clickzetta-sdk/src/auth/token.ts
@@ -200,12 +200,35 @@ async function acquireToken(config: ConnectionConfig, force: boolean): Promise<A
  * the existing `getToken`/`forceRefreshToken` engine — single-flight and
  * persistence come with them.
  */
+/**
+ * Whether this connection has anything to authenticate or rotate WITH: a persisted
+ * token to refresh, or credentials to log in with. False means every recovery path
+ * would drive a login with empty values — ~6 s of retries ending in a misleading
+ * "Login failed" that hides the error the server actually sent.
+ *
+ * An `oauth = "<id>"` pointer attaches a store whether or not its `[oauth.<id>]`
+ * section still exists, so the store is asked for a token rather than for its
+ * existence. Exported because callers outside the transport (a command deciding
+ * whether a 401 is worth retrying) need the same answer, and a second copy of this
+ * predicate is exactly what drifts.
+ */
+export function isRotatable(config: ConnectionConfig): boolean {
+  return Boolean(config.tokenStore?.load()) || hasLoginCredentials(config)
+}
+
 export function connectionTokenSource(config: ConnectionConfig): TokenSource {
   return {
     async get(): Promise<Credential> {
       return toCredential(await getToken(config))
     },
-    async rotate(): Promise<Credential> {
+    async rotate(rejected: Credential): Promise<Credential | undefined> {
+      if (!isRotatable(config)) return undefined
+      // A concurrent request may already have rotated this connection while this
+      // one was in flight; its 401 is then about a credential we have already
+      // replaced. Hand back the current one instead of rotating again, so N
+      // parallel requests cost one rotation rather than N.
+      const current = toCredential(await getToken(config))
+      if (current.token !== rejected.token) return current
       // Throws SESSION_EXPIRED when the refresh token is dead and there are no
       // credentials to fall back on — a terminal answer, not a missing path.
       return toCredential(await forceRefreshToken(config))

--- a/packages/clickzetta-sdk/src/auth/token.ts
+++ b/packages/clickzetta-sdk/src/auth/token.ts
@@ -1,4 +1,4 @@
-import type { AuthToken, ConnectionConfig } from "../types/index.js"
+import type { AuthToken, ConnectionConfig, Credential, TokenSource } from "../types/index.js"
 import { loginWithPat, loginWithPassword } from "./login.js"
 import { refreshAccessToken } from "./oauth.js"
 import { toServiceUrl } from "../config/region.js"
@@ -192,6 +192,48 @@ async function acquireToken(config: ConnectionConfig, force: boolean): Promise<A
   })()
   pendingFetches.set(key, fetch)
   return fetch
+}
+
+/**
+ * The standard source: an OAuth/PAT/password connection whose token is cached,
+ * refreshed proactively when stale, and rotated on demand. `get`/`rotate` are
+ * the existing `getToken`/`forceRefreshToken` engine — single-flight and
+ * persistence come with them.
+ */
+export function connectionTokenSource(config: ConnectionConfig): TokenSource {
+  return {
+    async get(): Promise<Credential> {
+      return toCredential(await getToken(config))
+    },
+    async rotate(): Promise<Credential> {
+      // Throws SESSION_EXPIRED when the refresh token is dead and there are no
+      // credentials to fall back on — a terminal answer, not a missing path.
+      return toCredential(await forceRefreshToken(config))
+    },
+  }
+}
+
+/**
+ * A credential supplied verbatim by the caller: a token minted moments ago by a
+ * login flow, a profile `[agent]` block, or a cookie session. There is no
+ * rotation path, so `rotate` reports that rather than pretending — which is how
+ * "this identity cannot self-heal" is expressed now that no request carries a
+ * flag for it.
+ */
+export function staticTokenSource(credential: Credential): TokenSource {
+  return {
+    get: async () => credential,
+    rotate: async () => undefined,
+  }
+}
+
+/** Unauthenticated endpoint (health probes, public metadata). */
+export function anonymous(): TokenSource {
+  return staticTokenSource({ token: "", instanceId: 0, userId: 0 })
+}
+
+function toCredential(token: AuthToken): Credential {
+  return { token: token.token, instanceId: token.instanceId, userId: token.userId }
 }
 
 export function clearTokenCache(): void {

--- a/packages/clickzetta-sdk/src/auth/user.ts
+++ b/packages/clickzetta-sdk/src/auth/user.ts
@@ -26,10 +26,10 @@ interface UserInfo {
  * cookie-authenticated deployments accept this call. Without it the request
  * only proves the token, which a session-authenticating gateway may reject.
  *
- * `auth.config` is required for the reason spelled out on `ClientOptions.config`:
- * this is a preflight call on the same token the command will use, so it must
- * be able to rotate on 401 too, and a caller with nothing to rotate has to say
- * `false` rather than leave it to a default.
+ * `auth.tokens` is required for the reason spelled out on `ClientOptions.tokens`:
+ * this is a preflight call on the same credential the command will use, so it must
+ * be able to rotate on a 401 too. A caller holding only a token string wraps it in
+ * `staticTokenSource`, which states that this identity cannot self-heal.
  */
 export async function getCurrentUser(
   baseUrl: string,

--- a/packages/clickzetta-sdk/src/auth/user.ts
+++ b/packages/clickzetta-sdk/src/auth/user.ts
@@ -1,5 +1,17 @@
 import { request, type ClientOptions } from "../client.js"
 import { ClickZettaApiError } from "../types/api.js"
+import type { TokenSource } from "../types/index.js"
+
+/**
+ * Auth context for a one-off portal call: the source to authenticate with, plus
+ * any profile headers the endpoint needs. There is no token field — a caller
+ * that only has a token string wraps it in `staticTokenSource`, which states
+ * that this identity cannot self-heal.
+ */
+export interface CallAuth {
+  tokens: TokenSource
+  customHeaders?: Record<string, string>
+}
 
 interface UserInfo {
   id: number
@@ -13,13 +25,17 @@ interface UserInfo {
  * `customHeaders` carries the profile's own headers (notably `Cookie`) so
  * cookie-authenticated deployments accept this call. Without it the request
  * only proves the token, which a session-authenticating gateway may reject.
+ *
+ * `auth.config` is required for the reason spelled out on `ClientOptions.config`:
+ * this is a preflight call on the same token the command will use, so it must
+ * be able to rotate on 401 too, and a caller with nothing to rotate has to say
+ * `false` rather than leave it to a default.
  */
 export async function getCurrentUser(
   baseUrl: string,
-  token: string,
-  customHeaders?: Record<string, string>,
+  auth: CallAuth,
 ): Promise<UserInfo> {
-  const opts: ClientOptions = { baseUrl, token, customHeaders }
+  const opts: ClientOptions = { baseUrl, tokens: auth.tokens, customHeaders: auth.customHeaders }
   const resp = await request<UserInfo>(
     opts,
     "/clickzetta-portal/user/getCurrentUser",
@@ -33,10 +49,10 @@ export async function getCurrentUser(
 
 export async function getInstanceByName(
   baseUrl: string,
-  token: string,
   instanceName: string,
+  auth: CallAuth,
 ): Promise<number> {
-  const opts: ClientOptions = { baseUrl, token }
+  const opts: ClientOptions = { baseUrl, tokens: auth.tokens, customHeaders: auth.customHeaders }
   const resp = await request<{ id: number }>(
     opts,
     `/clickzetta-portal/service/getInstanceByName?instanceName=${encodeURIComponent(instanceName)}`,

--- a/packages/clickzetta-sdk/src/client.ts
+++ b/packages/clickzetta-sdk/src/client.ts
@@ -1,27 +1,35 @@
 import { ClickZettaApiError, type ApiResponse } from "./types/api.js"
-import type { ConnectionConfig } from "./types/index.js"
+import type { Credential, RequestContext, TokenSource } from "./types/index.js"
 import { currentTraceparent } from "./traceparent.js"
 import { getHeader, mergeHeaders } from "./headers.js"
 
 const SDK_VERSION = "0.1.0"
 const MAX_RETRIES = 3
 const NON_RETRYABLE_STATUS = new Set([400, 403, 404, 409, 422])
+/**
+ * Error codes that end the retry loop immediately. A refresh that reported the
+ * session as dead will report it again on every attempt, so retrying only adds
+ * latency (and, for a profile with no credentials, further pointless network
+ * calls) before the same verdict. Transient refresh failures keep retrying.
+ */
+const TERMINAL_ERROR_CODES = new Set(["SESSION_EXPIRED"])
 const AUTH_EXPIRED_STATUS = 401
 const DEFAULT_TIMEOUT_MS = 60_000
 
 export interface ClientOptions {
   baseUrl: string
-  token?: string
+  /**
+   * How this request authenticates. The transport calls `get()` before each
+   * attempt and `rotate()` once on a 401, so a caller never holds a token and
+   * cannot forget to wire recovery. Use `staticTokenSource` for a credential
+   * with no rotation path and `anonymous()` for an unauthenticated endpoint.
+   */
+  tokens: TokenSource
   customHeaders?: Record<string, string>
   traceparent?: string
   timeout?: number
-  /**
-   * Optional connection config. When present, a 401 response will
-   * trigger an automatic `forceRefreshToken(config)` and retry with
-   * the refreshed token. Backwards compatible: when omitted, 401
-   * behaves as before (only the token cache is cleared).
-   */
-  config?: ConnectionConfig
+  /** Non-auth metadata some request bodies embed — see {@link RequestContext}. */
+  context?: RequestContext
 }
 
 /**
@@ -51,16 +59,16 @@ function generateRequestId(): string {
 
 /**
  * Header name of the wire credential. Lower case because {@link mergeHeaders}
- * folds every name that way; the 401 refresh path below rewrites this same key,
- * and using a different casing there would re-introduce a duplicate field.
+ * folds every name that way; after a rotation the headers are rebuilt from the
+ * new credential, and a different casing here would emit a duplicate field.
  */
 const TOKEN_HEADER = "x-clickzetta-token"
 
-function buildHeaders(opts: ClientOptions): Record<string, string> {
+function buildHeaders(opts: ClientOptions, credential: Credential): Record<string, string> {
   const requestId = generateRequestId()
   // Case-insensitive: a profile may spell this `Instancename`, and missing it
-  // here would fall back to config.instance and emit a second, conflicting value.
-  const instanceName = getHeader(opts.customHeaders, "instanceName") ?? opts.config?.instance
+  // here would fall back to the context instance and emit a second, conflicting value.
+  const instanceName = getHeader(opts.customHeaders, "instanceName") ?? opts.context?.instance
   return mergeHeaders(
     {
       "Content-Type": "application/json",
@@ -72,8 +80,11 @@ function buildHeaders(opts: ClientOptions): Record<string, string> {
       "traceparent": opts.traceparent ?? currentTraceparent(),
       ...(instanceName ? { instanceName } : {}),
     },
+    // The credential's own headers sit under the caller's: a Cookie belongs to
+    // the credential, but per-call identity headers still win.
+    credential.headers,
     opts.customHeaders,
-    opts.token ? { [TOKEN_HEADER]: opts.token } : undefined,
+    credential.token ? { [TOKEN_HEADER]: credential.token } : undefined,
   )
 }
 
@@ -82,9 +93,9 @@ function buildHeaders(opts: ClientOptions): Record<string, string> {
  * - parseWrapper=true  → returns parsed JSON as ApiResponse<T>
  * - parseWrapper=false → returns parsed JSON as T
  *
- * On 401, if `opts.config` is provided, we force-refresh the token
- * and retry with the new value written back into `opts.token`
- * (so subsequent attempts in the same loop pick it up too).
+ * Authentication is resolved here and nowhere else: the credential comes from
+ * `opts.tokens` before each attempt, and a 401 asks the same source to rotate
+ * it. A source with no rotation path returns undefined and the 401 stands.
  */
 async function doRequest<T>(
   opts: ClientOptions,
@@ -94,11 +105,27 @@ async function doRequest<T>(
   parseWrapper: boolean,
 ): Promise<T> {
   const url = `${opts.baseUrl}${path}`
-  const headers = buildHeaders(opts)
+  let credential = await opts.tokens.get()
+  let headers = buildHeaders(opts, credential)
+  // Re-resolved at the top of every attempt below: `get()` is cache-backed, so
+  // this costs nothing, and a retry after a multi-second backoff must not
+  // resend a credential that expired while we waited.
+  // A 401 gets exactly one rotation per request, matching RFC 6750's single
+  // re-authentication challenge: a second rejection is the server's answer
+  // about this identity, not a race we should keep re-running.
+  let rotated = false
+  // Set when a 401 cannot be recovered from. The generic retry loop below would
+  // otherwise resend the very credential the server just rejected, which is
+  // never useful and delays the error by three backoffs.
+  let authExhausted = false
 
   let lastError: Error | undefined
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
+      if (attempt > 0) {
+        credential = await opts.tokens.get()
+        headers = buildHeaders(opts, credential)
+      }
       const resp = await fetch(url, {
         method,
         headers,
@@ -113,20 +140,19 @@ async function doRequest<T>(
           resp.status,
         )
         if (NON_RETRYABLE_STATUS.has(resp.status)) throw apiErr
-        if (resp.status === AUTH_EXPIRED_STATUS && attempt < MAX_RETRIES) {
-          const { clearTokenCache, forceRefreshToken } = await import("./auth/token.js")
-          clearTokenCache()
-          if (opts.config) {
-            try {
-              const fresh = await forceRefreshToken(opts.config)
-              opts.token = fresh.token
-              headers[TOKEN_HEADER] = fresh.token
-            } catch (refreshErr) {
-              // Bubble up the refresh error as the final cause so
-              // callers see why we gave up on this request.
-              throw refreshErr
-            }
+        if (resp.status === AUTH_EXPIRED_STATUS) {
+          // Rotation is offered once; a source that cannot rotate (or a second
+          // rejection) makes this 401 the final answer for this identity.
+          const fresh = rotated || attempt >= MAX_RETRIES
+            ? undefined
+            : await opts.tokens.rotate(credential)
+          if (!fresh) {
+            authExhausted = true
+            throw apiErr
           }
+          rotated = true
+          credential = fresh
+          headers = buildHeaders(opts, credential)
         }
         throw apiErr
       }
@@ -141,6 +167,8 @@ async function doRequest<T>(
       if (err instanceof ClickZettaApiError && (NON_RETRYABLE_STATUS.has(err.statusCode ?? 0) || err.code === "PARSE_ERROR")) {
         throw err
       }
+      if (authExhausted) throw err
+      if (TERMINAL_ERROR_CODES.has(String((err as { code?: unknown }).code ?? ""))) throw err
       if (attempt < MAX_RETRIES) {
         await sleep(retryDelayMs(attempt))
         continue

--- a/packages/clickzetta-sdk/src/client.ts
+++ b/packages/clickzetta-sdk/src/client.ts
@@ -107,9 +107,12 @@ async function doRequest<T>(
   const url = `${opts.baseUrl}${path}`
   let credential = await opts.tokens.get()
   let headers = buildHeaders(opts, credential)
-  // Re-resolved at the top of every attempt below: `get()` is cache-backed, so
-  // this costs nothing, and a retry after a multi-second backoff must not
-  // resend a credential that expired while we waited.
+  // Credential a rotation just produced, to be used verbatim by the next attempt.
+  // `TokenSource.rotate` is contracted to RETURN the replacement, not to make
+  // `get()` observe it, so re-resolving over it would drop the rotation for any
+  // source that does not also persist (the built-in one happens to, via
+  // forceRefreshToken's cache write — which is exactly what would have hidden this).
+  let rotatedCredential: Credential | undefined
   // A 401 gets exactly one rotation per request, matching RFC 6750's single
   // re-authentication challenge: a second rejection is the server's answer
   // about this identity, not a race we should keep re-running.
@@ -123,7 +126,11 @@ async function doRequest<T>(
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       if (attempt > 0) {
-        credential = await opts.tokens.get()
+        // Prefer the rotated credential; otherwise re-resolve, because a retry
+        // after a multi-second backoff must not resend one that expired while
+        // we waited. `get()` is cache-backed, so re-resolving costs nothing.
+        credential = rotatedCredential ?? await opts.tokens.get()
+        rotatedCredential = undefined
         headers = buildHeaders(opts, credential)
       }
       const resp = await fetch(url, {
@@ -151,8 +158,7 @@ async function doRequest<T>(
             throw apiErr
           }
           rotated = true
-          credential = fresh
-          headers = buildHeaders(opts, credential)
+          rotatedCredential = fresh
         }
         throw apiErr
       }

--- a/packages/clickzetta-sdk/src/sql/job-info.ts
+++ b/packages/clickzetta-sdk/src/sql/job-info.ts
@@ -31,7 +31,7 @@ export async function getJobRaw(
   jobId: JobID,
   type: JobRequestTypeValue,
 ): Promise<unknown> {
-  const serviceInfo = normalizeServiceEndpoint(opts.config?.service ?? opts.baseUrl)
+  const serviceInfo = normalizeServiceEndpoint(opts.context?.service ?? opts.baseUrl)
   const body: Record<string, unknown> = {
     [type]: {
       jobId: {

--- a/packages/clickzetta-sdk/src/sql/poll.ts
+++ b/packages/clickzetta-sdk/src/sql/poll.ts
@@ -447,7 +447,7 @@ export async function pollJobResult(
 ): Promise<QueryResult> {
   const startTime = Date.now()
   const { jobTimeoutMs, timezone, maxRetries = Infinity, resubmitFn } = params
-  const serviceInfo = normalizeServiceEndpoint(opts.config?.service ?? opts.baseUrl)
+  const serviceInfo = normalizeServiceEndpoint(opts.context?.service ?? opts.baseUrl)
 
   const requestBody = {
     getResultRequest: {

--- a/packages/clickzetta-sdk/src/sql/session.ts
+++ b/packages/clickzetta-sdk/src/sql/session.ts
@@ -14,7 +14,7 @@
  *   - utils.py:212-227    strip_leading_comment  → stripLeadingComment
  */
 
-import { getToken } from "../auth/token.js"
+import { getToken, connectionTokenSource } from "../auth/token.js"
 import type { ClientOptions } from "../client.js"
 import { toServiceUrl } from "../config/region.js"
 import { InterfaceError, ProgrammingError } from "../types/errors.js"
@@ -635,9 +635,13 @@ export class SqlSession {
     const token = await getToken(this.config)
     return {
       baseUrl: toServiceUrl(this.config.service, this.config.protocol),
-      token: token.token,
+      tokens: connectionTokenSource(this.config),
       customHeaders: this.clientHeaders ?? this.config.customHeaders,
-      config: this.config,
+      context: {
+        service: this.config.service,
+        instance: this.config.instance,
+        username: this.config.username,
+      },
     }
   }
 }

--- a/packages/clickzetta-sdk/src/sql/submit.ts
+++ b/packages/clickzetta-sdk/src/sql/submit.ts
@@ -121,9 +121,9 @@ export async function submitJob(
     traceparent,
     maxRetries = 1,
   } = params
-  const serviceInfo = normalizeServiceEndpoint(opts.config?.service ?? opts.baseUrl)
+  const serviceInfo = normalizeServiceEndpoint(opts.context?.service ?? opts.baseUrl)
   const resolvedHost = host ?? serviceInfo.endpoint ?? serviceInfo.host
-  const resolvedUser = (user ?? opts.config?.username) || null
+  const resolvedUser = (user ?? opts.context?.username) || null
   const resolvedContextJson = contextJson ? { ...contextJson } : {}
   if (resolvedContextJson.host == null) resolvedContextJson.host = resolvedHost
   if (resolvedContextJson.instance == null) resolvedContextJson.instance = instanceName ?? null

--- a/packages/clickzetta-sdk/src/studio/client.ts
+++ b/packages/clickzetta-sdk/src/studio/client.ts
@@ -16,7 +16,7 @@ export async function studioRequest<T>(
 ) {
   const opts: ClientOptions = {
     baseUrl: config.baseUrl,
-    token: config.token,
+    tokens: config.tokens,
     customHeaders: {
       instanceName: config.instanceName,
       instanceid: String(config.instanceId),

--- a/packages/clickzetta-sdk/src/types/index.ts
+++ b/packages/clickzetta-sdk/src/types/index.ts
@@ -66,8 +66,70 @@ export interface AuthToken {
   issuer?: string
 }
 
-export interface StudioConfig {
+/**
+ * One resolved credential, valid at the moment {@link TokenSource.get} returned
+ * it. Nothing outside a TokenSource should store one: hold the source instead.
+ */
+export interface Credential {
+  /** Wire credential for the `x-clickzetta-token` header. */
   token: string
+  instanceId: number
+  userId: number
+  /**
+   * Headers this credential itself requires — a session/cookie credential is
+   * only accepted alongside its `Cookie`. Kept with the credential so the
+   * transport cannot send one without the other.
+   */
+  headers?: Record<string, string>
+}
+
+/**
+ * The single seam through which every authenticated request obtains its
+ * credential. Modeled on `oauth2.TokenSource` (Go) and `TokenCredential`
+ * (Azure SDK): the transport asks for a credential at request time and, on a
+ * 401, asks the same source to rotate it.
+ *
+ * Why this shape rather than passing a token string: a token handed to a caller
+ * is a snapshot, and every caller then needs its own copy of "how to replace
+ * this" — which is how `sql` ended up self-healing on an expired token while
+ * every Studio command surfaced a bare `401 token is invalid`. With a source,
+ * there is nothing for a call site to forget: it cannot obtain a credential
+ * without also holding the means to rotate it.
+ *
+ * An identity that cannot be rotated is a *kind of source*
+ * ({@link staticTokenSource}), not a flag on every request.
+ */
+export interface TokenSource {
+  /** Credential for the next request, refreshed proactively when near expiry. */
+  get(): Promise<Credential>
+  /**
+   * One-shot recovery after the server rejected `rejected` with 401. Returns
+   * the replacement credential, or `undefined` when this identity has no
+   * rotation path (static token, cookie session) — the caller then surfaces the
+   * 401. Throws when rotation was possible but failed for good (a dead refresh
+   * token raises `SESSION_EXPIRED`).
+   */
+  rotate(rejected: Credential): Promise<Credential | undefined>
+}
+
+/**
+ * Non-auth metadata that some request BODIES embed — the SQL job-submit payload
+ * carries the service endpoint and the login name. It exists only because those
+ * payloads need it; authentication never reads this. Deliberately separate from
+ * {@link TokenSource} so the two can't be confused again.
+ */
+export interface RequestContext {
+  service?: string
+  instance?: string
+  username?: string
+}
+
+export interface StudioConfig {
+  /**
+   * How this context authenticates. Ask it for a credential when one is needed
+   * (`await sc.tokens.get()`); never cache the result on the context.
+   */
+  tokens: TokenSource
   instanceId: number
   workspaceId: number
   projectId: number

--- a/packages/clickzetta-sdk/src/workspace/workspace.ts
+++ b/packages/clickzetta-sdk/src/workspace/workspace.ts
@@ -1,4 +1,5 @@
 import { request, type ClientOptions } from "../client.js"
+import type { CallAuth } from "../auth/user.js"
 import { ClickZettaApiError } from "../types/api.js"
 
 export interface WorkspaceInfo {
@@ -14,17 +15,16 @@ export interface WorkspaceInfo {
  */
 export async function listUserWorkspaces(
   baseUrl: string,
-  token: string,
   userId: number,
   tenantId: number,
   instanceId: number,
   instanceName: string,
-  debug?: boolean,
-  customHeaders?: Record<string, string>,
+  auth: CallAuth & { debug?: boolean },
 ): Promise<WorkspaceInfo[]> {
+  const { debug, customHeaders } = auth
   const opts: ClientOptions = {
     baseUrl,
-    token,
+    tokens: auth.tokens,
     customHeaders: {
       ...customHeaders,
       instanceid: String(instanceId),
@@ -59,24 +59,20 @@ export async function listUserWorkspaces(
 
 export async function getWorkspaceByName(
   baseUrl: string,
-  token: string,
   userId: number,
   tenantId: number,
   instanceId: number,
   instanceName: string,
   workspaceName: string,
-  debug?: boolean,
-  customHeaders?: Record<string, string>,
+  auth: CallAuth & { debug?: boolean },
 ): Promise<WorkspaceInfo | undefined> {
   const all = await listUserWorkspaces(
     baseUrl,
-    token,
     userId,
     tenantId,
     instanceId,
     instanceName,
-    debug,
-    customHeaders,
+    auth,
   )
   return all.find((w) => {
     const raw = w as unknown as Record<string, unknown>

--- a/packages/clickzetta-sdk/test/studio-401-refresh.test.ts
+++ b/packages/clickzetta-sdk/test/studio-401-refresh.test.ts
@@ -167,6 +167,30 @@ describe("Studio requests authenticate through the context's TokenSource", () =>
     expect(studioTokens).toEqual(["stale-access"])
   })
 
+  test("the retry sends what rotate() returned, not whatever get() resolves", async () => {
+    // A conforming source may only RETURN the replacement — nothing in the
+    // contract says `get()` must observe it. The built-in source happens to
+    // persist via forceRefreshToken's cache write, which is what hid an earlier
+    // bug where the transport re-resolved over the rotated credential and
+    // re-sent the one the server had just rejected.
+    let gets = 0
+    const returnOnly: TokenSource = {
+      get: async () => {
+        gets += 1
+        return { token: "stale-access", instanceId: 9, userId: 7 }
+      },
+      rotate: async () => ({ token: "fresh-access", instanceId: 9, userId: 7 }),
+    }
+    stubFetch({ refreshable: true })
+
+    const resp = await studioRequest(studioConfig(returnOnly), "/studio/anything", {})
+
+    expect(resp.code).toBe(0)
+    expect(studioTokens).toEqual(["stale-access", "fresh-access"])
+    // The retry used the rotated value directly instead of asking again.
+    expect(gets).toBe(1)
+  })
+
   test("a dead session fails before issuing the request", async () => {
     const store = memoryStore(oauthToken(now, { expired: true }))
     stubFetch({ refreshable: false })

--- a/packages/clickzetta-sdk/test/studio-401-refresh.test.ts
+++ b/packages/clickzetta-sdk/test/studio-401-refresh.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+import { studioRequest } from "../src/studio/client.js"
+import { clearTokenCache, connectionTokenSource, staticTokenSource } from "../src/auth/token.js"
+import type { AuthToken, ConnectionConfig, StudioConfig, TokenSource, TokenStore } from "../src/types/index.js"
+
+/**
+ * A Studio request whose token has expired must rotate the token and retry —
+ * the same self-healing `sql` has always had via `ClientOptions.config`.
+ *
+ * This is a regression lock, not a feature test. `studioRequest` used to pass a
+ * token STRING with no way to replace it, so `task` / `job` / `runs` / `schema`
+ * turned an expired token into a bare `401 token is invalid` while `sql` on the
+ * same profile kept working; PR #84 then hand-patched one more command instead
+ * of the shared transport. Contexts now carry a `TokenSource`, so obtaining a
+ * credential and being able to rotate it are the same capability.
+ */
+
+function memoryStore(initial: AuthToken): TokenStore {
+  let current: AuthToken | undefined = initial
+  return {
+    load: () => current,
+    save: (token) => { current = token },
+    clear: () => { current = undefined },
+  }
+}
+
+function oauthToken(now: number, opts: { expired: boolean }): AuthToken {
+  return {
+    token: "stale-access",
+    refreshToken: "refresh-1",
+    instanceId: 9,
+    userId: 7,
+    expireTimeMs: 3_600_000,
+    // Past expireTimeMs * EXPIRED_FACTOR when `expired`, comfortably inside it
+    // otherwise — the two cases the standard shape handles differently.
+    obtainedAt: opts.expired ? now - 3_600_000 : now,
+    issuer: "issuer.invalid",
+  }
+}
+
+function connectionConfig(store: TokenStore): ConnectionConfig {
+  return {
+    pat: "",
+    username: "",
+    password: "",
+    service: "region.invalid",
+    protocol: "https",
+    instance: "inst",
+    workspace: "ws",
+    schema: "public",
+    vcluster: "default",
+    tokenStore: store,
+    cacheKey: "studio-401-test",
+  }
+}
+
+function studioConfig(tokens: TokenSource): StudioConfig {
+  return {
+    tokens,
+    instanceId: 1,
+    workspaceId: 2,
+    projectId: 3,
+    userId: 7,
+    tenantId: 4,
+    instanceName: "inst",
+    workspaceName: "ws",
+    env: "prod",
+    baseUrl: "https://region.invalid",
+  }
+}
+
+const originalFetch = globalThis.fetch
+const originalDateNow = Date.now
+let now = 2_000_000
+
+/** Records the `x-clickzetta-token` of every Studio call the client makes. */
+let studioTokens: string[] = []
+
+beforeEach(() => {
+  now = 2_000_000
+  Date.now = () => now
+  studioTokens = []
+  clearTokenCache()
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  Date.now = originalDateNow
+  clearTokenCache()
+})
+
+function stubFetch(opts: { refreshable: boolean }): void {
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(typeof input === "string" || input instanceof URL ? input : input.url)
+    if (url.includes("/oauth2/token")) {
+      if (!opts.refreshable) {
+        return new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 })
+      }
+      return new Response(
+        JSON.stringify({ access_token: "fresh-access", refresh_token: "refresh-2", expires_in: 3600, token_type: "Bearer" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )
+    }
+    const headers = new Headers(init?.headers as HeadersInit)
+    const sent = headers.get("x-clickzetta-token") ?? ""
+    studioTokens.push(sent)
+    if (sent !== "fresh-access") {
+      return new Response(JSON.stringify({ code: 401, message: "token is invalid" }), { status: 401 })
+    }
+    return new Response(JSON.stringify({ code: 0, data: { ok: true } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }) as typeof fetch
+}
+
+describe("Studio requests authenticate through the context's TokenSource", () => {
+  test("a stale credential is refreshed BEFORE the request, so no 401 happens", async () => {
+    const store = memoryStore(oauthToken(now, { expired: true }))
+    stubFetch({ refreshable: true })
+
+    const resp = await studioRequest(
+      studioConfig(connectionTokenSource(connectionConfig(store))),
+      "/studio/anything",
+      {},
+    )
+
+    expect(resp.code).toBe(0)
+    // Proactive refresh (EXPIRED_FACTOR) is the primary mechanism: the expired
+    // token never reaches the wire. Before contexts carried a source, the token
+    // was captured once at context-build time and this request went out stale.
+    expect(studioTokens).toEqual(["fresh-access"])
+    expect(store.load()?.token).toBe("fresh-access")
+  })
+
+  test("a credential the server rejects is rotated and the request retried once", async () => {
+    // Not yet expired by the clock, so only the server knows it is dead (early
+    // revocation, clock skew). This is what the 401 path is actually for.
+    const store = memoryStore(oauthToken(now, { expired: false }))
+    stubFetch({ refreshable: true })
+
+    const resp = await studioRequest(
+      studioConfig(connectionTokenSource(connectionConfig(store))),
+      "/studio/anything",
+      {},
+    )
+
+    expect(resp.code).toBe(0)
+    expect(studioTokens).toEqual(["stale-access", "fresh-access"])
+    expect(store.load()?.token).toBe("fresh-access")
+  })
+
+  test("a source with no rotation path lets the 401 stand", async () => {
+    stubFetch({ refreshable: true })
+
+    await expect(
+      studioRequest(
+        studioConfig(staticTokenSource({ token: "stale-access", instanceId: 9, userId: 7 })),
+        "/studio/anything",
+        {},
+      ),
+    ).rejects.toThrow(/401/)
+
+    // Attempted once: a rejected credential that cannot be replaced is not
+    // worth resending, so the retry loop does not burn attempts on it.
+    expect(studioTokens).toEqual(["stale-access"])
+  })
+
+  test("a dead session fails before issuing the request", async () => {
+    const store = memoryStore(oauthToken(now, { expired: true }))
+    stubFetch({ refreshable: false })
+
+    await expect(
+      studioRequest(studioConfig(connectionTokenSource(connectionConfig(store))), "/studio/anything", {}),
+    ).rejects.toThrow(/session expired/i)
+
+    // The source refuses up front, so no doomed request is sent at all.
+    expect(studioTokens).toEqual([])
+    expect(store.load()).toBeUndefined()
+  })
+})

--- a/packages/clickzetta-sdk/test/traceparent.test.ts
+++ b/packages/clickzetta-sdk/test/traceparent.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, mock, test } from "bun:test"
+import { staticTokenSource } from "../src/auth/token.js"
+
+/** Every authenticated request now names its credential source explicitly. */
+const tokens = staticTokenSource({ token: "tok", instanceId: 1, userId: 2 })
 
 const fetchCalls: Array<{ url: string; init?: RequestInit }> = []
 
@@ -31,6 +35,7 @@ describe("traceparent propagation", () => {
     await requestRaw(
       {
         baseUrl: "https://example.invalid",
+        tokens,
       },
       "/lh/getJob",
       { id: 1 },
@@ -48,6 +53,7 @@ describe("traceparent propagation", () => {
     await requestRaw(
       {
         baseUrl: "https://example.invalid",
+        tokens,
       },
       "/lh/getJob",
       { id: 2 },
@@ -66,7 +72,7 @@ describe("traceparent propagation", () => {
     await studioRequest(
       {
         baseUrl: "https://studio.invalid",
-        token: "tok",
+        tokens,
         workspaceId: 1,
         projectId: 2,
         instanceName: "inst",
@@ -98,7 +104,7 @@ describe("traceparent propagation", () => {
       await studioRequest(
         {
           baseUrl: "https://studio.invalid",
-          token: "tok",
+          tokens,
           workspaceId: 1,
           projectId: 2,
           instanceName: "inst",
@@ -128,17 +134,10 @@ describe("traceparent propagation", () => {
     await submitJob(
       {
         baseUrl: "https://example.invalid/api",
-        config: {
-          pat: "",
-          username: "alice",
-          password: "",
-          service: "example.invalid/api",
-          protocol: "https",
-          instance: "inst",
-          workspace: "ws",
-          schema: "public",
-          vcluster: "vw",
-        },
+        tokens,
+        // Payload metadata only — the submit body embeds the endpoint and login
+        // name. Authentication comes from `tokens` and nothing else.
+        context: { service: "example.invalid/api", instance: "inst", username: "alice" },
       },
       {
         sql: "select 1;",

--- a/packages/cz-cli/src/commands/ai-gateway.ts
+++ b/packages/cz-cli/src/commands/ai-gateway.ts
@@ -80,7 +80,7 @@ async function portalGet<T>(sc: StudioConfig, path: string): Promise<ApiResponse
   return request<T>(
     {
       baseUrl: sc.baseUrl,
-      token: sc.token,
+      tokens: sc.tokens,
       customHeaders: {
         instanceName: sc.instanceName,
         userId: String(sc.userId),

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -725,12 +725,17 @@ async function requestAnalytics(
     // Rebuilt per attempt: a refresh replaces `studio` wholesale, tenantId
     // included, and buildUrl puts that tenant in the query string.
     const url = buildUrl(endpoint, route, argv, query, studio.tenantId)
+    // AIGW is reached with its own fetch (different host and header shape), so the
+    // credential is resolved from the context's source here rather than by the SDK
+    // transport. Asking the source — not caching a token on the context — is what
+    // keeps this path in step with the rest.
+    const credential = await studio.tokens.get()
     const headers = mergeHeaders(
       {
         "Content-Type": "application/json",
         Accept: "application/json",
-        "x-clickzetta-token": studio.token,
-        Authorization: studio.token,
+        "x-clickzetta-token": credential.token,
+        Authorization: credential.token,
         traceparent: createTraceparent(),
         userId: String(studio.userId),
         instanceId: String(studio.instanceId),
@@ -744,7 +749,7 @@ async function requestAnalytics(
       studio.customHeaders,
     )
     const requestBody = route.openSessionAuth
-      ? mergeBody(body, { tenantId: studio.tenantId, userId: studio.userId, loginToken: studio.token })
+      ? mergeBody(body, { tenantId: studio.tenantId, userId: studio.userId, loginToken: credential.token })
       : body
     const response = await fetch(url, {
       method: route.method,

--- a/packages/cz-cli/src/commands/analytics-agent.ts
+++ b/packages/cz-cli/src/commands/analytics-agent.ts
@@ -1,15 +1,14 @@
 import { stat } from "node:fs/promises"
 import { basename, posix, resolve } from "node:path"
 import type { Argv } from "yargs"
-import { createTraceparent, forceRefreshToken, mergeHeaders, type ConnectionConfig } from "@clickzetta/sdk"
+import { createTraceparent, isRotatable, mergeHeaders } from "@clickzetta/sdk"
 import type { GlobalArgs } from "../cli.js"
 import { commandGroup } from "../command-group.js"
 import { readAgentEndpoint } from "../connection/profile-store.js"
+import { resolveConnectionConfig } from "../connection/config.js"
 import { success, error, handledError, isHandledCliError, shouldColorize, renderOutput, EXIT_BIZ_ERROR, EXIT_USAGE_ERROR } from "../output/index.js"
 import { formatMarkdown } from "../output/formatter.js"
 import { getProfileAgentContext, getStudioContext, type StudioContext } from "./studio-context.js"
-import { hasCookieToken } from "../connection/cookie-token.js"
-import { resolveConnectionConfig } from "../connection/config.js"
 import { logOperation } from "../logger.js"
 
 const ROUTES = {
@@ -645,16 +644,6 @@ function authRejected(response: Response, text: string): boolean {
   }
 }
 
-function canRefreshCredential(config: ConnectionConfig): boolean {
-  if (hasCookieToken(config)) return false
-  // `tokenStore` is attached for any `oauth = "<id>"` pointer, resolvable or not.
-  // A pointer whose [oauth.<id>] section was pruned loads nothing, so acquireToken
-  // finds no candidate, skips the refresh path, and falls through to a login with
-  // empty credentials — the ~6 s dead end token.ts:80-83 warns about. Ask the store
-  // for an actual token (synchronous, file-local) rather than for its existence.
-  return Boolean(config.tokenStore?.load() || config.pat || (config.username && config.password))
-}
-
 async function resolveAnalyticsContext(argv: Record<string, unknown>): Promise<ResolvedContext> {
   const format = typeof argv.format === "string" ? argv.format : "json"
   const endpoint = readAgentEndpoint(typeof argv.profile === "string" ? argv.profile : undefined)
@@ -674,28 +663,40 @@ async function resolveAnalyticsContext(argv: Record<string, unknown>): Promise<R
       },
     )
   }
-  const config = resolveConnectionConfig(argv)
   const profileAgent = getProfileAgentContext(argv)
   const context: ResolvedContext = {
     endpoint: endpoint!,
     studio: profileAgent ?? (await getStudioContext(argv, { allowMissingWorkspace: true })),
   }
-  if (canRefreshCredential(config)) {
-    // WHAT the server rejected decides the remedy, and the two cases differ.
-    //
-    // A [profiles.<n>.agent] token is hand-pasted into profiles.toml and is not
-    // the config's SDK credential at all, so the fix is just to authenticate the
-    // way the profile normally does — deliberately swapping identity to the
-    // profile's own login. Forcing there would throw away a still-valid OAuth
-    // access token and spend a refresh-token rotation to replace a token that was
-    // never the problem, turning a transient rotation failure into a hard error.
-    //
-    // When the rejected token IS the SDK's own, the opposite holds: a plain
-    // getToken would hand back the same value the server just refused (it is
-    // cached and not yet expired), so that path has to force a rotation.
-    const rejectedTokenIsSdkOwned = profileAgent === undefined
+  // WHAT the server rejected decides the remedy, and the TokenSource already
+  // encodes it: `rotate()` returns undefined for an identity with no rotation path
+  // (a cookie-pinned profile) and rotates for OAuth/PAT/password. Asking the source
+  // replaces a local copy of that policy — which re-implemented the SDK's private
+  // `hasLoginCredentials` and was exactly the kind of second copy this seam exists
+  // to remove.
+  //
+  // A [profiles.<n>.agent] token is hand-pasted into profiles.toml and is not the
+  // profile's SDK credential at all, so its source reports "cannot rotate" and the
+  // remedy is simply to authenticate the way the profile normally does — a
+  // deliberate switch to the profile's own login, without spending a refresh-token
+  // rotation on a token that was never the problem.
+  //
+  // Rebuilding the studio context stays either way: tenantId and workspace are
+  // re-resolved by the login, not by the rotation.
+  //
+  // Both branches need the profile to be able to authenticate at all: the [agent]
+  // remedy is "log in the way this profile normally does", which a profile carrying
+  // no credential and no persisted token cannot do. `isRotatable` is the SDK's own
+  // predicate — the same one `connectionTokenSource.rotate` consults — so this stays
+  // one implementation rather than a local copy of it.
+  const config = resolveConnectionConfig(argv)
+  if (isRotatable(config)) {
+    const tokens = context.studio.tokens
     context.refresh = async () => {
-      if (rejectedTokenIsSdkOwned) await forceRefreshToken(config)
+      if (profileAgent === undefined) {
+        const rejected = await tokens.get()
+        if (!(await tokens.rotate(rejected))) throw new Error("this profile's credential cannot be rotated")
+      }
       context.studio = await getStudioContext(argv, { allowMissingWorkspace: true })
     }
   }

--- a/packages/cz-cli/src/commands/exec.ts
+++ b/packages/cz-cli/src/commands/exec.ts
@@ -1,25 +1,9 @@
 import { resolveConnectionConfig, type CliArgs } from "../connection/config.js"
-import {
-  getToken,
-  clearTokenCache,
-  toServiceUrl,
-  newJobId,
-  submitJob,
-  pollJobResult,
-  parseJobResponse,
-  isRetryableErrorCode,
-  isVolumeSql,
-  processVolumeSql,
-  ClickZettaApiError,
-  type ClientOptions,
-  type ConnectionConfig,
-  type AuthToken,
-  type QueryResult,
-  JobStatus,
-} from "@clickzetta/sdk"
+import { getToken, toServiceUrl, newJobId, submitJob, pollJobResult, parseJobResponse, isRetryableErrorCode, isVolumeSql, processVolumeSql, ClickZettaApiError, type ClientOptions, type ConnectionConfig, type AuthToken, type QueryResult, JobStatus } from "@clickzetta/sdk"
 import { currentTraceContext, defaultQueryTag } from "../trace.js"
 import { patchProfileUserId } from "../connection/profile-store.js"
 import { getCookieToken, hasCookieToken } from "../connection/cookie-token.js"
+import { profileTokenSource } from "../connection/token-source.js"
 
 export interface ExecContext {
   config: ConnectionConfig
@@ -62,9 +46,9 @@ export async function getExecContext(args: Partial<CliArgs>): Promise<ExecContex
   if (token.userId) patchProfileUserId(args.profile, token.userId)
   const clientOpts: ClientOptions = {
     baseUrl: toServiceUrl(config.service, config.protocol),
-    token: token.token,
+    tokens: profileTokenSource(config),
     customHeaders: { ...config.customHeaders, instanceName: config.instance },
-    config,
+    context: { service: config.service, instance: config.instance, username: config.username },
   }
   return { config, token, clientOpts }
 }
@@ -251,11 +235,27 @@ export async function execSqlWithRetry(
     return await execSql(ctx, sql, opts)
   } catch (err) {
     if (!isAuthError(err)) throw err
-    // Clear stale token and re-authenticate
-    clearTokenCache()
-    const freshToken = await getToken(ctx.config)
-    ctx.token = freshToken
-    ctx.clientOpts.token = freshToken.token
+    // The SQL gateway reports some auth failures in the body rather than as a
+    // 401, so the transport's own rotation never sees them; rotate explicitly
+    // and retry once. clientOpts needs no patching: its source re-reads the
+    // rotated token on the next request.
+    //
+    // Rotation goes through the context's OWN source, not forceRefreshToken(config):
+    // a cookie-pinned profile has no rotation path, and handing its config to the
+    // refresh engine drives a full login with empty credentials (no pat, no
+    // username/password, no token store) — ~6s of retries ending in a misleading
+    // "Login failed" that hides the server's actual 401.
+    const source = ctx.clientOpts.tokens
+    const fresh = await source.rotate(await source.get())
+    if (!fresh) throw err
+    // Only the identity ids are carried over; the wire credential itself is read
+    // from the source on each request.
+    ctx.token = {
+      ...ctx.token,
+      token: fresh.token,
+      instanceId: fresh.instanceId || ctx.token.instanceId,
+      userId: fresh.userId || ctx.token.userId,
+    }
     return await execSql(ctx, sql, opts)
   }
 }

--- a/packages/cz-cli/src/commands/exec.ts
+++ b/packages/cz-cli/src/commands/exec.ts
@@ -1,5 +1,21 @@
 import { resolveConnectionConfig, type CliArgs } from "../connection/config.js"
-import { getToken, toServiceUrl, newJobId, submitJob, pollJobResult, parseJobResponse, isRetryableErrorCode, isVolumeSql, processVolumeSql, ClickZettaApiError, type ClientOptions, type ConnectionConfig, type AuthToken, type QueryResult, JobStatus } from "@clickzetta/sdk"
+import {
+  getToken,
+  toServiceUrl,
+  newJobId,
+  submitJob,
+  pollJobResult,
+  parseJobResponse,
+  isRetryableErrorCode,
+  isVolumeSql,
+  processVolumeSql,
+  ClickZettaApiError,
+  type ClientOptions,
+  type ConnectionConfig,
+  type AuthToken,
+  type QueryResult,
+  JobStatus,
+} from "@clickzetta/sdk"
 import { currentTraceContext, defaultQueryTag } from "../trace.js"
 import { patchProfileUserId } from "../connection/profile-store.js"
 import { getCookieToken, hasCookieToken } from "../connection/cookie-token.js"

--- a/packages/cz-cli/src/commands/job.ts
+++ b/packages/cz-cli/src/commands/job.ts
@@ -121,54 +121,50 @@ async function requestStudioJobJson(
   params: Record<string, string | number | boolean>,
   debug?: boolean,
 ): Promise<unknown> {
-  // new URL(path, base) discards base's path when path starts with "/", so concatenate manually
-  const base = sc.baseUrl.endsWith("/") ? sc.baseUrl.slice(0, -1) : sc.baseUrl
-  const url = new URL(base + path)
-  Object.entries(params).forEach((entry) => url.searchParams.set(entry[0], String(entry[1])))
-  const headers = {
-    "Content-Type": "application/json",
-    "Accept": "application/json, text/plain, */*",
-    "X-Clickzetta-Token": sc.token,
-    "userId": String(sc.userId),
-    "instanceId": String(sc.instanceId),
-    "accountId": String(sc.tenantId),
-    "tenantId": String(sc.tenantId),
-    "instanceName": sc.instanceName,
-    "workspaceName": sc.workspaceName,
-    "workspaceId": String(sc.workspaceId),
-    "projectId": String(sc.projectId),
+  // Query string is built here, but the request itself goes through the SDK
+  // transport so this path gets the same credential resolution and 401 rotation
+  // as every other authenticated call. It used to run its own `fetch` with a
+  // token string, which is exactly how paths drift apart.
+  const query = new URLSearchParams(
+    Object.entries(params).map(([key, value]) => [key, String(value)]),
+  ).toString()
+  const customHeaders = {
+    userId: String(sc.userId),
+    instanceId: String(sc.instanceId),
+    accountId: String(sc.tenantId),
+    tenantId: String(sc.tenantId),
+    instanceName: sc.instanceName,
+    workspaceName: sc.workspaceName,
+    workspaceId: String(sc.workspaceId),
+    projectId: String(sc.projectId),
     ...sc.customHeaders,
   }
   debugJobProfile(debug, "GET", {
-    url: url.toString(),
+    url: `${sc.baseUrl}${path}?${query}`,
     headers: {
-      instanceId: headers.instanceId,
-      instanceName: headers.instanceName,
-      workspaceName: headers.workspaceName,
-      workspaceId: headers.workspaceId,
-      projectId: headers.projectId,
-      userId: headers.userId,
-      tenantId: headers.tenantId,
+      instanceId: customHeaders.instanceId,
+      instanceName: customHeaders.instanceName,
+      workspaceName: customHeaders.workspaceName,
+      workspaceId: customHeaders.workspaceId,
+      projectId: customHeaders.projectId,
+      userId: customHeaders.userId,
+      tenantId: customHeaders.tenantId,
     },
   })
-  const response = await fetch(url, { headers, signal: AbortSignal.timeout(30_000) })
-  const text = await response.text()
-  debugJobProfile(debug, "response", {
-    path,
-    status: response.status,
-    ok: response.ok,
-    bytes: Buffer.byteLength(text, "utf-8"),
-  })
-  if (!response.ok) {
-    debugJobProfile(debug, "http_error", {
-      path,
-      status: response.status,
-      statusText: response.statusText,
-      bodyPreview: text.slice(0, 500),
-    })
-    throw new Error(`HTTP ${response.status} ${response.statusText}: ${text.slice(0, 500)}`)
+  let payload: unknown
+  try {
+    payload = await requestRaw<unknown>(
+      { baseUrl: sc.baseUrl, tokens: sc.tokens, customHeaders, timeout: 30_000 },
+      `${path}?${query}`,
+      undefined,
+      "GET",
+    )
+    debugJobProfile(debug, "response", { path, ok: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    debugJobProfile(debug, "response", { path, ok: false, message })
+    throw err
   }
-  const payload = JSON.parse(text) as unknown
   debugJobProfile(debug, "payload", {
     path,
     topLevelKeys: payloadKeys(payload),

--- a/packages/cz-cli/src/commands/job.ts
+++ b/packages/cz-cli/src/commands/job.ts
@@ -3,7 +3,7 @@ import { commandGroup } from "../command-group.js"
 import { mkdir, stat, writeFile } from "node:fs/promises"
 import { dirname } from "node:path"
 import {
-  requestRaw, pollJobResult, cancelJob,
+  requestRaw, pollJobResult, cancelJob, ClickZettaApiError,
   type ClientOptions, type JobID, type StudioConfig,
   JobStatus,
 } from "@clickzetta/sdk"
@@ -125,6 +125,8 @@ async function requestStudioJobJson(
   // transport so this path gets the same credential resolution and 401 rotation
   // as every other authenticated call. It used to run its own `fetch` with a
   // token string, which is exactly how paths drift apart.
+  // Trailing slash stripped so `${baseUrl}${path}` cannot produce a `//` path.
+  const baseUrl = sc.baseUrl.endsWith("/") ? sc.baseUrl.slice(0, -1) : sc.baseUrl
   const query = new URLSearchParams(
     Object.entries(params).map(([key, value]) => [key, String(value)]),
   ).toString()
@@ -140,7 +142,7 @@ async function requestStudioJobJson(
     ...sc.customHeaders,
   }
   debugJobProfile(debug, "GET", {
-    url: `${sc.baseUrl}${path}?${query}`,
+    url: `${baseUrl}${path}?${query}`,
     headers: {
       instanceId: customHeaders.instanceId,
       instanceName: customHeaders.instanceName,
@@ -154,15 +156,22 @@ async function requestStudioJobJson(
   let payload: unknown
   try {
     payload = await requestRaw<unknown>(
-      { baseUrl: sc.baseUrl, tokens: sc.tokens, customHeaders, timeout: 30_000 },
+      { baseUrl, tokens: sc.tokens, customHeaders, timeout: 30_000 },
       `${path}?${query}`,
       undefined,
       "GET",
     )
-    debugJobProfile(debug, "response", { path, ok: true })
+    debugJobProfile(debug, "response", { path, ok: true, bytes: JSON.stringify(payload ?? null).length })
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    debugJobProfile(debug, "response", { path, ok: false, message })
+    // The HTTP status is the field that makes this event worth reading, so it is
+    // pulled off the error rather than dropped with the hand-rolled fetch.
+    const status = err instanceof ClickZettaApiError ? err.statusCode : undefined
+    debugJobProfile(debug, "response", {
+      path,
+      ok: false,
+      ...(status !== undefined ? { status } : {}),
+      message: err instanceof Error ? err.message : String(err),
+    })
     throw err
   }
   debugJobProfile(debug, "payload", {

--- a/packages/cz-cli/src/commands/profile-bootstrap.ts
+++ b/packages/cz-cli/src/commands/profile-bootstrap.ts
@@ -7,6 +7,7 @@ import type { GlobalArgs } from "../cli.js"
 import { success, error } from "../output/index.js"
 import { logOperation } from "../logger.js"
 import { loginByAccountSite } from "./account-login.js"
+import { verbatimTokenSource } from "../connection/token-source.js"
 
 // ---------------------------------------------------------------------------
 // Data interfaces
@@ -306,7 +307,7 @@ async function loginByInstance(
 
   if (!tenantId) {
     try {
-      const user = await getCurrentUser(baseUrl, jwt)
+      const user = await getCurrentUser(baseUrl, { tokens: verbatimTokenSource(jwt) })
       userId = userId || coerceInt(user.id)
       tenantId = coerceInt(user.accountId)
       userName = user.name || userName
@@ -552,7 +553,7 @@ async function ensureIdentity(auth: AuthResult): Promise<AuthResult> {
   if (auth.userId && auth.tenantId) return auth
   const baseUrl = (auth.serviceUrl || "").replace(/\/$/, "")
   if (!baseUrl) throw new Error("failed to resolve tenant/account id")
-  const user = await getCurrentUser(baseUrl, auth.token)
+  const user = await getCurrentUser(baseUrl, { tokens: verbatimTokenSource(auth.token) })
   const userId = auth.userId || coerceInt(user.id)
   const tenantId = auth.tenantId || coerceInt(user.accountId)
   if (!tenantId) throw new Error("failed to resolve tenant/account id")
@@ -566,8 +567,9 @@ async function listWorkspacesForInstance(
 ): Promise<{ workspace_name: string; workspace_id: string; project_id: number }[]> {
   const fixed = await ensureIdentity(auth)
   const rows = await listUserWorkspaces(
-    fixed.serviceUrl, fixed.token, fixed.userId, fixed.tenantId,
+    fixed.serviceUrl, fixed.userId, fixed.tenantId,
     instanceId, instanceName,
+    { tokens: verbatimTokenSource(fixed.token) }, // minted by the login flow moments ago
   )
   return (rows || [])
     .map((row) => {

--- a/packages/cz-cli/src/commands/profile.ts
+++ b/packages/cz-cli/src/commands/profile.ts
@@ -112,9 +112,9 @@ async function resolveTenantNameRemotely(profile: ProfileEntry): Promise<{ tenan
   if (!pat && !(username && password)) {
     throw new Error("profile must contain PAT or username/password to resolve tenant name")
   }
-  const { getCurrentUser, getToken, toServiceUrl } = await import("@clickzetta/sdk")
+  const { getCurrentUser, getToken, toServiceUrl, connectionTokenSource } = await import("@clickzetta/sdk")
   const baseUrl = toServiceUrl(service, protocol)
-  const token = await getToken({
+  const resolveConfig = {
     pat,
     username,
     password,
@@ -124,8 +124,9 @@ async function resolveTenantNameRemotely(profile: ProfileEntry): Promise<{ tenan
     workspace: String(profile.workspace ?? ""),
     schema: String(profile.schema ?? "public"),
     vcluster: String(profile.vcluster ?? "default"),
-  })
-  const user = await getCurrentUser(baseUrl, token.token)
+  }
+  const token = await getToken(resolveConfig)
+  const user = await getCurrentUser(baseUrl, { tokens: connectionTokenSource(resolveConfig) })
   const tenantName = String((user as unknown as Record<string, unknown>).accountDisplayName ?? "").trim()
   if (!tenantName) throw new Error("accountDisplayName not found from current user")
   return { tenantName, source: pat ? "resolved_pat" : "resolved_password" }
@@ -358,12 +359,13 @@ export function registerProfileCommand(cli: Argv<GlobalArgs>): void {
                   schema: String(profileObj.schema ?? "public"),
                   vcluster: String(profileObj.vcluster ?? "default"),
                 }
-                const { getToken: getTokenSdk, toServiceUrl: toSvcUrl } = await import("@clickzetta/sdk")
+                const { getToken: getTokenSdk, toServiceUrl: toSvcUrl, connectionTokenSource: connectionTokenSourceSdk } = await import("@clickzetta/sdk")
                 const token = await getTokenSdk(verifyCfg)
                 const clientOpts = {
                   baseUrl: toSvcUrl(verifyCfg.service, verifyCfg.protocol),
-                  token: token.token,
+                  tokens: connectionTokenSourceSdk(verifyCfg),
                   customHeaders: { instanceName: verifyCfg.instance },
+                  context: { service: verifyCfg.service, instance: verifyCfg.instance, username: verifyCfg.username },
                 }
                 const r = await execSql({ config: verifyCfg, token, clientOpts }, "SELECT 1", { timeoutMs: 30000 })
                 if (isQueryResult(r) && r.status === JobStatus.FAILED) {

--- a/packages/cz-cli/src/commands/setup.ts
+++ b/packages/cz-cli/src/commands/setup.ts
@@ -18,6 +18,7 @@ import { execSql, isQueryResult } from "./exec.js"
 import { accountLoginUrlForService, loginByAccountSite, stripProtocol } from "./account-login.js"
 import { browserOpenCommandForPlatform } from "../util/browser.js"
 import { trackCommand, isSensitiveKey } from "../telemetry.js"
+import { profileTokenSource, verbatimTokenSource } from "../connection/token-source.js"
 
 const setupStartMs = Date.now()
 
@@ -601,7 +602,7 @@ async function loginWithInstanceCandidate(
   let resolvedUsername = String(jwt.userName ?? username)
 
   if (!tenantId) {
-    const user = await getCurrentUser(serviceUrl, login.token)
+    const user = await getCurrentUser(serviceUrl, { tokens: verbatimTokenSource(login.token) })
     userId = userId || coerceInt(user.id)
     tenantId = coerceInt(user.accountId)
     resolvedUsername = user.name || resolvedUsername
@@ -717,11 +718,11 @@ async function listWorkspaces(
 ): Promise<WorkspaceOption[]> {
   const rows = await listUserWorkspaces(
     auth.serviceUrl,
-    auth.token,
     auth.userId,
     auth.tenantId,
     instance.instanceId,
     instance.instanceName,
+    { tokens: verbatimTokenSource(auth.token) }, // minted by the login flow moments ago
   )
   return rows
     .map((row) => {
@@ -881,8 +882,9 @@ async function listSchemas(
         token,
         clientOpts: {
           baseUrl: toServiceUrl(config.service, config.protocol),
-          token: token.token,
+          tokens: profileTokenSource(config),
           customHeaders: { instanceName: config.instance },
+          context: { service: config.service, instance: config.instance, username: config.username },
         },
       },
       "SHOW SCHEMAS",

--- a/packages/cz-cli/src/commands/sql.ts
+++ b/packages/cz-cli/src/commands/sql.ts
@@ -467,7 +467,7 @@ async function executeSingle(
 
 async function resolveAccountDisplayName(ctx: ExecContext) {
   try {
-    return (await getCurrentUser(ctx.clientOpts.baseUrl, ctx.token.token, ctx.clientOpts.customHeaders)).accountDisplayName
+    return (await getCurrentUser(ctx.clientOpts.baseUrl, { tokens: ctx.clientOpts.tokens, customHeaders: ctx.clientOpts.customHeaders })).accountDisplayName
   } catch {
     return undefined
   }

--- a/packages/cz-cli/src/commands/studio-context.ts
+++ b/packages/cz-cli/src/commands/studio-context.ts
@@ -1,8 +1,8 @@
 import type { StudioConfig } from "@clickzetta/sdk"
-import { getToken, toServiceUrl, getCurrentUser, getWorkspaceByName, detectEnv } from "@clickzetta/sdk"
+import { toServiceUrl, getCurrentUser, getWorkspaceByName, detectEnv } from "@clickzetta/sdk"
 import { resolveConnectionConfig, type CliArgs } from "../connection/config.js"
 import { readAgentProfile } from "../connection/profile-store.js"
-import { getCookieToken } from "../connection/cookie-token.js"
+import { profileTokenSource, verbatimTokenSource } from "../connection/token-source.js"
 import { resolveInstanceIdByName } from "../connection/instance-id.js"
 import { handledError } from "../output/index.js"
 
@@ -22,20 +22,21 @@ export interface StudioContext extends StudioConfig {
 export async function getGatewayContext(args: Partial<CliArgs> & { format?: string; debug?: boolean }): Promise<GatewayContext> {
   const debug = !!args.debug
   const config = resolveConnectionConfig(args)
-  const token = await getCookieToken(config) ?? await getToken(config)
+  const tokens = profileTokenSource(config)
   const baseUrl = toServiceUrl(config.service, config.protocol)
-  const user = await getCurrentUser(baseUrl, token.token, config.customHeaders)
-  const instanceId = await resolveInstanceIdByName(baseUrl, token.token, user.accountId, config.instance, {
+  const user = await getCurrentUser(baseUrl, { tokens, customHeaders: config.customHeaders })
+  const credential = await tokens.get()
+  const instanceId = await resolveInstanceIdByName(baseUrl, tokens, user.accountId, config.instance, {
     customHeaders: config.customHeaders,
-    fallbackId: token.instanceId,
+    fallbackId: credential.instanceId,
     debug,
   })
   return {
-    token: token.token,
+    tokens,
     instanceId,
     workspaceId: 0,
     projectId: 0,
-    userId: token.userId,
+    userId: credential.userId,
     tenantId: user.accountId,
     instanceName: config.instance,
     workspaceName: config.workspace ?? "",
@@ -64,17 +65,18 @@ export async function getStudioContext(
   const format = args.format ?? "json"
   const debug = !!args.debug
   const config = resolveConnectionConfig(args)
-  const token = await getCookieToken(config) ?? await getToken(config)
+  const tokens = profileTokenSource(config)
   const baseUrl = toServiceUrl(config.service, config.protocol)
 
-  const user = await getCurrentUser(baseUrl, token.token, config.customHeaders)
+  const user = await getCurrentUser(baseUrl, { tokens, customHeaders: config.customHeaders })
+  const credential = await tokens.get()
   const tenantId = user.accountId
 
-  if (debug) process.stderr.write(`[debug] studio-context: baseUrl=${baseUrl} userId=${token.userId} tenantId=${tenantId} instanceId=${token.instanceId} instance=${config.instance} workspace=${config.workspace}\n`)
+  if (debug) process.stderr.write(`[debug] studio-context: baseUrl=${baseUrl} userId=${credential.userId} tenantId=${tenantId} instanceId=${credential.instanceId} instance=${config.instance} workspace=${config.workspace}\n`)
 
-  const instanceId = await resolveInstanceIdByName(baseUrl, token.token, tenantId, config.instance, {
+  const instanceId = await resolveInstanceIdByName(baseUrl, tokens, tenantId, config.instance, {
     customHeaders: config.customHeaders,
-    fallbackId: token.instanceId,
+    fallbackId: credential.instanceId,
     debug,
   })
 
@@ -85,14 +87,12 @@ export async function getStudioContext(
   const ws = config.workspace
     ? await getWorkspaceByName(
         baseUrl,
-        token.token,
-        token.userId,
+        credential.userId,
         tenantId,
         instanceId,
         config.instance,
         config.workspace,
-        debug,
-        config.customHeaders,
+        { tokens, debug, customHeaders: config.customHeaders },
       )
     : undefined
 
@@ -107,11 +107,11 @@ export async function getStudioContext(
   if (!ws && debug) process.stderr.write(`[debug] studio-context: workspace '${config.workspace}' unresolved, falling back to workspaceId=0 projectId=0 (allowMissingWorkspace)\n`)
 
   return {
-    token: token.token,
+    tokens,
     instanceId,
     workspaceId: ws?.workspaceId ?? 0,
     projectId: ws?.projectId ?? 0,
-    userId: token.userId,
+    userId: credential.userId,
     tenantId,
     instanceName: config.instance,
     workspaceName: config.workspace ?? "",
@@ -134,7 +134,11 @@ export function getProfileAgentContext(args: Partial<CliArgs> & { format?: strin
   if (!agent?.token || agent.tenantId === undefined || agent.userId === undefined) return undefined
   const config = resolveConnectionConfig(args)
   return {
-    token: agent.token,
+    // The [agent] block's token is its OWN identity, unrelated to the profile's
+    // OAuth login: rotating that login would not replace this token, so this
+    // source reports "cannot rotate" and callers wanting recovery re-resolve
+    // via getStudioContext (analytics-agent.ts).
+    tokens: verbatimTokenSource(agent.token, { instanceId: agent.instanceId, userId: agent.userId }),
     instanceId: agent.instanceId ?? 0,
     workspaceId: 0,
     projectId: 0,

--- a/packages/cz-cli/src/connection/cookie-token.ts
+++ b/packages/cz-cli/src/connection/cookie-token.ts
@@ -1,4 +1,4 @@
-import { toServiceUrl, type AuthToken, type ConnectionConfig } from "@clickzetta/sdk"
+import { staticTokenSource, toServiceUrl, type AuthToken, type ConnectionConfig } from "@clickzetta/sdk"
 import { resolveInstanceIdByName } from "./instance-id.js"
 
 function getHeader(headers: Record<string, string> | undefined, name: string): string | undefined {
@@ -65,7 +65,7 @@ export async function getCookieToken(config: ConnectionConfig): Promise<AuthToke
     || numeric(getHeader(config.customHeaders, "Instanceid"))
     || await resolveInstanceIdByName(
       toServiceUrl(config.service, config.protocol),
-      token,
+      staticTokenSource({ token, instanceId: 0, userId }),
       accountId,
       config.instance,
       { customHeaders: config.customHeaders },

--- a/packages/cz-cli/src/connection/instance-id.ts
+++ b/packages/cz-cli/src/connection/instance-id.ts
@@ -1,3 +1,4 @@
+import { requestRaw, type TokenSource } from "@clickzetta/sdk"
 function numeric(value: unknown): number {
   if (typeof value === "number" && Number.isFinite(value)) return value
   if (typeof value !== "string") return 0
@@ -18,18 +19,23 @@ function numeric(value: unknown): number {
  */
 export async function resolveInstanceIdByName(
   baseUrl: string,
-  token: string,
+  tokens: TokenSource,
   accountId: number,
   instanceName: string,
   opts?: { customHeaders?: Record<string, string>; fallbackId?: number; debug?: boolean },
 ): Promise<number> {
   const fallbackId = opts?.fallbackId ?? 0
   try {
-    const response = await fetch(`${baseUrl}/clickzetta-portal/service/serviceInstanceList?accountId=${accountId}`, {
-      headers: { ...opts?.customHeaders, "x-clickzetta-token": token, Accept: "application/json" },
-    })
-    if (!response.ok) return fallbackId
-    const payload = await response.json() as { data?: Array<Record<string, unknown>> }
+    // Goes through the SDK transport like every other authenticated call, so a
+    // rejected credential rotates here too. It used to run its own `fetch` with
+    // a token string, which meant an expired token silently degraded to
+    // `fallbackId` and the failure surfaced later as a wrong instance id.
+    const payload = await requestRaw<{ data?: Array<Record<string, unknown>> }>(
+      { baseUrl, tokens, customHeaders: opts?.customHeaders },
+      `/clickzetta-portal/service/serviceInstanceList?accountId=${accountId}`,
+      undefined,
+      "GET",
+    )
     const match = (payload.data ?? []).find((row) =>
       String(row.name ?? row.instanceName ?? "") === instanceName
       && numeric(row.serviceId ?? 1) === 1,

--- a/packages/cz-cli/src/connection/instance-id.ts
+++ b/packages/cz-cli/src/connection/instance-id.ts
@@ -27,9 +27,10 @@ export async function resolveInstanceIdByName(
   const fallbackId = opts?.fallbackId ?? 0
   try {
     // Goes through the SDK transport like every other authenticated call, so a
-    // rejected credential rotates here too. It used to run its own `fetch` with
-    // a token string, which meant an expired token silently degraded to
-    // `fallbackId` and the failure surfaced later as a wrong instance id.
+    // rejected credential rotates here instead of the request simply failing.
+    // A failure that rotation cannot fix STILL degrades to `fallbackId` (the
+    // catch below) — callers decide what a missing id means, and that contract
+    // predates this change.
     const payload = await requestRaw<{ data?: Array<Record<string, unknown>> }>(
       { baseUrl, tokens, customHeaders: opts?.customHeaders },
       `/clickzetta-portal/service/serviceInstanceList?accountId=${accountId}`,

--- a/packages/cz-cli/src/connection/oauth-enumerate.ts
+++ b/packages/cz-cli/src/connection/oauth-enumerate.ts
@@ -1,6 +1,7 @@
 import { listUserWorkspaces, toServiceUrl } from "@clickzetta/sdk"
 import type { AuthToken } from "@clickzetta/sdk"
 import type { OAuthInstance } from "../commands/login-browser.js"
+import { verbatimTokenSource } from "./token-source.js"
 
 /**
  * One (instance × workspace) connection combination discovered after an OAuth
@@ -50,11 +51,11 @@ export async function enumerateOAuthCombos(input: {
     try {
       const rows = await listUserWorkspaces(
         toServiceUrl(inst.service),
-        token.token,
         userId,
         tenantId,
         inst.instanceId,
         inst.instanceName,
+        { tokens: verbatimTokenSource(token.token) }, // the token the login just minted
       )
       for (const row of rows) {
         const raw = row as unknown as Record<string, unknown>

--- a/packages/cz-cli/src/connection/token-source.ts
+++ b/packages/cz-cli/src/connection/token-source.ts
@@ -22,14 +22,42 @@ import { getCookieToken, hasCookieToken } from "./cookie-token.js"
  */
 export function profileTokenSource(config: ConnectionConfig): TokenSource {
   if (!hasCookieToken(config)) return connectionTokenSource(config)
+
+  // Resolved once per source, not per request: `getCookieToken` parses the cookie
+  // AND may resolve the instance id over the network when the JWT lacks it, while
+  // the transport calls `get()` before every attempt of every request on the
+  // premise that it is cache-backed.
+  let resolved: Promise<Credential | undefined> | undefined
+  const fallback = connectionTokenSource(config)
   return {
     async get(): Promise<Credential> {
-      const token = await getCookieToken(config)
-      if (!token) throw new Error("profile cookie token disappeared while resolving credentials")
-      return { token: token.token, instanceId: token.instanceId, userId: token.userId }
+      resolved ??= getCookieToken(config).then((token) =>
+        token
+          ? {
+              token: token.token,
+              instanceId: token.instanceId,
+              userId: token.userId,
+              // The Cookie travels WITH the credential: a session credential is
+              // only accepted alongside it, and the transport merges these.
+              ...(cookieHeader(config) ? { headers: { Cookie: cookieHeader(config)! } } : {}),
+            }
+          : undefined,
+      )
+      // `hasCookieToken` accepts an empty `X-ClickZetta-Token=` value that
+      // `getCookieToken` rejects. That profile still has a pat/OAuth login to fall
+      // back to, exactly as it did before this seam existed.
+      return (await resolved) ?? await fallback.get()
     },
-    rotate: async () => undefined,
+    async rotate(rejected: Credential): Promise<Credential | undefined> {
+      // A cookie is not rotatable; a profile that fell through to pat/OAuth is.
+      return (await resolved) ? undefined : fallback.rotate(rejected)
+    },
   }
+}
+
+function cookieHeader(config: ConnectionConfig): string | undefined {
+  return Object.entries(config.customHeaders ?? {})
+    .find(([key]) => key.toLowerCase() === "cookie")?.[1]
 }
 
 /**

--- a/packages/cz-cli/src/connection/token-source.ts
+++ b/packages/cz-cli/src/connection/token-source.ts
@@ -1,0 +1,42 @@
+import {
+  connectionTokenSource,
+  staticTokenSource,
+  type ConnectionConfig,
+  type Credential,
+  type TokenSource,
+} from "@clickzetta/sdk"
+import { getCookieToken, hasCookieToken } from "./cookie-token.js"
+
+/**
+ * The one place cz-cli decides how a profile authenticates.
+ *
+ * A cookie-pinned profile's credential IS its `Cookie`: it was issued by a
+ * browser session, the profile gets no OAuth token store
+ * (`connection/config.ts`), and rotating would mint an identity the server never
+ * saw. That is expressed by handing back a source with no rotation path rather
+ * than by a flag every request has to carry — which is what let the Studio
+ * commands lose 401 recovery while `sql` kept it.
+ *
+ * Everything else (OAuth, PAT, username/password) gets the standard connection
+ * source: cached, proactively refreshed, rotatable on 401.
+ */
+export function profileTokenSource(config: ConnectionConfig): TokenSource {
+  if (!hasCookieToken(config)) return connectionTokenSource(config)
+  return {
+    async get(): Promise<Credential> {
+      const token = await getCookieToken(config)
+      if (!token) throw new Error("profile cookie token disappeared while resolving credentials")
+      return { token: token.token, instanceId: token.instanceId, userId: token.userId }
+    },
+    rotate: async () => undefined,
+  }
+}
+
+/**
+ * A credential the caller already holds and cannot rotate: a token a login flow
+ * minted seconds ago, or a profile `[agent]` block's own identity. Prefer
+ * {@link profileTokenSource} whenever a `ConnectionConfig` is in reach.
+ */
+export function verbatimTokenSource(token: string, ids?: { instanceId?: number; userId?: number }): TokenSource {
+  return staticTokenSource({ token, instanceId: ids?.instanceId ?? 0, userId: ids?.userId ?? 0 })
+}

--- a/packages/cz-cli/src/opencode-plugin/gateway-prompt.ts
+++ b/packages/cz-cli/src/opencode-plugin/gateway-prompt.ts
@@ -25,6 +25,7 @@ import * as Profile from "../connection/profile-context.js"
 import { loadProfiles } from "../connection/profile-store.js"
 import { rewriteClickzettaGatewayError, type GatewayErrorCode } from "../llm/gateway-error.js"
 import { readLlmEntries } from "../llm/native-config.js"
+import { profileTokenSource } from "../connection/token-source.js"
 
 export { browserOpenCommandForPlatform }
 
@@ -151,7 +152,9 @@ async function runtimeAccountName(input: {
     })
     const token = (await getCookieToken(config)) ?? (await getToken(config))
     if (input.signal?.aborted) return undefined
-    const user = await getCurrentUser(toServiceUrl(config.service, config.protocol), token.token)
+    const user = await getCurrentUser(toServiceUrl(config.service, config.protocol), {
+      tokens: profileTokenSource(config),
+    })
     return str(user.accountDisplayName)
   } catch {
     return undefined

--- a/packages/cz-cli/src/opencode-plugin/gateway-prompt.ts
+++ b/packages/cz-cli/src/opencode-plugin/gateway-prompt.ts
@@ -16,11 +16,10 @@
 // intact (rewriteApiCallError keeps it, parseAPICallError forwards it), so the
 // classifier is simply run a second time here — same function, same verdict, no
 // schema change and no private field smuggled through the event.
-import { getCurrentUser, getToken, toServiceUrl } from "@clickzetta/sdk"
+import { getCurrentUser, toServiceUrl } from "@clickzetta/sdk"
 import { browserOpenCommandForPlatform } from "../util/browser.js"
 import { resolveAccountsUrl } from "../commands/billing-error.js"
 import { resolveConnectionConfig } from "../connection/config.js"
-import { getCookieToken } from "../connection/cookie-token.js"
 import * as Profile from "../connection/profile-context.js"
 import { loadProfiles } from "../connection/profile-store.js"
 import { rewriteClickzettaGatewayError, type GatewayErrorCode } from "../llm/gateway-error.js"
@@ -150,7 +149,6 @@ async function runtimeAccountName(input: {
         : {}),
       ...(instance ? { instance } : {}),
     })
-    const token = (await getCookieToken(config)) ?? (await getToken(config))
     if (input.signal?.aborted) return undefined
     const user = await getCurrentUser(toServiceUrl(config.service, config.protocol), {
       tokens: profileTokenSource(config),

--- a/packages/cz-cli/src/opencode-plugin/tui-quota-data.ts
+++ b/packages/cz-cli/src/opencode-plugin/tui-quota-data.ts
@@ -20,10 +20,10 @@ import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { getToken, toServiceUrl } from "@clickzetta/sdk"
 import { resolveConnectionConfig } from "../connection/config.js"
-import { getCookieToken } from "../connection/cookie-token.js"
 import * as Profile from "../connection/profile-context.js"
 import { deriveAuthType, explicitAuthType, loadProfiles } from "../connection/profile-store.js"
 import { readLlmEntries } from "../llm/native-config.js"
+import { profileTokenSource } from "../connection/token-source.js"
 
 const BILLING_PATH = "/clickzetta-portal/hornhub/account/billing/account"
 const API_KEYS_PATH = "/clickzetta-portal/user/listApiKeys"
@@ -293,8 +293,11 @@ export async function fetchProfileUserName(
       ...(profile.protocol === "http" || profile.protocol === "https" ? { protocol: profile.protocol } : {}),
       ...(typeof profile.instance === "string" ? { instance: profile.instance } : {}),
     })
-    const token = (await getCookieToken(config)) ?? (await getToken(config))
-    const name = await readCurrentUserName(toServiceUrl(config.service, config.protocol), token.token, input.signal)
+    // Resolve through the shared source so an expired token refreshes here too,
+    // instead of the indicator silently going blank (this file kept its own
+    // fetch for host probing and cancellation, but not its own credential).
+    const credential = await profileTokenSource(config).get()
+    const name = await readCurrentUserName(toServiceUrl(config.service, config.protocol), credential.token, input.signal)
     if (!name) return undefined
     userNameCache.set(info.profile, name)
     return { profile: info.profile, name }
@@ -682,7 +685,7 @@ async function fetchProfileSnapshot(input: {
       : {}),
     ...(typeof input.profile.instance === "string" ? { instance: input.profile.instance } : {}),
   })
-  const token = (await getCookieToken(config)) ?? (await getToken(config))
+  const credential = await profileTokenSource(config).get()
   const baseUrl = toServiceUrl(config.service, config.protocol)
   const accountId = num(input.profile.account_id)
   const profileUserName = typeof input.profile.username === "string" ? input.profile.username.trim() : ""
@@ -691,7 +694,7 @@ async function fetchProfileSnapshot(input: {
       ? Promise.resolve(undefined)
       : accountId === undefined
         ? Promise.reject(new Error("profile has no account_id"))
-        : portalRead(baseUrl, `${BILLING_PATH}/${accountId}`, token.token, { signal: input.signal }),
+        : portalRead(baseUrl, `${BILLING_PATH}/${accountId}`, credential.token, { signal: input.signal }),
     (async () => {
       // No key to match against — skip the read rather than spend two portal
       // round-trips on a result nothing can consume.
@@ -700,8 +703,8 @@ async function fetchProfileSnapshot(input: {
       // lets us pass it through, but listApiKeys ignores the userName value and
       // scopes to the token identity regardless, so a failed/empty lookup still
       // returns the caller's keys — fall back to an empty name rather than bail.
-      const userName = profileUserName || (await readCurrentUserName(baseUrl, token.token, input.signal)) || ""
-      return portalRead(baseUrl, `${API_KEYS_PATH}?userName=${encodeURIComponent(userName)}`, token.token, {
+      const userName = profileUserName || (await readCurrentUserName(baseUrl, credential.token, input.signal)) || ""
+      return portalRead(baseUrl, `${API_KEYS_PATH}?userName=${encodeURIComponent(userName)}`, credential.token, {
         signal: input.signal,
       })
     })(),

--- a/packages/cz-cli/test/analytics-agent-id-validation.test.ts
+++ b/packages/cz-cli/test/analytics-agent-id-validation.test.ts
@@ -12,7 +12,9 @@ mock.module("../src/connection/profile-store.js", () => ({
 mock.module("../src/commands/studio-context.js", () => ({
   getProfileAgentContext: () => undefined,
   getStudioContext: async () => ({
-    token: "studio-token",
+    // Contexts carry a TokenSource now: the transport asks it per request, so
+    // a fixture supplies a source rather than a token string.
+    tokens: { get: async () => ({ token: "studio-token", instanceId: 11, userId: 44 }), rotate: async () => undefined },
     instanceId: 11,
     workspaceId: 22,
     projectId: 33,

--- a/packages/cz-cli/test/analytics-agent-knowledge-domain-id.test.ts
+++ b/packages/cz-cli/test/analytics-agent-knowledge-domain-id.test.ts
@@ -15,7 +15,9 @@ mock.module("../src/connection/profile-store.js", () => ({
 mock.module("../src/commands/studio-context.js", () => ({
   getProfileAgentContext: () => undefined,
   getStudioContext: async () => ({
-    token: "studio-token",
+    // Contexts carry a TokenSource now: the transport asks it per request, so
+    // a fixture supplies a source rather than a token string.
+    tokens: { get: async () => ({ token: "studio-token", instanceId: 11, userId: 44 }), rotate: async () => undefined },
     instanceId: 11,
     workspaceId: 22,
     projectId: 33,

--- a/packages/cz-cli/test/analytics-agent-session-commands.test.ts
+++ b/packages/cz-cli/test/analytics-agent-session-commands.test.ts
@@ -18,7 +18,9 @@ mock.module("../src/connection/profile-store.js", () => ({
 mock.module("../src/commands/studio-context.js", () => ({
   getProfileAgentContext: () => undefined,
   getStudioContext: async () => ({
-    token: "studio-token",
+    // Contexts carry a TokenSource now: the transport asks it per request, so
+    // a fixture supplies a source rather than a token string.
+    tokens: { get: async () => ({ token: "studio-token", instanceId: 11, userId: 44 }), rotate: async () => undefined },
     instanceId: 11,
     workspaceId: 22,
     projectId: 33,

--- a/packages/cz-cli/test/analytics-agent-session-run.test.ts
+++ b/packages/cz-cli/test/analytics-agent-session-run.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { onFetch, onStudio, stubStudioContext } from "./support/cz-fixtures.js"
+import { clearTokenCache } from "@clickzetta/sdk"
 
 // Network-boundary test: no mock.module of our own src. The real analytics-agent session run
 // command runs (registerAnalyticsAgentCommand → resolveAnalyticsContext →
@@ -62,6 +63,11 @@ describe("analytics-agent session run", () => {
       ].join("\n"),
     )
     stubStudioContext()
+    // The SDK token cache is process-global, and these cases assert what a refresh
+    // does — a token another suite left cached under the same key makes the
+    // assertion depend on file order. Sibling suites (main-sync-ports, task-merge,
+    // task-condition-flow, tui-quota-data) already reset it.
+    clearTokenCache()
   })
 
   afterEach(() => {

--- a/packages/cz-cli/test/profile-cookie-auth.test.ts
+++ b/packages/cz-cli/test/profile-cookie-auth.test.ts
@@ -106,8 +106,59 @@ test("getExecContext uses X-ClickZetta-Token from profile Cookie header", async 
     expect(ctx.token.token).toBe(token)
     expect(ctx.token.instanceId).toBe(86)
     expect(ctx.token.userId).toBe(7)
-    expect(ctx.clientOpts.token).toBe(token)
+    // The context carries a SOURCE, not a token: it must resolve to the cookie
+    // credential and report that this identity cannot be rotated (rotating would
+    // mint an OAuth token the cookie-authenticating server never issued).
+    const credential = await ctx.clientOpts.tokens.get()
+    expect(credential.token).toBe(token)
+    expect(await ctx.clientOpts.tokens.rotate(credential)).toBeUndefined()
     expect(ctx.clientOpts.customHeaders.Cookie).toContain(token)
     expect(ctx.clientOpts.customHeaders.instanceName).toBe("inst")
   })
 })
+
+test("a 401 on a cookie profile surfaces, and never attempts a credential-less login", async () => {
+  await withHome("cz-profile-cookie-401-", async (home) => {
+    const token = jwt({ userId: 7, accountId: 3, instanceId: 86, exp: 4_102_444_800 })
+    writeFileSync(
+      join(home, ".clickzetta", "profiles.toml"),
+      [
+        'default_profile = "cookie"',
+        "",
+        "[profiles.cookie]",
+        'service = "api.example.com"',
+        'protocol = "https"',
+        'instance = "inst"',
+        'workspace = "ws"',
+        "",
+        "[profiles.cookie.header]",
+        `"Cookie" = "theme=light; X-ClickZetta-Token=${token}"`,
+        "",
+      ].join("\n"),
+    )
+
+    const { getExecContext, execSqlWithRetry } = await import(`../src/commands/exec.ts?cookie-401-${Date.now()}`)
+    const ctx = await getExecContext({})
+
+    // `execSqlWithRetry` used to recover by calling forceRefreshToken(ctx.config).
+    // A cookie profile has no pat, no username/password and no token store, so that
+    // drove a full portal login with EMPTY credentials: several seconds of retries
+    // ending in a misleading "Login failed" that hid the server's actual 401.
+    const originalFetch = globalThis.fetch
+    const urls: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      urls.push(String(input))
+      return new Response("token is invalid", { status: 401 })
+    }) as typeof fetch
+
+    try {
+      await expect(execSqlWithRetry(ctx, "select 1")).rejects.toThrow(/401/)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+
+    expect(urls.some((u) => u.includes("/lh/submitJob"))).toBe(true)
+    expect(urls.some((u) => u.includes("loginSingle"))).toBe(false)
+    expect(urls.some((u) => u.includes("oauth2/token"))).toBe(false)
+  })
+}, 30_000)

--- a/packages/cz-cli/test/studio-cookie-auth.test.ts
+++ b/packages/cz-cli/test/studio-cookie-auth.test.ts
@@ -101,7 +101,11 @@ test("getStudioContext resolves via profile Cookie token without hitting loginSi
     const { getStudioContext } = await import(`../src/commands/studio-context.ts?studio-cookie-${Date.now()}`)
     try {
       const ctx = await getStudioContext({ format: "json" })
-      expect(ctx.token).toBe(token)
+      // The context carries a source; a cookie identity resolves to the cookie
+      // token and reports that it cannot be rotated.
+      const credential = await ctx.tokens.get()
+      expect(credential.token).toBe(token)
+      expect(await ctx.tokens.rotate(credential)).toBeUndefined()
       expect(ctx.userId).toBe(7)
       expect(ctx.instanceId).toBe(86)
       expect(ctx.workspaceId).toBe("wid-1")


### PR DESCRIPTION
Authentication was data that callers passed around: client options and studio
contexts carried a token string, so every call site also needed its own copy of
"how to replace this". Only sql/session.ts ever had it, so an expired token
self-healed on the SQL path while task, job, runs and schema surfaced
`401 token is invalid` on the same profile — and the previous fix had to be
written a second time inside analytics-agent.

- ClientOptions.tokens and StudioConfig.tokens are required TokenSources. The
  transport resolves the credential before each attempt and asks the same source
  to rotate once on a 401, so obtaining a credential and being able to replace it
  are one capability.
- An identity with no rotation path is a kind of source — staticTokenSource, or
  profileTokenSource for a cookie-pinned profile whose Cookie is the credential —
  rather than a flag each request carries.
- Proactive refresh keeps an expired token off the wire; an unrecoverable 401 is
  terminal instead of burning three retries, and a dead session fails before the
  request is sent.
- Request-body metadata (the SQL submit payload's service, instance and login
  name) moved to ClientOptions.context, which authentication never reads.
- job profile reads and instance-id resolution go through the transport too;
  instance-id used to swallow a 401 into a fallback instance id.
- exec's SQL retry rotates through the context's source: handing a cookie-pinned
  profile's config to the refresh engine drove a login with empty credentials.

Verified: sdk 280 tests, cz-cli 1198 tests, typecheck and build clean.

