### PR TITLE
feat: gateway quota, Windows spinner + install, sql job_id, per-profile instance id

### DIFF
--- a/packages/clickzetta-ai-gateway/package.json
+++ b/packages/clickzetta-ai-gateway/package.json
@@ -6,7 +6,9 @@
   "exports": {
     ".": "./src/index.ts",
     "./gateway-error": "./src/gateway-error.ts",
-    "./url": "./src/url.ts"
+    "./url": "./src/url.ts",
+    "./quota": "./src/quota.ts",
+    "./quota-store": "./src/quota-store.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/packages/clickzetta-ai-gateway/src/index.ts
+++ b/packages/clickzetta-ai-gateway/src/index.ts
@@ -9,8 +9,12 @@ import type {
   LanguageModelV3CallOptions,
   LanguageModelV3GenerateResult,
   LanguageModelV3StreamResult,
+  SharedV3Headers,
+  SharedV3ProviderMetadata,
 } from "@ai-sdk/provider"
 import { rewriteClickzettaGatewayError } from "./gateway-error"
+import { parseClickzettaQuota, type ClickzettaQuota } from "./quota"
+import { recordGatewayQuota } from "./quota-store"
 import { normalizeClickzettaGatewayUrl } from "./url"
 
 /**
@@ -18,10 +22,17 @@ import { normalizeClickzettaGatewayUrl } from "./url"
  * ClickZetta AI gateway.
  *
  * ClickZetta speaks the OpenAI-compatible wire protocol, so the base SDK does
- * all the real work. This shell adds one behaviour: when the gateway returns a
- * billing / quota error, the raw APICallError is rewritten into an actionable,
- * user-facing message and marked non-retryable — so the retry loop stops and the
- * user sees a clear next step instead of a raw 429/402 body.
+ * all the real work. This shell adds two behaviours:
+ *
+ *  - when the gateway returns a billing / quota error, the raw APICallError is
+ *    rewritten into an actionable, user-facing message and marked non-retryable —
+ *    so the retry loop stops and the user sees a clear next step instead of a raw
+ *    429/402 body;
+ *  - the key's remaining token quota, which the gateway reports on every
+ *    successful completion's headers, is published as
+ *    `providerMetadata.clickzetta.quota` and cached for out-of-process readers,
+ *    so a caller can show it without a second request or portal credentials.
+ *    See quota.ts and quota-store.ts.
  *
  * Everything else (model listing, streaming, tool calls, prompt caching) passes
  * straight through.
@@ -123,14 +134,69 @@ function withClickzettaPromptCaching(options: LanguageModelV3CallOptions, modelI
 }
 
 /**
+ * The endpoint/key a wrapped model answers for, so a quota reading can be filed
+ * against the credential it describes. Absent when the provider was built without
+ * an apiKey, in which case only the in-band metadata is published.
+ */
+type QuotaTarget = { baseURL: string; apiKey: string } | undefined
+
+/**
+ * Read the quota off a response's headers and cache it for the sidebar indicator,
+ * which reads it from another process (quota-store.ts).
+ *
+ * Called as soon as the headers exist — for a stream that is when it opens, not when
+ * it finishes. Caching at `finish` would throw away a reading already in hand
+ * whenever the turn is aborted or errors mid-stream, and the numbers describe the
+ * request's admission, so waiting adds nothing.
+ *
+ * Total: an HTTP call that already succeeded must not fail over a local cache. The
+ * guard is HERE rather than at the two call sites so neither can forget it, and so a
+ * third can't: `recordGatewayQuota` swallows its own write errors, but the parse and
+ * the read-modify-write around it can still throw (a truncated store from a racing
+ * writer, a homedir that resolves somewhere unreadable). In doStream that would
+ * escape uncaught; in doGenerate it would be worse — `mapThrown` would dress a local
+ * cache problem up as a ClickZetta gateway error.
+ */
+function recordQuota(headers: SharedV3Headers | undefined, target: QuotaTarget) {
+  try {
+    const quota = parseClickzettaQuota(headers)
+    if (quota && target) recordGatewayQuota({ ...target, quotas: quota })
+    return quota
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Publish the quota on a result's provider metadata, leaving any metadata the base
+ * provider already set untouched. Returns the input unchanged when there is nothing
+ * to add, so a response the wrapper has nothing to say about stays identical.
+ */
+function withQuota(
+  metadata: SharedV3ProviderMetadata | undefined,
+  quota: ClickzettaQuota[] | undefined,
+): SharedV3ProviderMetadata | undefined {
+  if (!quota) return metadata
+  return {
+    ...metadata,
+    clickzetta: { ...metadata?.clickzetta, quota },
+  }
+}
+
+/**
  * Wrap a LanguageModelV3 so doGenerate/doStream errors run through the rewriter.
  * Delegates every other member to the underlying model via prototype so future
  * SDK additions keep working without changes here.
  */
-function wrapModel(model: LanguageModelV3, modelId: string): LanguageModelV3 {
+function wrapModel(model: LanguageModelV3, modelId: string, target?: QuotaTarget): LanguageModelV3 {
   const doGenerate = async (options: LanguageModelV3CallOptions): Promise<LanguageModelV3GenerateResult> => {
     try {
-      return await model.doGenerate(withClickzettaPromptCaching(options, modelId))
+      const result = await model.doGenerate(withClickzettaPromptCaching(options, modelId))
+      const quota = recordQuota(result.response?.headers, target)
+      const providerMetadata = withQuota(result.providerMetadata, quota)
+      // Same object back when the gateway reported no quota, so a response the
+      // wrapper has nothing to add to stays byte-identical.
+      return providerMetadata === result.providerMetadata ? result : { ...result, providerMetadata }
     } catch (error) {
       throw mapThrown(error)
     }
@@ -143,6 +209,11 @@ function wrapModel(model: LanguageModelV3, modelId: string): LanguageModelV3 {
     } catch (error) {
       throw mapThrown(error)
     }
+    // Response headers are already available here — they arrive before the body — so
+    // the cache is written now, while the reading cannot be lost to an aborted turn.
+    // Only the in-band publication waits for the "finish" part, because that is where
+    // consumers read per-step metadata.
+    const quota = recordQuota(result.response?.headers, target)
     // HTTP errors usually reject doStream above, but the SDK can also surface a
     // late error as an in-stream "error" part — rewrite those too.
     const stream = result.stream.pipeThrough(
@@ -150,6 +221,11 @@ function wrapModel(model: LanguageModelV3, modelId: string): LanguageModelV3 {
         transform(chunk, controller) {
           if (chunk?.type === "error") {
             controller.enqueue({ ...chunk, error: mapThrown(chunk.error) })
+            return
+          }
+          if (chunk?.type === "finish") {
+            const providerMetadata = withQuota(chunk.providerMetadata, quota)
+            controller.enqueue(providerMetadata === chunk.providerMetadata ? chunk : { ...chunk, providerMetadata })
             return
           }
           controller.enqueue(chunk)
@@ -192,11 +268,14 @@ export function createClickzetta(options: ClickzettaProviderSettings): OpenAICom
     baseURL: normalizeClickzettaGatewayUrl(options.baseURL),
   })
 
-  const languageModel = (modelId: string): LanguageModelV3 => wrapModel(base.languageModel(modelId), modelId)
+  // Recorded against the normalized URL so a reader that resolved the same endpoint
+  // from llm.json's raw form lands on the same cache key.
+  const target = options.apiKey ? { baseURL: normalizeClickzettaGatewayUrl(options.baseURL), apiKey: options.apiKey } : undefined
+  const languageModel = (modelId: string): LanguageModelV3 => wrapModel(base.languageModel(modelId), modelId, target)
 
   const provider = ((modelId: string) => languageModel(modelId)) as OpenAICompatibleProvider
   provider.languageModel = languageModel
-  provider.chatModel = (modelId: string) => wrapModel(base.chatModel(modelId), modelId)
+  provider.chatModel = (modelId: string) => wrapModel(base.chatModel(modelId), modelId, target)
   provider.completionModel = base.completionModel.bind(base)
   provider.embeddingModel = base.embeddingModel.bind(base)
   provider.textEmbeddingModel = base.textEmbeddingModel.bind(base)
@@ -206,6 +285,18 @@ export function createClickzetta(options: ClickzettaProviderSettings): OpenAICom
 
 export { createClickzetta as createOpenAICompatible }
 export { normalizeClickzettaGatewayUrl } from "./url"
+export {
+  parseClickzettaQuota,
+  formatClickzettaQuota,
+  type ClickzettaQuota,
+  type ClickzettaQuotaPeriod,
+} from "./quota"
+export {
+  gatewayQuotaCacheKey,
+  readGatewayQuota,
+  recordGatewayQuota,
+  type GatewayQuotaEntry,
+} from "./quota-store"
 export {
   rewriteClickzettaGatewayError,
   clickzettaGatewayCode,

--- a/packages/clickzetta-ai-gateway/src/quota-store.ts
+++ b/packages/clickzetta-ai-gateway/src/quota-store.ts
@@ -21,7 +21,7 @@
  * falls back to what it showed before.
  */
 import { createHash } from "node:crypto"
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import type { ClickzettaQuota } from "./quota"
@@ -72,12 +72,26 @@ export function recordGatewayQuota(input: { baseURL: string; apiKey: string; quo
     entries[gatewayQuotaCacheKey(input.baseURL, input.apiKey)] = { updated_at: now, quotas: input.quotas }
     const body = JSON.stringify({ entries }, null, 2)
     try {
-      writeFileSync(file, body, "utf-8")
+      writeFileSync(file, body, { encoding: "utf-8", mode: 0o600 })
     } catch {
-      // Only the first write of a fresh install needs the directory; paying mkdirSync on
-      // every request to create something that already exists is a syscall per LLM call.
-      mkdirSync(dirname(file), { recursive: true })
-      writeFileSync(file, body, "utf-8")
+      // Only the first write of a fresh install needs the directory. Skipping it on the happy
+      // path is a small saving next to what this function already pays per request (read,
+      // parse, retention sweep, stringify, write, chmod) — the reason to do it this way is
+      // that mkdirSync's mode only applies on creation, so the branch that CREATES the
+      // directory is the one that has to set 0700.
+      //
+      // 0700/0600 to match llm/native-config.ts. It matters which writer gets there first:
+      // mkdirSync does not tighten a directory that already exists, so if this one creates
+      // ~/.clickzetta at the default 0755, llm.json — which holds api_key in plaintext — is
+      // later created inside a world-readable directory. chmod after the write because an
+      // existing file keeps its old mode.
+      mkdirSync(dirname(file), { recursive: true, mode: 0o700 })
+      writeFileSync(file, body, { encoding: "utf-8", mode: 0o600 })
+    }
+    try {
+      chmodSync(file, 0o600)
+    } catch {
+      // An unwritable mode is not worth failing a cache write over.
     }
   } catch {
     // An unwritable home, a full disk, a racing writer: the indicator goes stale,

--- a/packages/clickzetta-ai-gateway/src/quota-store.ts
+++ b/packages/clickzetta-ai-gateway/src/quota-store.ts
@@ -1,0 +1,120 @@
+/**
+ * Carry the header-reported quota from the process that sees it to the process
+ * that shows it.
+ *
+ * Only this provider ever sees the gateway's response headers, and it runs inside
+ * the opencode server. The sidebar indicator that displays the numbers runs in the
+ * TUI process, and the TUI plugin API exposes no response-side hook — `chat.headers`
+ * is outbound only, and the event bus carries a fixed set of server events with no
+ * way to publish a new one. Nothing in the message surface carries it either:
+ * opencode's processor hands `step-finish` metadata to Session.getUsage and then
+ * drops it (packages/opencode/src/session/processor.ts).
+ *
+ * So the quota goes through a small file next to llm.json, and the reader is
+ * triggered by an event that already exists — a `step-finish` part, one per LLM
+ * request. Deliberately NOT an intrusive patch to upstream's processor: the
+ * de-opencode invariant in packages/cz-cli/UPSTREAM-PATCHES.md is worth more than
+ * saving this file.
+ *
+ * The file is a cache, never a source of truth: a miss, a stale entry, a corrupt
+ * body or an unwritable home all mean "no header quota available", and the caller
+ * falls back to what it showed before.
+ */
+import { createHash } from "node:crypto"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import type { ClickzettaQuota } from "./quota"
+
+/** Same home resolution as cz-cli's own config readers, including the test override. */
+function storePath() {
+  return join(process.env.CLICKZETTA_TEST_HOME || homedir(), ".clickzetta", "gateway-quota.json")
+}
+
+export type GatewayQuotaEntry = {
+  /** When these numbers were read off a response, epoch ms. */
+  updated_at: number
+  quotas: ClickzettaQuota[]
+}
+
+/**
+ * Identify the (endpoint, credential) pair a reading belongs to.
+ *
+ * Keying on the endpoint alone is not enough — two llm.json entries routinely point
+ * at the same gateway with different keys, and they would overwrite each other's
+ * numbers. The key itself is hashed rather than stored: this file lives beside
+ * llm.json, which holds the key in plaintext already, but that is no reason for a
+ * second copy of it to exist.
+ */
+export function gatewayQuotaCacheKey(baseURL: string, apiKey: string) {
+  return `${baseURL.replace(/\/+$/, "")}#${createHash("sha256").update(apiKey).digest("hex").slice(0, 16)}`
+}
+
+/**
+ * Record the quota just read from a response. Best-effort: a failure here must
+ * never disturb the completion that produced it.
+ *
+ * Read-modify-write, so two servers finishing a request at the same instant can
+ * lose one entry. The loser is restored by that key's next request, and the cost of
+ * being wrong is one stale row in an ambient indicator — not worth a lock file.
+ */
+export function recordGatewayQuota(input: { baseURL: string; apiKey: string; quotas: ClickzettaQuota[] }) {
+  const file = storePath()
+  const now = Date.now()
+  try {
+    const entries = readStore(file)
+    // Bound the file so it cannot grow across every endpoint and key the machine has ever
+    // used. This is retention, not freshness — how old a reading may be before it stops
+    // being SHOWN is the reader's call, and always far shorter than this window.
+    for (const [key, entry] of Object.entries(entries)) {
+      if (typeof entry?.updated_at !== "number" || now - entry.updated_at > RETENTION_MS) delete entries[key]
+    }
+    entries[gatewayQuotaCacheKey(input.baseURL, input.apiKey)] = { updated_at: now, quotas: input.quotas }
+    const body = JSON.stringify({ entries }, null, 2)
+    try {
+      writeFileSync(file, body, "utf-8")
+    } catch {
+      // Only the first write of a fresh install needs the directory; paying mkdirSync on
+      // every request to create something that already exists is a syscall per LLM call.
+      mkdirSync(dirname(file), { recursive: true })
+      writeFileSync(file, body, "utf-8")
+    }
+  } catch {
+    // An unwritable home, a full disk, a racing writer: the indicator goes stale,
+    // which is strictly better than failing the user's request over a cache write.
+  }
+}
+
+/** How long an entry stays in the file at all. Bounds growth; see recordGatewayQuota. */
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * The last quota recorded for this endpoint/key, with the timestamp it was taken at.
+ *
+ * Deliberately no freshness argument. Whether a reading is still worth showing is not one
+ * question but several — a daily allowance stops being true at its reset, a lifetime one
+ * never does — so the caller answers it with `updated_at` and the periods in hand. cz-cli's
+ * reader does exactly that (see readHeaderQuota in tui-quota-data.ts). A `maxAgeMs` here
+ * only ever duplicated the coarsest half of that decision, and once the reader took the
+ * whole of it, nothing passed one.
+ */
+export function readGatewayQuota(input: { baseURL: string; apiKey: string }): GatewayQuotaEntry | undefined {
+  const entry = readStore(storePath())[gatewayQuotaCacheKey(input.baseURL, input.apiKey)]
+  if (!entry || !Array.isArray(entry.quotas) || entry.quotas.length === 0) return undefined
+  if (typeof entry.updated_at !== "number") return undefined
+  return entry
+}
+
+function readStore(file: string): Record<string, GatewayQuotaEntry> {
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf-8"))
+    if (!parsed || typeof parsed !== "object") return {}
+    const entries = (parsed as { entries?: unknown }).entries
+    if (!entries || typeof entries !== "object" || Array.isArray(entries)) return {}
+    return entries as Record<string, GatewayQuotaEntry>
+  } catch {
+    // Missing on first run, and a truncated body from an interrupted write reads the
+    // same way — both mean "nothing cached", not an error worth surfacing.
+    return {}
+  }
+}

--- a/packages/clickzetta-ai-gateway/src/quota.ts
+++ b/packages/clickzetta-ai-gateway/src/quota.ts
@@ -1,0 +1,151 @@
+/**
+ * Read a virtual key's token quota off the AI gateway's response headers.
+ *
+ * Every `/gateway/v1/chat/completions` response — streamed or not — carries the
+ * key's allowance for each configured period:
+ *
+ *   x-czgw-ratelimit-api-key-token-period:    PDO
+ *   x-czgw-ratelimit-api-key-token-limit:     10000000
+ *   x-czgw-ratelimit-api-key-token-used:      238
+ *   x-czgw-ratelimit-api-key-token-remaining: 9999762
+ *
+ * This is the only quota source a plain API key can reach. The admin API
+ * (`cz-cli ai-gateway key list`) reports the same numbers but needs a portal
+ * token and the caller's ownership of the key, so it cannot answer "how much is
+ * left on the key I am using right now".
+ *
+ * Two shapes to survive:
+ *
+ * 1. A key with several periods repeats all four headers, once per period. Both
+ *    `Headers` and the AI SDK's `SharedV3Headers` (`Record<string, string>`)
+ *    collapse duplicates into one comma-joined value, so the lists are zipped
+ *    positionally — index i of each list describes the same period.
+ * 2. The headers are absent on any error response, 429 included: a spent key
+ *    reports its ceiling only through the error body, which gateway-error.ts
+ *    already classifies. They are also absent on a 200 from a gateway that
+ *    predates the feature — measured 2026-09-01, uat-aimesh sends them and
+ *    cn-shanghai-alicloud-aimesh sends none even while enforcing a quota. So
+ *    `undefined` here means "not reported", never "zero" and never "no limit".
+ */
+
+/** `x-czgw-ratelimit-<scope>-token-<field>`; scope is `api-key` on everything observed so far. */
+const QUOTA_HEADER = /^x-czgw-ratelimit-(.+)-token-(period|limit|used|remaining)$/
+
+/** The gateway's period codes, matching the admin API's quota_pdo/pwo/pmo/total fields. */
+const PERIODS: Record<string, ClickzettaQuotaPeriod> = {
+  PDO: "daily",
+  PWO: "weekly",
+  PMO: "monthly",
+  PTO: "total",
+}
+
+export type ClickzettaQuotaPeriod = "daily" | "weekly" | "monthly" | "total"
+
+export type ClickzettaQuota = {
+  /** Which allowance this is — `undefined` when the gateway sent a code we don't know. */
+  period?: ClickzettaQuotaPeriod
+  /** The gateway's raw code (`PDO`, `PTO`, …), kept so an unmapped period is still reportable. */
+  periodCode: string
+  /** What the key is limited to, in tokens. */
+  limit?: number
+  /**
+   * Tokens spent in this period. Counted as of when the request was admitted, so
+   * the current call's own tokens are not included yet.
+   */
+  used?: number
+  remaining?: number
+  /** Which limiter the numbers came from; `api-key` for a virtual key's own allowance. */
+  scope: string
+}
+
+/**
+ * Both shapes a response's headers actually arrive in here: a `Headers` from fetch (the two
+ * CLI call sites) and the AI SDK's `SharedV3Headers`, which is a plain `Record<string,
+ * string>` (the provider). Not an array-valued record — node's raw-headers shape — because
+ * nothing passes one, and carrying a branch for it meant carrying a test that only ever
+ * proved the branch existed.
+ */
+type HeaderSource = Headers | Record<string, string | undefined>
+
+/**
+ * Parse every quota the headers report, one entry per period.
+ *
+ * Returns `undefined` when the response carried no quota headers at all, so a
+ * caller can tell "the gateway said nothing" from "the gateway said zero".
+ */
+export function parseClickzettaQuota(headers: HeaderSource | undefined): ClickzettaQuota[] | undefined {
+  if (!headers) return undefined
+
+  // scope -> field -> per-period values
+  const scopes = new Map<string, Map<string, string[]>>()
+  for (const [name, value] of headerEntries(headers)) {
+    const match = QUOTA_HEADER.exec(name.toLowerCase())
+    if (!match || value === undefined) continue
+    const fields = scopes.get(match[1]!) ?? new Map<string, string[]>()
+    scopes.set(match[1]!, fields)
+    // A repeated header is already comma-joined by the time it reaches us, in both source
+    // shapes — so splitting on the comma is what turns one header into its per-period list.
+    fields.set(
+      match[2]!,
+      (fields.get(match[2]!) ?? []).concat(value.split(",").map((part) => part.trim())),
+    )
+  }
+  if (scopes.size === 0) return undefined
+
+  const quotas = [...scopes].flatMap(([scope, fields]) => {
+    const codes = fields.get("period") ?? []
+    const count = Math.max(codes.length, ...["limit", "used", "remaining"].map((f) => fields.get(f)?.length ?? 0))
+    return Array.from({ length: count }, (_, index) => {
+      const periodCode = codes[index] ?? ""
+      return {
+        ...(PERIODS[periodCode.toUpperCase()] ? { period: PERIODS[periodCode.toUpperCase()] } : {}),
+        periodCode,
+        ...numeric(fields.get("limit")?.[index], "limit"),
+        ...numeric(fields.get("used")?.[index], "used"),
+        ...numeric(fields.get("remaining")?.[index], "remaining"),
+        scope,
+      }
+    })
+  })
+  // All four headers present but empty-valued yields nothing worth reporting. `used`
+  // counts: a reading that knows only the spend is still a reading, and
+  // formatClickzettaQuota has a branch for exactly that shape.
+  const reported = quotas.filter(
+    (q) => q.periodCode !== "" || q.limit !== undefined || q.used !== undefined || q.remaining !== undefined,
+  )
+  return reported.length === 0 ? undefined : reported
+}
+
+/** One quota as a line a human reads: `total: 21,306,417 / 1,000,000,000 tokens (978,693,343 left)`. */
+export function formatClickzettaQuota(quota: ClickzettaQuota) {
+  const label = quota.period ?? (quota.periodCode || quota.scope)
+  const spend =
+    quota.used !== undefined && quota.limit !== undefined
+      ? `${quota.used.toLocaleString("en-US")} / ${quota.limit.toLocaleString("en-US")} tokens`
+      : quota.limit !== undefined
+        ? `limit ${quota.limit.toLocaleString("en-US")} tokens`
+        : quota.used !== undefined
+          ? `${quota.used.toLocaleString("en-US")} tokens used`
+          : "no numbers reported"
+  if (quota.remaining === undefined) return `${label}: ${spend}`
+  return `${label}: ${spend} (${quota.remaining.toLocaleString("en-US")} left)`
+}
+
+function headerEntries(headers: HeaderSource): Iterable<[string, string | undefined]> {
+  if (typeof (headers as Headers).forEach === "function" && typeof (headers as Headers).get === "function") {
+    const out: [string, string][] = []
+    ;(headers as Headers).forEach((value, name) => out.push([name, value]))
+    return out
+  }
+  return Object.entries(headers as Record<string, string | undefined>)
+}
+
+/** Return type is spelled out so a spread of the empty case keeps the field optional, not absent. */
+function numeric(
+  value: string | undefined,
+  field: "limit" | "used" | "remaining",
+): Partial<Pick<ClickzettaQuota, "limit" | "used" | "remaining">> {
+  if (value === undefined || value === "") return {}
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? { [field]: parsed } : {}
+}

--- a/packages/clickzetta-ai-gateway/test/provider-wrap.test.ts
+++ b/packages/clickzetta-ai-gateway/test/provider-wrap.test.ts
@@ -12,9 +12,12 @@
  *
  * No network: a fake LanguageModelV3 throws or emits whatever each case needs.
  */
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { APICallError } from "@ai-sdk/provider"
-import { createClickzetta, wrapModelForTest as wrap } from "../src/index"
+import { createClickzetta, readGatewayQuota, wrapModelForTest as wrap } from "../src/index"
 
 const BASE_URL = "https://cn-shanghai-alicloud-aimesh.api.clickzetta.com/"
 const PROMPT = [{ role: "user", content: [{ type: "text", text: "hi" }] }]
@@ -33,8 +36,12 @@ function fakeModel(behaviour: {
   onGenerate?: () => never | Promise<never>
   streamParts?: unknown[]
   onStream?: () => never
+  /** Response headers the base SDK would have lifted off the HTTP response. */
+  responseHeaders?: Record<string, string>
+  providerMetadata?: Record<string, Record<string, unknown>>
   extras?: Record<string, unknown>
 }) {
+  const response = behaviour.responseHeaders ? { headers: behaviour.responseHeaders } : undefined
   return {
     specificationVersion: "v3",
     provider: "clickzetta.chat",
@@ -42,7 +49,14 @@ function fakeModel(behaviour: {
     supportedUrls: {},
     async doGenerate() {
       if (behaviour.onGenerate) return behaviour.onGenerate()
-      return { content: [{ type: "text", text: "ok" }], finishReason: "stop", usage: {}, warnings: [] }
+      return {
+        content: [{ type: "text", text: "ok" }],
+        finishReason: "stop",
+        usage: {},
+        warnings: [],
+        ...(behaviour.providerMetadata ? { providerMetadata: behaviour.providerMetadata } : {}),
+        ...(response ? { response } : {}),
+      }
     },
     async doStream() {
       if (behaviour.onStream) return behaviour.onStream()
@@ -54,11 +68,23 @@ function fakeModel(behaviour: {
             controller.close()
           },
         }),
+        ...(response ? { response } : {}),
       }
     },
     ...behaviour.extras,
   } as any
 }
+
+/** What a live single-period key reports on a completion. */
+const QUOTA_HEADERS = {
+  "x-czgw-ratelimit-api-key-token-period": "PDO",
+  "x-czgw-ratelimit-api-key-token-limit": "10000000",
+  "x-czgw-ratelimit-api-key-token-used": "238",
+  "x-czgw-ratelimit-api-key-token-remaining": "9999762",
+}
+const QUOTA = [
+  { period: "daily", periodCode: "PDO", limit: 10000000, used: 238, remaining: 9999762, scope: "api-key" },
+]
 
 async function collect(stream: ReadableStream) {
   const out: any[] = []
@@ -323,5 +349,110 @@ describe("Proxy delegation", () => {
   test("a successful doGenerate is untouched", async () => {
     const result = await wrap(fakeModel({})).doGenerate({ prompt: PROMPT } as any)
     expect(result.content).toEqual([{ type: "text", text: "ok" }])
+  })
+})
+
+/**
+ * The quota only helps if it survives the trip out of the provider. doGenerate
+ * publishes it on the result; doStream publishes it on the "finish" part, because
+ * that is where consumers read per-step metadata even though the headers were
+ * available the moment the stream opened.
+ */
+describe("quota metadata", () => {
+  test("doGenerate publishes the quota the headers reported", async () => {
+    const result = await wrap(fakeModel({ responseHeaders: QUOTA_HEADERS })).doGenerate({ prompt: PROMPT } as any)
+    expect(result.providerMetadata?.clickzetta?.quota).toEqual(QUOTA)
+  })
+
+  test("metadata the base provider already set is preserved alongside it", async () => {
+    const model = fakeModel({
+      responseHeaders: QUOTA_HEADERS,
+      providerMetadata: { openaiCompatible: { fingerprint: "fp_1" }, clickzetta: { requestId: "req-1" } },
+    })
+    const result = await wrap(model).doGenerate({ prompt: PROMPT } as any)
+    expect(result.providerMetadata).toEqual({
+      openaiCompatible: { fingerprint: "fp_1" },
+      clickzetta: { requestId: "req-1", quota: QUOTA },
+    })
+  })
+
+  test("doStream publishes it on the finish part", async () => {
+    const model = fakeModel({
+      responseHeaders: QUOTA_HEADERS,
+      streamParts: [
+        { type: "text-delta", id: "1", delta: "hi" },
+        { type: "finish", finishReason: "stop", usage: {} },
+      ],
+    })
+    const parts = await collect((await wrap(model).doStream({ prompt: PROMPT } as any)).stream)
+    expect(parts.find((p) => p.type === "finish")?.providerMetadata?.clickzetta?.quota).toEqual(QUOTA)
+    // Only the finish part is touched; content parts pass through untouched.
+    expect(parts[0]).toEqual({ type: "text-delta", id: "1", delta: "hi" })
+  })
+
+  /**
+   * A 429 carries no quota headers at all, so there is nothing to publish and the
+   * result must come back exactly as the base provider built it — the error body,
+   * which gateway-error.ts classifies, stays the only signal.
+   */
+  test("a response without quota headers is handed back unchanged", async () => {
+    const model = fakeModel({ responseHeaders: { "content-type": "application/json" } })
+    const wrapped = wrap(model)
+    const result = await wrapped.doGenerate({ prompt: PROMPT } as any)
+    expect("providerMetadata" in result).toBe(false)
+
+    const finish = { type: "finish", finishReason: "stop", usage: {} }
+    const parts = await collect(
+      (await wrap(fakeModel({ streamParts: [finish] })).doStream({ prompt: PROMPT } as any)).stream,
+    )
+    expect(parts[0]).toEqual(finish)
+  })
+})
+
+/**
+ * The cache the sidebar reads is written as soon as the headers exist, which for a
+ * stream is when it opens. Writing it at the "finish" part instead would discard a
+ * reading already in hand whenever the turn is aborted or errors mid-stream — and the
+ * numbers describe the request's admission, so waiting buys nothing.
+ */
+describe("quota cache", () => {
+  const TARGET = { baseURL: "https://uat-aimesh.clickzetta.com/gateway/v1", apiKey: "k".repeat(32) }
+  let home: string
+  let previous: string | undefined
+
+  beforeEach(() => {
+    previous = process.env.CLICKZETTA_TEST_HOME
+    home = mkdtempSync(join(tmpdir(), "cz-quota-cache-"))
+    process.env.CLICKZETTA_TEST_HOME = home
+  })
+  afterEach(() => {
+    if (previous === undefined) delete process.env.CLICKZETTA_TEST_HOME
+    else process.env.CLICKZETTA_TEST_HOME = previous
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  test("doStream records the reading without the stream ever reaching finish", async () => {
+    const model = fakeModel({
+      responseHeaders: QUOTA_HEADERS,
+      // No "finish" part at all: the turn ends early, as an abort would.
+      streamParts: [{ type: "text-delta", id: "1", delta: "hi" }],
+    })
+    const result = await wrap(model, "deepseek/deepseek-v3.2", TARGET).doStream({ prompt: PROMPT } as any)
+    await collect(result.stream)
+    expect(readGatewayQuota(TARGET)?.quotas).toEqual(QUOTA)
+  })
+
+  test("doGenerate records it too", async () => {
+    await wrap(fakeModel({ responseHeaders: QUOTA_HEADERS }), "deepseek/deepseek-v3.2", TARGET).doGenerate({
+      prompt: PROMPT,
+    } as any)
+    expect(readGatewayQuota(TARGET)?.quotas).toEqual(QUOTA)
+  })
+
+  test("a response with no quota headers writes nothing", async () => {
+    await wrap(fakeModel({ responseHeaders: { "content-type": "application/json" } }), "m", TARGET).doGenerate({
+      prompt: PROMPT,
+    } as any)
+    expect(readGatewayQuota(TARGET)).toBeUndefined()
   })
 })

--- a/packages/clickzetta-ai-gateway/test/quota-store.test.ts
+++ b/packages/clickzetta-ai-gateway/test/quota-store.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the cross-process quota cache.
+ * Run: bun test test/quota-store.test.ts
+ *
+ * Real files under a temp CLICKZETTA_TEST_HOME — the same override cz-cli's own
+ * config readers honour — rather than a mocked fs, so the path resolution is
+ * covered too.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { gatewayQuotaCacheKey, readGatewayQuota, recordGatewayQuota } from "../src/quota-store"
+
+const BASE = "https://uat-aimesh.clickzetta.com/gateway/v1"
+const KEY = "k".repeat(32)
+const QUOTAS = [
+  { period: "daily" as const, periodCode: "PDO", limit: 10000000, used: 238, remaining: 9999762, scope: "api-key" },
+]
+
+let home: string
+const previous = process.env.CLICKZETTA_TEST_HOME
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "cz-quota-store-"))
+  process.env.CLICKZETTA_TEST_HOME = home
+})
+
+afterEach(() => {
+  if (previous === undefined) delete process.env.CLICKZETTA_TEST_HOME
+  else process.env.CLICKZETTA_TEST_HOME = previous
+  rmSync(home, { recursive: true, force: true })
+})
+
+describe("recordGatewayQuota / readGatewayQuota", () => {
+  test("a recorded reading comes back, and creates .clickzetta if absent", () => {
+    recordGatewayQuota({ baseURL: BASE, apiKey: KEY, quotas: QUOTAS })
+    const entry = readGatewayQuota({ baseURL: BASE, apiKey: KEY })
+    expect(entry?.quotas).toEqual(QUOTAS)
+    expect(entry?.updated_at).toBeGreaterThan(0)
+  })
+
+  /**
+   * The reason the key is part of the cache key at all: two llm.json entries
+   * pointing at one gateway with different keys must not overwrite each other.
+   */
+  test("two keys on the same endpoint keep separate readings", () => {
+    recordGatewayQuota({ baseURL: BASE, apiKey: KEY, quotas: QUOTAS })
+    recordGatewayQuota({
+      baseURL: BASE,
+      apiKey: "z".repeat(32),
+      quotas: [{ periodCode: "PTO", period: "total" as const, limit: 5, used: 1, remaining: 4, scope: "api-key" }],
+    })
+    expect(readGatewayQuota({ baseURL: BASE, apiKey: KEY })?.quotas).toEqual(QUOTAS)
+    expect(readGatewayQuota({ baseURL: BASE, apiKey: "z".repeat(32) })?.quotas?.[0]?.limit).toBe(5)
+  })
+
+  test("a trailing slash is the same endpoint", () => {
+    recordGatewayQuota({ baseURL: BASE, apiKey: KEY, quotas: QUOTAS })
+    expect(readGatewayQuota({ baseURL: `${BASE}/`, apiKey: KEY })?.quotas).toEqual(QUOTAS)
+  })
+
+  test("a later reading replaces the earlier one for the same key", () => {
+    recordGatewayQuota({ baseURL: BASE, apiKey: KEY, quotas: QUOTAS })
+    recordGatewayQuota({
+      baseURL: BASE,
+      apiKey: KEY,
+      quotas: [{ ...QUOTAS[0]!, used: 999, remaining: 9999001 }],
+    })
+    expect(readGatewayQuota({ baseURL: BASE, apiKey: KEY })?.quotas?.[0]?.used).toBe(999)
+  })
+
+  /** Quota moves with every request, so a reading from an old session is worse than none. */
+  /** The timestamp comes back so the caller can make the freshness decision itself. */
+  test("the reading carries the moment it was taken", () => {
+    const before = Date.now()
+    recordGatewayQuota({ baseURL: BASE, apiKey: KEY, quotas: QUOTAS })
+    const entry = readGatewayQuota({ baseURL: BASE, apiKey: KEY })
+    expect(entry?.updated_at).toBeGreaterThanOrEqual(before)
+    expect(entry?.updated_at).toBeLessThanOrEqual(Date.now())
+  })
+
+  test("an unknown endpoint or key reads as nothing cached", () => {
+    recordGatewayQuota({ baseURL: BASE, apiKey: KEY, quotas: QUOTAS })
+    expect(readGatewayQuota({ baseURL: "https://other/gateway/v1", apiKey: KEY })).toBeUndefined()
+    expect(readGatewayQuota({ baseURL: BASE, apiKey: "other" })).toBeUndefined()
+  })
+
+  test("no file at all reads as nothing cached, not an error", () => {
+    expect(readGatewayQuota({ baseURL: BASE, apiKey: KEY })).toBeUndefined()
+  })
+
+  /** An interrupted write leaves a truncated body; it must read like a miss. */
+  test("a corrupt store reads as nothing cached", () => {
+    mkdirSync(join(home, ".clickzetta"), { recursive: true })
+    writeFileSync(join(home, ".clickzetta", "gateway-quota.json"), '{"entries":{"a":', "utf-8")
+    expect(readGatewayQuota({ baseURL: BASE, apiKey: KEY })).toBeUndefined()
+    // And a following write repairs it rather than throwing.
+    recordGatewayQuota({ baseURL: BASE, apiKey: KEY, quotas: QUOTAS })
+    expect(readGatewayQuota({ baseURL: BASE, apiKey: KEY })?.quotas).toEqual(QUOTAS)
+  })
+
+  test("an empty quota list is not a reading", () => {
+    recordGatewayQuota({ baseURL: BASE, apiKey: KEY, quotas: [] })
+    expect(readGatewayQuota({ baseURL: BASE, apiKey: KEY })).toBeUndefined()
+  })
+
+  /** The key must not be recoverable from the file that sits next to llm.json. */
+  test("the cache key hashes the credential instead of storing it", () => {
+    const id = gatewayQuotaCacheKey(BASE, KEY)
+    expect(id).toStartWith(`${BASE}#`)
+    expect(id).not.toContain(KEY)
+    expect(id).toBe(gatewayQuotaCacheKey(`${BASE}///`, KEY))
+  })
+})

--- a/packages/clickzetta-ai-gateway/test/quota.test.ts
+++ b/packages/clickzetta-ai-gateway/test/quota.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for reading a key's token quota off the gateway's response headers.
+ * Run: bun test test/quota.test.ts
+ *
+ * The header values here are copied from live UAT and prod responses, including
+ * the multi-period case where all four headers repeat and arrive comma-joined.
+ */
+import { describe, expect, test } from "bun:test"
+import { formatClickzettaQuota, parseClickzettaQuota } from "../src/quota"
+
+describe("parseClickzettaQuota", () => {
+  test("a single-period key, verbatim from a UAT completion", () => {
+    expect(
+      parseClickzettaQuota({
+        "x-czgw-ratelimit-api-key-token-period": "PDO",
+        "x-czgw-ratelimit-api-key-token-limit": "10000000",
+        "x-czgw-ratelimit-api-key-token-used": "238",
+        "x-czgw-ratelimit-api-key-token-remaining": "9999762",
+      }),
+    ).toEqual([
+      { period: "daily", periodCode: "PDO", limit: 10000000, used: 238, remaining: 9999762, scope: "api-key" },
+    ])
+  })
+
+  /**
+   * The shape that made a naive parser wrong: a key with both a lifetime and a
+   * daily allowance repeats every header, and Headers (like the AI SDK's
+   * SharedV3Headers) hands the duplicates over as one comma-joined string. Index i
+   * of each list belongs to the same period, so 1,000,000,000 must land on `total`
+   * and 1,000 on `daily` — never averaged, summed, or last-one-wins.
+   */
+  test("a key with two periods keeps each period's own numbers", () => {
+    expect(
+      parseClickzettaQuota({
+        "x-czgw-ratelimit-api-key-token-period": "PTO, PDO",
+        "x-czgw-ratelimit-api-key-token-limit": "1000000000, 1000",
+        "x-czgw-ratelimit-api-key-token-used": "21306657, 0",
+        "x-czgw-ratelimit-api-key-token-remaining": "978693343, 1000",
+      }),
+    ).toEqual([
+      { period: "total", periodCode: "PTO", limit: 1000000000, used: 21306657, remaining: 978693343, scope: "api-key" },
+      { period: "daily", periodCode: "PDO", limit: 1000, used: 0, remaining: 1000, scope: "api-key" },
+    ])
+  })
+
+  test("all four period codes map to the admin API's own vocabulary", () => {
+    const parsed = parseClickzettaQuota({
+      "x-czgw-ratelimit-api-key-token-period": "PDO,PWO,PMO,PTO",
+    })
+    expect(parsed?.map((q) => q.period)).toEqual(["daily", "weekly", "monthly", "total"])
+  })
+
+  test("reads a real Headers object, not just a plain record", () => {
+    const headers = new Headers()
+    headers.append("X-Czgw-Ratelimit-Api-Key-Token-Period", "PTO")
+    headers.append("X-Czgw-Ratelimit-Api-Key-Token-Limit", "500")
+    // Appending twice is how a multi-period response actually arrives.
+    headers.append("X-Czgw-Ratelimit-Api-Key-Token-Period", "PDO")
+    headers.append("X-Czgw-Ratelimit-Api-Key-Token-Limit", "50")
+    expect(parseClickzettaQuota(headers)).toEqual([
+      { period: "total", periodCode: "PTO", limit: 500, scope: "api-key" },
+      { period: "daily", periodCode: "PDO", limit: 50, scope: "api-key" },
+    ])
+  })
+
+  test("no quota headers means not reported, not zero", () => {
+    expect(parseClickzettaQuota({ "content-type": "application/json", "x-request-id": "abc" })).toBeUndefined()
+    expect(parseClickzettaQuota(undefined)).toBeUndefined()
+    expect(parseClickzettaQuota({})).toBeUndefined()
+  })
+
+  test("an unmapped period code is still reported, under its raw code", () => {
+    expect(parseClickzettaQuota({ "x-czgw-ratelimit-api-key-token-period": "PYO" })).toEqual([
+      { periodCode: "PYO", scope: "api-key" },
+    ])
+  })
+
+  test("a non-numeric or empty value drops that field instead of becoming NaN", () => {
+    expect(
+      parseClickzettaQuota({
+        "x-czgw-ratelimit-api-key-token-period": "PDO",
+        "x-czgw-ratelimit-api-key-token-limit": "unlimited",
+        "x-czgw-ratelimit-api-key-token-used": "",
+        "x-czgw-ratelimit-api-key-token-remaining": "12",
+      }),
+    ).toEqual([{ period: "daily", periodCode: "PDO", remaining: 12, scope: "api-key" }])
+  })
+
+  /** A shorter list leaves that field unknown for the trailing periods rather than shifting values onto them. */
+  test("mismatched list lengths do not shift values between periods", () => {
+    expect(
+      parseClickzettaQuota({
+        "x-czgw-ratelimit-api-key-token-period": "PTO, PDO",
+        "x-czgw-ratelimit-api-key-token-limit": "900",
+      }),
+    ).toEqual([
+      { period: "total", periodCode: "PTO", limit: 900, scope: "api-key" },
+      { period: "daily", periodCode: "PDO", scope: "api-key" },
+    ])
+  })
+
+  /** Scope is captured rather than hardcoded, so a limiter other than the virtual key still parses. */
+  test("a non-api-key limiter is reported under its own scope", () => {
+    expect(
+      parseClickzettaQuota({
+        "x-czgw-ratelimit-tenant-token-period": "PMO",
+        "x-czgw-ratelimit-tenant-token-remaining": "42",
+      }),
+    ).toEqual([{ period: "monthly", periodCode: "PMO", remaining: 42, scope: "tenant" }])
+  })
+})
+
+describe("formatClickzettaQuota", () => {
+  test("used, limit and remaining read as one line", () => {
+    expect(
+      formatClickzettaQuota({
+        period: "total",
+        periodCode: "PTO",
+        limit: 1000000000,
+        used: 21306657,
+        remaining: 978693343,
+        scope: "api-key",
+      }),
+    ).toBe("total: 21,306,657 / 1,000,000,000 tokens (978,693,343 left)")
+  })
+
+  test("partial numbers still produce a line", () => {
+    expect(formatClickzettaQuota({ period: "daily", periodCode: "PDO", limit: 1000, scope: "api-key" })).toBe(
+      "daily: limit 1,000 tokens",
+    )
+    expect(formatClickzettaQuota({ periodCode: "PYO", used: 5, scope: "api-key" })).toBe("PYO: 5 tokens used")
+    expect(formatClickzettaQuota({ periodCode: "", scope: "api-key" })).toBe("api-key: no numbers reported")
+  })
+})

--- a/packages/clickzetta-sdk/src/auth/token.ts
+++ b/packages/clickzetta-sdk/src/auth/token.ts
@@ -256,7 +256,10 @@ export function anonymous(): TokenSource {
 }
 
 function toCredential(token: AuthToken): Credential {
-  return { token: token.token, instanceId: token.instanceId, userId: token.userId }
+  // 0 when the token carries none: the connection is the authoritative source now (see
+  // ConnectionConfig.instanceId), and a Credential's copy is only a convenience for the
+  // standalone-SDK login path that still has one.
+  return { token: token.token, instanceId: token.instanceId ?? 0, userId: token.userId }
 }
 
 export function clearTokenCache(): void {

--- a/packages/clickzetta-sdk/src/sql/session.ts
+++ b/packages/clickzetta-sdk/src/sql/session.ts
@@ -625,10 +625,18 @@ export class SqlSession {
     }
   }
 
-  /** Resolve JobID using cached auth token, matching cz-cli exec.ts. */
+  /**
+   * Resolve JobID from the CONNECTION's instance id, not the credential's.
+   *
+   * `config.instanceId` is the connection's own (see ConnectionConfig.instanceId); a
+   * shared OAuth token's id can belong to a different instance. The token remains the
+   * fallback for callers that construct a config without one — a standalone SDK user
+   * doing a password login, where the login response is the only source.
+   */
   private async newJobId(): Promise<JobID> {
+    if (this.config.instanceId) return newJobId(this.workspace, this.config.instanceId)
     const token = await getToken(this.config)
-    return newJobId(this.workspace, token.instanceId)
+    return newJobId(this.workspace, token.instanceId ?? 0)
   }
 
   private async toClientOptions(): Promise<ClientOptions> {

--- a/packages/clickzetta-sdk/src/types/index.ts
+++ b/packages/clickzetta-sdk/src/types/index.ts
@@ -5,6 +5,23 @@ export interface ConnectionConfig {
   service: string
   protocol: string
   instance: string
+  /**
+   * Numeric id of {@link instance}, which is what the wire actually carries (every
+   * JobID is built from it).
+   *
+   * It belongs HERE, on the connection, and not on the credential. It used to live on
+   * AuthToken, where it was wrong twice over: an OAuth token is deliberately SHARED by
+   * every profile one login can reach — `[oauth.<id>]` in profiles.toml, many profiles
+   * pointing at it — so one token carried one id for profiles on different instances in
+   * different regions; and the value it carried came from userinfo's "default" instance,
+   * which is not necessarily the Lakehouse one the profile names. Measured on a real
+   * profiles.toml: a token holding 160812 (`serviceId` 2) while its profile named the
+   * instance whose id is 160813 (`serviceId` 1).
+   *
+   * Optional because a profile written before this existed has no `instance_id`; cz-cli
+   * resolves it by name on first use and writes it back (see getExecContext).
+   */
+  instanceId?: number
   workspace: string
   schema: string
   vcluster: string
@@ -49,7 +66,19 @@ export const DEFAULT_CONNECTION: ConnectionConfig = {
 
 export interface AuthToken {
   token: string
-  instanceId: number
+  /**
+   * NOT a source of truth for a profile-backed connection — use
+   * {@link ConnectionConfig.instanceId}.
+   *
+   * It survives only for a standalone SDK login, where the portal's login response is the
+   * only place an instance id comes from. cz-cli never reads it: an OAuth token is SHARED
+   * by every profile one login reaches (`[oauth.<id>]` in profiles.toml), so a single id
+   * here is wrong for every profile but one, and the value the portal puts here is its
+   * "default" instance, which need not be the Lakehouse instance the profile names. It is
+   * no longer persisted; sections written by older versions still carry one and it is
+   * ignored on read.
+   */
+  instanceId?: number
   userId: number
   expireTimeMs: number
   obtainedAt: number

--- a/packages/cz-cli/UPSTREAM-PATCHES.md
+++ b/packages/cz-cli/UPSTREAM-PATCHES.md
@@ -378,7 +378,15 @@ rg -n "cz-cli change" packages/core packages/opencode packages/tui -g '!**/dist/
   ```sh
   rg -n 'registerOpencodeSpinner' packages/tui packages/opencode   # 11 hits: 1 definition + import+call at each of the 5 sites
   rg -n 'import "opentui-spinner/solid"' packages/tui packages/opencode   # expect none
+  rg -n 'component/register-spinner' packages/tui/package.json     # the export map entry
   ```
+
+  The third check is not redundant: the two `packages/opencode` sites import
+  `@opencode-ai/tui/component/register-spinner`, which only resolves while
+  `packages/tui/package.json`'s `exports` publishes it — and a baseline bump will almost
+  certainly overwrite that file, since upstream touches versions and deps in it constantly.
+  Both `.ts`-level greps would still pass with the export map reverted, leaving two imports
+  of an unpublished subpath.
 
   The silent-revert window is exactly v1.17.11 → v1.18.9: before it the patch does not
   exist, from v1.18.9 on upstream provides it and this entry is deleted.
@@ -567,7 +575,8 @@ the hooks they depend on still exist in the new upstream.
 2. `rg -n "cz-cli change" packages/core packages/opencode packages/tui` — expect the
    INTRUSIVE patches above. If any is missing, re-apply it from this ledger. This sweep
    does NOT cover entry 12, which carries no banner on purpose; check it separately with
-   `rg -n 'registerOpencodeSpinner' packages/tui packages/opencode` (expect 11 hits) until
+   `rg -n 'registerOpencodeSpinner' packages/tui packages/opencode` (expect 11 hits) plus
+   `rg -n 'component/register-spinner' packages/tui/package.json` for the export map, until
    the baseline reaches v1.18.9, at which point entry 12 is deleted.
 3. For each HOOK customization, confirm its "upstream hook to re-verify" still holds.
 4. `cd packages/cz-cli && bun run typecheck && bun test`.

--- a/packages/cz-cli/UPSTREAM-PATCHES.md
+++ b/packages/cz-cli/UPSTREAM-PATCHES.md
@@ -337,6 +337,63 @@ rg -n "cz-cli change" packages/core packages/opencode packages/tui -g '!**/dist/
 - **Re-baseline:** all 25 return as additions. Re-delete them, and re-check whether the
   new baseline added more scheduled workflows before merging.
 
+### 12. `<spinner>` registration — backport of upstream #35292
+
+- **Files:** `packages/tui/src/component/register-spinner.ts` (new),
+  `packages/tui/package.json` (export map), and a `registerOpencodeSpinner()` call at
+  five sites: `packages/tui/src/app.tsx`,
+  `packages/tui/src/component/spinner.tsx`,
+  `packages/tui/src/component/prompt/index.tsx`,
+  `packages/opencode/src/cli/cmd/run/footer.subagent.tsx`,
+  `packages/opencode/src/cli/cmd/run/footer.view.tsx`
+- **Upstream:** https://github.com/anomalyco/opencode/pull/35292 ("tui: preserve
+  spinner registration"), merged 2026-07-04 as `7a8e7c88f4`. Our baseline v1.17.11 is
+  dated 2026-06-25 — nine days earlier, so it predates the fix. Upstream v1.18.9 and
+  later carry it.
+- **Bug:** each of those five sites used to register `<spinner>` with a bare
+  side-effect import, `import "opentui-spinner/solid"`. `opentui-spinner` declares a
+  whitelist `sideEffects` (`["./dist/react.mjs", "./dist/solid.mjs"]`), so the module
+  survives tree-shaking only while the bundler matches those POSIX patterns against
+  the resolved path. Our release build compiles the win32 target ON a
+  `windows-latest` runner (`release-cos.yml`: `runner: windows-latest` +
+  `OPENCODE_HOST_ONLY=1`); there the match fails, `minify` drops an import that binds
+  nothing, `extend({ spinner })` never runs, and the first spinner render kills the
+  session with `[Reconciler] Unknown component type: spinner`. Reported on cz-cli
+  2.0.3 (Windows). Upstream never saw it: its `build-cli` job bundles every target,
+  Windows included, on `blacksmith-4vcpu-ubuntu-2404` (the `windows-2025` runner only
+  signs), and dev `bun run` does not tree-shake at all.
+- **Measured:** forcing the match to fail (`sideEffects: false` on the installed
+  package) collapses a bare-import bundle from 935,609 bytes to 27 — registration and
+  all. Cross-compiling with `--target=bun-windows-x64` from macOS keeps it, which is
+  why the build host, not the target, is what matters.
+- **Why intrusive (no hook):** the catalogue is module-level state inside
+  `@opentui/solid`, and these are the modules that render `<spinner>`.
+- **No `cz-cli change` banner, deliberately — grep for the call instead:** the edit is
+  byte-identical to upstream's, so wrapping it in a banner would make the file differ
+  from the fixed upstream file and turn a clean fast-forward into a conflict. The cost
+  is that the ledger's usual `rg -n "cz-cli change"` sweep cannot see this patch, so it
+  is the one entry that could be reverted by a baseline bump without the sweep noticing.
+  The substitute check, added to the re-baseline procedure below, is:
+
+  ```sh
+  rg -n 'registerOpencodeSpinner' packages/tui packages/opencode   # 11 hits: 1 definition + import+call at each of the 5 sites
+  rg -n 'import "opentui-spinner/solid"' packages/tui packages/opencode   # expect none
+  ```
+
+  The silent-revert window is exactly v1.17.11 → v1.18.9: before it the patch does not
+  exist, from v1.18.9 on upstream provides it and this entry is deleted.
+- **Verify:** `packages/opencode/test/cli/run/footer.view.test.tsx` asserts a spinner
+  renders in the `run` footer (`expect(spinner).toBeDefined()`); it goes RED if the
+  registration is gone from that path. Run it plus `packages/tui`'s suite after any
+  baseline bump. Neither is in `cz-test.yml`, so this is a manual step. Pins that must
+  keep exporting what the fix calls: `opentui-spinner@0.0.7` (`registerSpinner`) and
+  `@opentui/solid@0.3.4` (`getComponentCatalogue`).
+- **Re-baseline:** once the baseline is at v1.18.9 or newer, upstream provides all of
+  this — take upstream's version wholesale and **delete this entry**. Until then, the
+  bare imports return on every baseline bump; re-apply from #35292 rather than by
+  hand, and check for new `<spinner>` call sites with
+  `rg -n 'opentui-spinner|<spinner' packages/tui packages/opencode`.
+
 ## HOOK-based customizations (safe — live entirely in the cz layer)
 
 These do **not** edit upstream files. They are listed so a re-baseline can confirm
@@ -508,7 +565,10 @@ the hooks they depend on still exist in the new upstream.
 
 1. Fast-forward upstream packages to the new opencode version.
 2. `rg -n "cz-cli change" packages/core packages/opencode packages/tui` — expect the
-   INTRUSIVE patches above. If any is missing, re-apply it from this ledger.
+   INTRUSIVE patches above. If any is missing, re-apply it from this ledger. This sweep
+   does NOT cover entry 12, which carries no banner on purpose; check it separately with
+   `rg -n 'registerOpencodeSpinner' packages/tui packages/opencode` (expect 11 hits) until
+   the baseline reaches v1.18.9, at which point entry 12 is deleted.
 3. For each HOOK customization, confirm its "upstream hook to re-verify" still holds.
 4. `cd packages/cz-cli && bun run typecheck && bun test`.
 5. Update this file if the set of patches changed.

--- a/packages/cz-cli/UPSTREAM-PATCHES.md
+++ b/packages/cz-cli/UPSTREAM-PATCHES.md
@@ -415,7 +415,7 @@ the hooks they depend on still exist in the new upstream.
 - **Mechanism:** registers on the public `sidebar_content` slot
   (`packages/plugin/src/tui.ts`'s `TuiHostSlotMap`), rendering a "Profile" section
   (which profile/account/env/instance/workspace the session is connected as) and a
-  "Quota" section (balance + token usage) at `order: 150` — directly after
+  "Quota" section (cash balance + per-period token allowance) at `order: 150` — directly after
   upstream's own Context section (`order: 100`) and ahead of MCP/LSP/Todo/Files
   (200/300/400/500).
 - **Why:** the readout used to share the prompt's top-right corner with the
@@ -446,6 +446,32 @@ the hooks they depend on still exist in the new upstream.
     on parent and child. Expected/accepted: a subagent turn still spends the
     parent's quota and the user returns to the parent session to see it, but this
     is upstream's policy, not cz's, and worth re-verifying it still holds.
+  - **Two upstream event shapes this feature reads** (recorded with the header-quota
+    change; the older `session.status` subscription had gone unrecorded too):
+    - `session.status` — `properties.sessionID` / `properties.status`, driving the
+      busy→idle edge that triggers the balance read.
+    - `message.part.updated` — `properties.part.type === "step-finish"`. This is the
+      only response-adjacent signal a TUI plugin can observe, and the token half of the
+      section refreshes on it, once per LLM request. If upstream renames that part type,
+      stops publishing it through this event, or moves `part` out of `properties`, the
+      token rows silently stop updating — they do not error, because the read is a cache
+      lookup that simply never runs. No test covers the live event shape;
+      `packages/cz-cli/test/tui-quota-data.test.ts` covers the reader only.
+- **On-disk path this feature owns:** `~/.clickzetta/gateway-quota.json`, written by
+  `@clickzetta/ai-gateway`'s `quota-store.ts` inside the opencode SERVER process and read
+  by the sidebar in the TUI process. It exists because those are different processes and
+  no plugin hook carries a response header between them: `chat.headers` is outbound only,
+  the event bus is a fixed set with no way to publish a new event, and upstream's
+  `packages/opencode/src/session/processor.ts` hands `step-finish` metadata to
+  `Session.getUsage` and then drops it. Patching that processor was the alternative and
+  was rejected — the de-opencode invariant is worth more than saving the file. The file is
+  a cache with a 7-day retention and a reader-side freshness window; a miss, a stale entry
+  or an unwritable home all mean "no header quota", never "zero".
+- **Token quota no longer comes from Portal.** It used to be a second portal call,
+  `/clickzetta-portal/user/listApiKeys`, matched against the key by its masked form. That
+  route, `maskApiKey`/`matchKeyUsage`, and the walk over every configured profile hunting
+  the one whose portal knew the selected key are all deleted. Only the cash balance is a
+  portal read now, and only for the CURRENT profile.
 - **Also new on this feature's network path:** `centralPortalHost`/`portalRead`
   (`tui-quota-data.ts`) send the profile's portal token to `api.clickzetta.com`/
   `api.singdata.com` when the profile's own regional host answers an unusable

--- a/packages/cz-cli/src/bootstrap/update.ts
+++ b/packages/cz-cli/src/bootstrap/update.ts
@@ -305,7 +305,16 @@ function repairMacOSBinary(binaryPath: string) {
 export async function ensureRestartBinaryAtPath(target: string, restartPath = process.execPath, env: NodeJS.ProcessEnv = process.env) {
   repairMacOSBinary(restartPath)
   if (binaryVersion(restartPath, env) === target) return
-  const candidate = path.join(homeDirectory(undefined, env), ".local", "bin", "cz-cli")
+  // .exe on Windows: install.sh now installs Git Bash / MSYS2 / Cygwin hosts (see
+  // scripts/cos-release.mjs's platform mapping), and what it puts in ~/.local/bin is
+  // cz-cli.exe. Hardcoding the extensionless name meant this candidate could never
+  // exist there, so every auto-update on such an install ended at the throw below.
+  const candidate = path.join(
+    homeDirectory(undefined, env),
+    ".local",
+    "bin",
+    process.platform === "win32" ? "cz-cli.exe" : "cz-cli",
+  )
   if (candidate === restartPath || binaryVersion(candidate, env) !== target) {
     throw new Error(`Updated cz-cli binary is not available at ${restartPath}; clean stale PATH entries and reinstall cz-cli`)
   }

--- a/packages/cz-cli/src/commands/agent-llm.ts
+++ b/packages/cz-cli/src/commands/agent-llm.ts
@@ -11,7 +11,7 @@ import {
   type LlmEntryView,
 } from "../llm/native-config.js"
 import { buildLlmProbeRequest, firstClickzettaModel, normalizeLlmBaseUrl } from "../llm/probe.js"
-import { rewriteClickzettaGatewayError } from "../llm/gateway-error.js"
+import { formatClickzettaQuota, parseClickzettaQuota, rewriteClickzettaGatewayError } from "../llm/gateway-error.js"
 import { describeSelectionSource, resolveDefaultModel } from "../llm/default-model.js"
 
 const VALID_PROVIDERS = [
@@ -684,11 +684,18 @@ const LlmTestCommand = cmd({
 
     const body = safeJson(text)
     const completion = completionSummary(body) ?? anthropicSummary(body) ?? googleSummary(body)
+    // cz_change: the ClickZetta gateway reports the key's remaining token quota on
+    // every completion's headers, and this probe just made one — so the test that
+    // proves the key works can also say how much of it is left, at no extra call.
+    // Absent for other providers, and absent on a gateway error (which never
+    // carries these headers), so it only ever adds a line.
+    const quotas = parseClickzettaQuota(response.headers)
     const ttyOut = [
       `\n  Agent LLM '${target.name}' test passed`,
       `    provider: ${target.provider}`,
       `    url:      ${displayUrl}`,
       `    response: ${completion ?? "(endpoint reachable; completion returned)"}`,
+      ...(quotas ?? []).map((quota, index) => `    ${index === 0 ? "quota:   " : "         "} ${formatClickzettaQuota(quota)}`),
       "",
       "",
     ].join("\n")
@@ -702,6 +709,7 @@ const LlmTestCommand = cmd({
       probe: "chat.completions",
       sample_response: completion,
       source: target.source,
+      ...(quotas ? { quotas } : {}),
     })
   },
 })

--- a/packages/cz-cli/src/commands/ai-gateway.ts
+++ b/packages/cz-cli/src/commands/ai-gateway.ts
@@ -9,6 +9,15 @@ import { pinAlicloudAdminHost } from "../llm/clickzetta-gateway-host.js"
 import * as Profile from "../connection/profile-context.js"
 import { readProfileEntry } from "../connection/profile-store.js"
 import { readLlmEntries, writeLlmEntries } from "../llm/native-config.js"
+import { classifyClickzettaEntry } from "../llm/clickzetta-entry.js"
+import { CLICKZETTA_DEFAULT_GATEWAY_URL } from "../llm/clickzetta-provider.js"
+import { buildLlmProbeRequest, firstClickzettaModel, normalizeLlmBaseUrl } from "../llm/probe.js"
+import {
+  formatClickzettaQuota,
+  parseClickzettaQuota,
+  recordGatewayQuota,
+  rewriteClickzettaGatewayError,
+} from "../llm/gateway-error.js"
 
 // ── AIGW admin API paths ────────────────────────────────────────────────────
 // Portal-proxied endpoints (standard portal token auth):
@@ -68,6 +77,40 @@ function resolveDefaultKey(): string | undefined {
   }
   const firstClickzetta = Object.values(llm).find((e) => e.provider === "clickzetta" && e.api_key)
   return firstClickzetta?.api_key
+}
+
+/**
+ * The ClickZetta llm.json entry a quota read should speak to.
+ *
+ * A name the user typed is answered directly — nothing is being guessed there. With no
+ * name, the question becomes "which entry is this session spending?", and that is
+ * classifyClickzettaEntry's to answer, not this command's: an earlier version of this
+ * function ran its own chain and picked the FIRST ClickZetta entry where the classifier
+ * deliberately refuses to choose, so `ai-gateway quota` reported one tenant's allowance
+ * while the sidebar showed nothing for the same llm.json. Ambiguity now asks the user to
+ * name one instead of picking for them.
+ */
+function resolveQuotaEntry(name?: string) {
+  const { llm } = readLlmEntries()
+  if (name) {
+    const entry = llm[name]
+    if (!entry) throw new Error(`No agent LLM named '${name}' in ~/.clickzetta/llm.json. List them with \`cz-cli agent llm list\`.`)
+    if (entry.provider !== "clickzetta")
+      throw new Error(`Agent LLM '${name}' is a ${entry.provider} entry; token quota is only reported by the ClickZetta AI gateway.`)
+    return { name, ...entry }
+  }
+  const resolved = classifyClickzettaEntry()
+  if (resolved.kind === "clickzetta") return { name: resolved.name, ...llm[resolved.name]! }
+  const candidates = Object.entries(llm)
+    .filter(([, entry]) => entry.provider === "clickzetta")
+    .map(([entryName]) => entryName)
+  if (candidates.length === 0)
+    throw new Error("No ClickZetta agent LLM configured in ~/.clickzetta/llm.json. Add one with `cz-cli ai-gateway key create <alias> --add-to-llm <alias>`.")
+  throw new Error(
+    `Could not tell which ClickZetta agent LLM this session is using, so naming one is required: ` +
+      `\`cz-cli ai-gateway quota <${candidates.join("|")}>\`. ` +
+      `Pin one instead with \`cz-cli agent llm use <entry>/<model>\`.`,
+  )
 }
 
 function reportError(err: unknown, format: string | undefined): void {
@@ -280,6 +323,106 @@ function buildRoutingRule(argv: Dict): Dict | undefined {
 export function registerGatewayCommand(cli: Argv<GlobalArgs>): void {
   cli.command("ai-gateway", "Manage ClickZetta AIGW virtual keys and list available models", (yargs) => {
     yargs
+      // ── quota ──────────────────────────────────────────────────────────────
+      .command(
+        "quota [llm]",
+        "Show the token quota left on a ClickZetta agent LLM's key, read from the gateway's response headers",
+        (y) =>
+          y
+            .positional("llm", { type: "string", describe: "Agent LLM entry name in ~/.clickzetta/llm.json (defaults to the active one)" })
+            .option("model", { type: "string", describe: "Model to send the probe to (defaults to the first model the key serves)" })
+            .epilogue(
+              [
+                "The gateway reports quota only on a completion, so this sends a 1-token chat request and reads",
+                "x-czgw-ratelimit-api-key-token-* off the response. Unlike `ai-gateway key list` it needs no portal",
+                "credentials and no ownership of the key — just the key itself.",
+              ].join("\n"),
+            ),
+        async (argv) => {
+          const format = argv.format
+          setGatewayDebug(!!argv.debug)
+          const t0 = Date.now()
+          try {
+            const entry = resolveQuotaEntry(argv.llm)
+            if (!entry.api_key) {
+              error("MISSING_API_KEY", `Agent LLM '${entry.name}' has no api_key. Set one with \`cz-cli agent llm add ${entry.name} --api-key <API_KEY>\`.`, { format, exitCode: 2 })
+              return
+            }
+            // The same default the provider applies (providerFromInput, native-config.ts):
+            // an entry with no base_url still chats, through the default gateway, so
+            // refusing to read its quota would report a problem the entry does not have.
+            const baseUrl = entry.base_url ?? CLICKZETTA_DEFAULT_GATEWAY_URL
+            // Undefined here means NEITHER the user named a model nor the catalog could
+            // be listed, so buildLlmProbeRequest falls back to a hardcoded id this tenant
+            // may not serve. That distinction decides how a 404 is reported below.
+            const probeModel = argv.model ?? (await firstClickzettaModel(baseUrl, entry.api_key))
+            const probe = buildLlmProbeRequest("clickzetta", baseUrl, entry.api_key, probeModel)
+            if (!probe) {
+              error("MISSING_BASE_URL", `Agent LLM '${entry.name}' needs a base_url before its quota can be read.`, { format, exitCode: 2 })
+              return
+            }
+            if (_debug) process.stderr.write(`[debug] → ${probe.method} ${probe.url}\n`)
+            const response = await fetch(probe.url, { method: probe.method, headers: probe.headers, body: probe.body })
+            const body = await response.text()
+            const quotas = parseClickzettaQuota(response.headers)
+
+            // A key with nothing left 429s, and that response carries no quota
+            // headers at all — the error body is the only account of the ceiling,
+            // so it is reported rather than swallowed as "quota unknown".
+            if (!response.ok) {
+              const rewrite = rewriteClickzettaGatewayError({ statusCode: response.status, message: response.statusText, responseBody: body })
+              logOperation("gateway quota", { ok: false, timeMs: Date.now() - t0 })
+              // A 404 on a model nobody asked for says nothing about the quota — it says
+              // the probe guessed an id this tenant does not serve. Reporting that as
+              // GATEWAY_QUOTA_UNAVAILABLE is the same "two surfaces, two verdicts" defect
+              // probe.ts:14-30 documents, so it gets its own code and names the remedy.
+              if (response.status === 404 && !probeModel) {
+                // buildLlmProbeRequest picks the fallback id itself and does not report
+                // it back, so read it out of the request we just sent.
+                const attempted = (() => {
+                  try { return String((JSON.parse(probe.body) as { model?: unknown }).model ?? "") } catch { return "" }
+                })()
+                error(
+                  "GATEWAY_PROBE_MODEL_UNAVAILABLE",
+                  `Could not read the quota for '${entry.name}': the gateway does not serve the fallback probe model${attempted ? ` '${attempted}'` : ""} (HTTP 404), and its model catalog could not be listed to pick one instead. This says nothing about the quota itself — retry with \`--model <id>\` naming a model this key can use.`,
+                  { format, extra: { llm: entry.name, status: response.status, ...(attempted ? { probe_model: attempted } : {}) } },
+                )
+                return
+              }
+              error(
+                "GATEWAY_QUOTA_UNAVAILABLE",
+                `Could not read the quota for '${entry.name}': the gateway answered HTTP ${response.status}.\n${rewrite?.message ?? body.slice(0, 500)}`,
+                { format, extra: { llm: entry.name, status: response.status, ...(rewrite ? { gateway_code: rewrite.code } : {}) } },
+              )
+              return
+            }
+
+            // Same cache the provider fills, so this command and the TUI sidebar never
+            // disagree about the same key — this reading is simply the fresher one. The
+            // "same key" half of that is what resolveQuotaEntry delegating to
+            // classifyClickzettaEntry buys: a shared cache is not agreement if the two
+            // sides can pick different entries to look up.
+            if (quotas) {
+              recordGatewayQuota({ baseURL: normalizeLlmBaseUrl("clickzetta", baseUrl)!, apiKey: entry.api_key, quotas })
+            }
+            logOperation("gateway quota", { ok: true, timeMs: Date.now() - t0 })
+            success(
+              { llm: entry.name, ...(probeModel ? { model: probeModel } : {}), ...(quotas ? { quotas } : {}) },
+              {
+                format,
+                timeMs: Date.now() - t0,
+                aiMessage: quotas
+                  ? quotas.map(formatClickzettaQuota).join("\n")
+                  : `The gateway at ${baseUrl} reported no quota headers, so the quota for '${entry.name}' is unknown.\n` +
+                    "Not every deployment sends them yet (cn-shanghai-alicloud does not, as of 2026-09-01) — fall back to `cz-cli ai-gateway key list`.",
+              },
+            )
+          } catch (err) {
+            logOperation("gateway quota", { ok: false, timeMs: Date.now() - t0 })
+            reportError(err, format)
+          }
+        },
+      )
       .command("key", "Manage AIGW virtual keys", (k) => {
         k
           // ── list ───────────────────────────────────────────────────────

--- a/packages/cz-cli/src/commands/ai-gateway.ts
+++ b/packages/cz-cli/src/commands/ai-gateway.ts
@@ -356,11 +356,11 @@ export function registerGatewayCommand(cli: Argv<GlobalArgs>): void {
             // be listed, so buildLlmProbeRequest falls back to a hardcoded id this tenant
             // may not serve. That distinction decides how a 404 is reported below.
             const probeModel = argv.model ?? (await firstClickzettaModel(baseUrl, entry.api_key))
-            const probe = buildLlmProbeRequest("clickzetta", baseUrl, entry.api_key, probeModel)
-            if (!probe) {
-              error("MISSING_BASE_URL", `Agent LLM '${entry.name}' needs a base_url before its quota can be read.`, { format, exitCode: 2 })
-              return
-            }
+            // No MISSING_BASE_URL guard: baseUrl is defaulted just above, and
+            // normalizeLlmBaseUrl only returns undefined for a falsy url, so the request
+            // cannot fail to build here. The guard that used to sit here named a condition
+            // the default had already handled.
+            const probe = buildLlmProbeRequest("clickzetta", baseUrl, entry.api_key, probeModel)!
             if (_debug) process.stderr.write(`[debug] → ${probe.method} ${probe.url}\n`)
             const response = await fetch(probe.url, { method: probe.method, headers: probe.headers, body: probe.body })
             const body = await response.text()

--- a/packages/cz-cli/src/commands/exec.ts
+++ b/packages/cz-cli/src/commands/exec.ts
@@ -17,7 +17,9 @@ import {
   JobStatus,
 } from "@clickzetta/sdk"
 import { currentTraceContext, defaultQueryTag } from "../trace.js"
-import { patchProfileUserId } from "../connection/profile-store.js"
+import { legacyOAuthInstanceId, numericField, patchProfileInstanceId, patchProfileUserId, readProfileEntry } from "../connection/profile-store.js"
+import * as Profile from "../connection/profile-context.js"
+import { resolveInstanceIdByName } from "../connection/instance-id.js"
 import { getCookieToken, hasCookieToken } from "../connection/cookie-token.js"
 import { profileTokenSource } from "../connection/token-source.js"
 
@@ -46,6 +48,10 @@ export function hasUsableCredentials(config: ConnectionConfig): boolean {
   return config.tokenStore?.load() !== undefined
 }
 
+export function execInstanceId(ctx: ExecContext): number {
+  return ctx.config.instanceId ?? 0
+}
+
 export async function getExecContext(args: Partial<CliArgs>): Promise<ExecContext> {
   const config = resolveConnectionConfig(args)
   if (!hasUsableCredentials(config)) {
@@ -58,8 +64,113 @@ export async function getExecContext(args: Partial<CliArgs>): Promise<ExecContex
     throw new Error("Workspace is required. Provide --workspace or configure it in your profile.")
   }
   const token = await getCookieToken(config) ?? await getToken(config)
+  // Resolved once and reused: passing `undefined` here would let these writes land on
+  // `default_profile` while the config above came from Profile.current() (CZ_PROFILE first).
+  const activeProfile = args.profile ?? Profile.current()
   // Persist userId to profile for telemetry (enduser.id). Fire-and-forget.
-  if (token.userId) patchProfileUserId(args.profile, token.userId)
+  if (token.userId) patchProfileUserId(activeProfile, token.userId)
+  // The instance id the wire needs belongs to the CONNECTION, not the credential — see
+  // ConnectionConfig.instanceId. A profile written before that carries no `instance_id`, so
+  // resolve it from the name the profile does carry and cache it back. One extra portal
+  // call, once per stale profile; a login records it up front.
+  if (!config.instanceId) {
+    // activeProfile, never `undefined`: readProfileEntry(undefined) and
+    // patchProfileInstanceId(undefined) both fall back to `default_profile`, while the
+    // config above came from Profile.current(), which prefers CZ_PROFILE. With the two
+    // disagreeing this read the account id off one profile and cached it onto another.
+    const entry = readProfileEntry(activeProfile)
+    const accountId = numericField(entry?.account_id) ?? 0
+    // Whether the name we are resolving is the PROFILE's own. It may instead have come from
+    // --instance, CZ_INSTANCE or --jdbc-url, and an id resolved for one of those must never
+    // be cached: patchProfileInstanceId only writes when absent, so a single overridden
+    // invocation would pin the profile to another instance's id permanently, with no path
+    // back. Same wrong-instance defect this change exists to remove, reached from a third
+    // direction — after the guard that compared a value to itself and the layer that
+    // cleared unconditionally.
+    const nameIsProfiles = typeof entry?.instance === "string" && entry.instance === config.instance
+    // Separated from "no match" so the two cannot be reported as the same thing: a portal
+    // that could not be reached says nothing about which instance the name belongs to.
+    let lookupError: unknown
+    let notListed = false
+    // Read once: each call re-reads and re-parses profiles.toml, and this is already the
+    // slow path.
+    const legacyId = legacyOAuthInstanceId(activeProfile)
+    const resolved = accountId
+      ? await resolveInstanceIdByName(
+          toServiceUrl(config.service, config.protocol),
+          profileTokenSource(config),
+          accountId,
+          config.instance,
+          {
+            customHeaders: config.customHeaders,
+            onError: (err) => { lookupError = err },
+            onNotFound: () => { notListed = true },
+          },
+        )
+      : 0
+    if (resolved) {
+      config.instanceId = resolved
+      if (nameIsProfiles) patchProfileInstanceId(activeProfile, resolved)
+    } else if (notListed && !nameIsProfiles) {
+      // Fatal only for a name the caller supplied — --instance, CZ_INSTANCE, --jdbc-url.
+      // There, "this account does not list it" contradicts something explicit and falling
+      // back to a credential's id would silently run against a DIFFERENT instance than the
+      // one named; that was the silent case worth closing.
+      //
+      // A name that came from the PROFILE is not fatal, because the credential's id can be
+      // just as definitive: cookie auth derives it from the cookie's own JWT payload
+      // (cookie-token.ts), and that cookie is scoped to an instance. Failing there would
+      // discard an authoritative answer over a lookup that can also miss for reasons other
+      // than ownership — a renamed instance, or one that is not serviceId 1.
+      throw new Error(
+        `Instance '${config.instance}' is not listed for this account on ${config.service}. ` +
+          `Check the name (\`cz-cli profile list\`), or set instance_id in the profile.`,
+      )
+    } else if (token.instanceId) {
+      // Reached only when the lookup could not answer — it failed, or there was no
+      // account_id to ask with. Never on a definitive "no such instance": that is the throw
+      // above. Only a PAT/password credential carries an id (from its own login response);
+      // an OAuth one does not, so it goes to the legacy read or the throw below.
+      config.instanceId = token.instanceId
+      // Warned when a lookup was ATTEMPTED and could not answer, not when none was possible.
+      // The definitive "this account has no such instance" is the throw above, so what is
+      // left here is a portal that failed — worth saying — and a profile with no account_id
+      // to ask with, which is not anomalous at all: a PAT/password profile has always used
+      // the id from its own login response, and warning there would put a line on every
+      // command for every such profile. The first version of this warning was conditional
+      // for the wrong reason (it skipped the no-match case, which is now fatal); making it
+      // unconditional then put it on the wrong cases instead.
+      if (lookupError) {
+        process.stderr.write(
+          `Warning: could not verify the instance id for '${config.instance}' ` +
+            `(${lookupError instanceof Error ? lookupError.message : String(lookupError)}); ` +
+            `using the credential's ${token.instanceId}, which may belong to a different instance.\n`,
+        )
+      }
+    } else if (legacyId) {
+      // Last resort, and only to preserve what used to work: an OAuth profile with no
+      // cached id and no usable lookup. The value comes from the shared `[oauth.<id>]`
+      // section an older version wrote — per-profile data in a shared place, i.e. the very
+      // thing this change removes — so it is used but never cached, and never quietly.
+      config.instanceId = legacyId
+      process.stderr.write(
+        `Warning: could not resolve the instance id for '${config.instance}'` +
+          (lookupError ? ` (${lookupError instanceof Error ? lookupError.message : String(lookupError)})` : "") +
+          `; falling back to ${legacyId} from this login's shared OAuth section, which may belong to a different instance. ` +
+          `Re-run \`cz-cli auth login\` to record the right one per profile.\n`,
+      )
+    } else {
+      throw new Error(
+        `Could not determine the instance id for '${config.instance}'.` +
+          (!accountId
+            ? ` The profile has no account_id to look it up with — run \`cz-cli auth login\` to refresh it, or set instance_id in the profile.`
+            : notListed
+              ? ` ${config.service} does not list it for this account — check the instance name, re-run \`cz-cli auth login\`, or set instance_id in the profile.`
+              : ` The lookup against ${config.service} failed${lookupError ? ` (${lookupError instanceof Error ? lookupError.message : String(lookupError)})` : ""} — this may be transient; retry, or set instance_id in the profile.`),
+      )
+    }
+  }
+
   const clientOpts: ClientOptions = {
     baseUrl: toServiceUrl(config.service, config.protocol),
     tokens: profileTokenSource(config),
@@ -110,7 +221,7 @@ export async function execSql(
 ): Promise<QueryResult | ExecResult> {
   const normalizedSql = sql + "\n;"
   const timezone = opts?.hints?.["cz.sql.timezone"]
-  const jobId = newJobId(ctx.config.workspace, ctx.token.instanceId)
+  const jobId = newJobId(ctx.config.workspace, execInstanceId(ctx))
   opts?.onJobId?.(jobId.id)
   const traceContext = currentTraceContext()
   const submitResp = await submitJob(ctx.clientOpts, {
@@ -119,7 +230,7 @@ export async function execSql(
     schema: ctx.config.schema,
     vcluster: ctx.config.vcluster,
     instanceName: ctx.config.instance,
-    instanceId: ctx.token.instanceId,
+    instanceId: execInstanceId(ctx),
     jobId,
     hints: buildExecHints(opts?.hints, traceContext),
     asynchronous: opts?.asynchronous,
@@ -148,7 +259,7 @@ export async function execSql(
   // Volume SQL (PUT/GET): process file transfers after getting the job result
   if (isVolumeSql(normalizedSql) && result.status === JobStatus.SUCCEEDED) {
     return processVolumeSql(
-      { clientOpts: ctx.clientOpts, workspace: ctx.config.workspace, instanceId: ctx.token.instanceId },
+      { clientOpts: ctx.clientOpts, workspace: ctx.config.workspace, instanceId: execInstanceId(ctx) },
       jobId,
       result,
       normalizedSql,
@@ -269,7 +380,6 @@ export async function execSqlWithRetry(
     ctx.token = {
       ...ctx.token,
       token: fresh.token,
-      instanceId: fresh.instanceId || ctx.token.instanceId,
       userId: fresh.userId || ctx.token.userId,
     }
     return await execSql(ctx, sql, opts)

--- a/packages/cz-cli/src/commands/job.ts
+++ b/packages/cz-cli/src/commands/job.ts
@@ -11,7 +11,7 @@ import type { GlobalArgs } from "../cli.js"
 import { success, successRows, error } from "../output/index.js"
 import { maskRows } from "../output/masking.js"
 import { logOperation } from "../logger.js"
-import { getExecContext } from "./exec.js"
+import { execInstanceId, getExecContext } from "./exec.js"
 import { getStudioContext } from "./studio-context.js"
 import { buildJobProfileRows } from "./job-profile.js"
 
@@ -238,7 +238,7 @@ export function registerJobCommand(cli: Argv<GlobalArgs>): void {
             const jobId: JobID = {
               id: argv["job-id"] as string,
               workspace: ctx.config.workspace,
-              instanceId: ctx.token.instanceId,
+              instanceId: execInstanceId(ctx),
             }
             const raw = await getJobStatus(ctx.clientOpts, jobId)
             const state = raw.status?.state ?? "UNKNOWN"
@@ -276,7 +276,7 @@ export function registerJobCommand(cli: Argv<GlobalArgs>): void {
             const jobId: JobID = {
               id: argv["job-id"] as string,
               workspace: ctx.config.workspace,
-              instanceId: ctx.token.instanceId,
+              instanceId: execInstanceId(ctx),
             }
             const t0 = Date.now()
             const timeoutMs = (argv.timeout as number) * 1000
@@ -394,7 +394,7 @@ export function registerJobCommand(cli: Argv<GlobalArgs>): void {
             const jobId: JobID = {
               id: argv["job-id"] as string,
               workspace: ctx.config.workspace,
-              instanceId: ctx.token.instanceId,
+              instanceId: execInstanceId(ctx),
             }
             await cancelJob(ctx.clientOpts, jobId)
             logOperation("job cancel", { ok: true })

--- a/packages/cz-cli/src/commands/profile-bootstrap.ts
+++ b/packages/cz-cli/src/commands/profile-bootstrap.ts
@@ -319,7 +319,7 @@ async function loginByInstance(
     token: jwt,
     userId,
     tenantId,
-    instanceId: loginData.instanceId,
+    instanceId: loginData.instanceId ?? 0,
     username: userName,
     accountDisplayName: info.accountDisplayName,
     serviceUrl: baseUrl,

--- a/packages/cz-cli/src/commands/sql.ts
+++ b/packages/cz-cli/src/commands/sql.ts
@@ -402,9 +402,7 @@ async function executeSingle(
     }
     if (!isQueryResult(r)) { error("UNEXPECTED_RESULT", "Expected query result but got async marker.", { format }); return }
     if (r.status === JobStatus.FAILED) {
-      const hint = await fetchSchemaHint(ctx, sql, r.errorMessage ?? "")
-      logOperation("sql", { sql, ok: false, errorCode: r.errorCode, timeMs: Date.now() - t0 })
-      error(r.errorCode ?? "SQL_ERROR", await formatQueryError(r, ctx, argv.profile), { format, extra: hint ? { schema: hint } : undefined })
+      await handleFailure(r, sql, ctx, format, t0, argv.profile)
       return
     }
     if (r.rowCount > rowLimit) {
@@ -504,9 +502,12 @@ async function handleFailure(r: QueryResult, sql: string, ctx: ExecContext, form
   const aiMessage = hint
     ? `SQL failed. Available schema info attached in the 'schema' field — check table/column names and retry.`
     : undefined
+  // job_id travels on failures too, so a failed query can still be traced via
+  // `cz-cli job profile <id>` the same way a successful one can.
+  const extra = { ...(hint ? { schema: hint } : {}), ...(r.jobId ? { job_id: r.jobId } : {}) }
   error(r.errorCode ?? "SQL_ERROR", await formatQueryError(r, ctx, profileName), {
     format,
-    extra: hint ? { schema: hint } : undefined,
+    extra: Object.keys(extra).length > 0 ? extra : undefined,
     ...(aiMessage && { aiMessage }),
   })
 }
@@ -679,7 +680,7 @@ async function handler(argv: SqlArgs): Promise<void> {
           const r = await execSqlWithRetry(ctx, stmt, { hints: accumulatedHints, timeoutMs: argv.timeout * 1000, configStatements })
           if (isQueryResult(r) && r.status === JobStatus.FAILED) {
             logOperation("sql", { sql: stmt, ok: false, errorCode: r.errorCode })
-            error(r.errorCode ?? "SQL_ERROR", await formatQueryError(r, ctx, argv.profile), { format })
+            error(r.errorCode ?? "SQL_ERROR", await formatQueryError(r, ctx, argv.profile), { format, ...(r.jobId ? { extra: { job_id: r.jobId } } : {}) })
             return
           }
         } else {

--- a/packages/cz-cli/src/commands/sql.ts
+++ b/packages/cz-cli/src/commands/sql.ts
@@ -5,7 +5,7 @@ import type { GlobalArgs } from "../cli.js"
 import { success, successRows, error, handledError, parseOutputArgs, renderOutput, renderErrorOutput } from "../output/index.js"
 import { maskRows } from "../output/masking.js"
 import { logOperation } from "../logger.js"
-import { getExecContext, execSql, execSqlWithRetry, isQueryResult, validateIdentifier, classifyExecError, type ExecContext } from "./exec.js"
+import { type ExecContext, classifyExecError, execInstanceId, execSql, execSqlWithRetry, getExecContext, isQueryResult, validateIdentifier } from "./exec.js"
 import { formatBillingError } from "./billing-error.js"
 import { czConfigBool, CZ_CONFIG_FILE } from "../config/cz-config.js"
 
@@ -562,7 +562,7 @@ async function handler(argv: SqlArgs): Promise<void> {
     const jobId: JobID = {
       id: argv["job-profile"],
       workspace: ctx.config.workspace,
-      instanceId: ctx.token.instanceId,
+      instanceId: execInstanceId(ctx),
     }
     const body = {
       get_result_request: {
@@ -677,10 +677,15 @@ async function handler(argv: SqlArgs): Promise<void> {
           }
         } else if (i < statements.length - 1) {
           // Non-batch: silently execute intermediate statements
+          const started = Date.now()
           const r = await execSqlWithRetry(ctx, stmt, { hints: accumulatedHints, timeoutMs: argv.timeout * 1000, configStatements })
           if (isQueryResult(r) && r.status === JobStatus.FAILED) {
-            logOperation("sql", { sql: stmt, ok: false, errorCode: r.errorCode })
-            error(r.errorCode ?? "SQL_ERROR", await formatQueryError(r, ctx, argv.profile), { format, ...(r.jobId ? { extra: { job_id: r.jobId } } : {}) })
+            // Through the shared helper, like every other failure path. Adding job_id
+            // inline here is what the single-statement branch used to do, and folding that
+            // one in is the reason this file has one failure reporter: an inline copy gets
+            // job_id but not the schema hint, the ai_message or the timing, so the two
+            // paths drift apart again the moment either gains something.
+            await handleFailure(r, stmt, ctx, format, started, argv.profile)
             return
           }
         } else {
@@ -716,7 +721,7 @@ export function registerSqlCommand(cli: Argv<GlobalArgs>): void {
               const jobId: JobID = {
                 id: argv["job-id"] as string,
                 workspace: ctx.config.workspace,
-                instanceId: ctx.token.instanceId,
+                instanceId: execInstanceId(ctx),
               }
               const body = {
                 get_result_request: {

--- a/packages/cz-cli/src/commands/studio-context.ts
+++ b/packages/cz-cli/src/commands/studio-context.ts
@@ -28,7 +28,10 @@ export async function getGatewayContext(args: Partial<CliArgs> & { format?: stri
   const credential = await tokens.get()
   const instanceId = await resolveInstanceIdByName(baseUrl, tokens, user.accountId, config.instance, {
     customHeaders: config.customHeaders,
-    fallbackId: credential.instanceId,
+    // The connection's own id first: it is the authoritative one now (see
+    // ConnectionConfig.instanceId), and for an OAuth profile the credential's is 0 —
+    // `[oauth.<id>]` no longer stores one, so it cannot be a fallback for anything.
+    fallbackId: config.instanceId ?? credential.instanceId,
     debug,
   })
   return {
@@ -76,7 +79,10 @@ export async function getStudioContext(
 
   const instanceId = await resolveInstanceIdByName(baseUrl, tokens, tenantId, config.instance, {
     customHeaders: config.customHeaders,
-    fallbackId: credential.instanceId,
+    // The connection's own id first: it is the authoritative one now (see
+    // ConnectionConfig.instanceId), and for an OAuth profile the credential's is 0 —
+    // `[oauth.<id>]` no longer stores one, so it cannot be a fallback for anything.
+    fallbackId: config.instanceId ?? credential.instanceId,
     debug,
   })
 

--- a/packages/cz-cli/src/commands/table.ts
+++ b/packages/cz-cli/src/commands/table.ts
@@ -5,7 +5,7 @@ import { JobStatus, request, type QueryResult } from "@clickzetta/sdk"
 import type { GlobalArgs } from "../cli.js"
 import { success, successRows, error } from "../output/index.js"
 import { logOperation } from "../logger.js"
-import { getExecContext, execSql, isQueryResult, validateIdentifier, classifyExecError, rowsToRecords } from "./exec.js"
+import { classifyExecError, execInstanceId, execSql, getExecContext, isQueryResult, rowsToRecords, validateIdentifier } from "./exec.js"
 
 const DEFAULT_LIMIT = 100
 const DEFAULT_PREVIEW_LIMIT = 10
@@ -246,7 +246,7 @@ export function registerTableCommand(cli: Argv<GlobalArgs>): void {
                 const body = {
                   get_summary_request: {
                     account: { user_id: 0 },
-                    job_id: { id: r.jobId, workspace: ctx.config.workspace, instance_id: ctx.token.instanceId },
+                    job_id: { id: r.jobId, workspace: ctx.config.workspace, instance_id: execInstanceId(ctx) },
                     offset: 0,
                     user_agent: "",
                   },

--- a/packages/cz-cli/src/connection/config.ts
+++ b/packages/cz-cli/src/connection/config.ts
@@ -75,7 +75,15 @@ export function resolveConnectionConfig(cliArgs: Partial<CliArgs> = {}): Connect
     // Treat it as absent, which is what every other CLI does with an empty
     // operand, and let the profile keep its value.
     if (val !== undefined && val !== null && String(val).trim() !== "") {
+      // Read BEFORE the write. Comparing against cfg[key] afterwards is comparing val to
+      // itself, which is how the first version of this guard never fired once — and the
+      // symptom was silent: `--instance other` kept the profile's cached id and submitted
+      // the job against the profile's instance.
+      const previous = cfg[key]
       cfg[key] = val
+      // An id resolved for one instance is meaningless for another, so naming a different
+      // instance drops it and getExecContext resolves the right one.
+      if (key === "instance" && val !== previous) cfg.instanceId = undefined
     }
   }
   cfg.protocol = normalizeProtocol(cfg.protocol)
@@ -329,7 +337,25 @@ function applyNonAuth(target: ConnectionConfig, src: Partial<ConnectionConfig> |
   if (!src) return
   if (src.service) target.service = src.service
   if (src.protocol) target.protocol = normalizeProtocol(src.protocol)
-  if (src.instance) target.instance = src.instance
+  if (src.instance) {
+    // The id travels WITH the name. A layer that carries its own id wins; a layer that
+    // names the SAME instance without one leaves the id alone; only a layer naming a
+    // DIFFERENT instance clears it, because a numeric id is meaningless for another
+    // instance and getExecContext must resolve the right one.
+    //
+    // The distinction is not academic: ConnectionEnv has no CZ_INSTANCE_ID, so an exported
+    // CZ_INSTANCE arrives with instanceId undefined. Clearing unconditionally meant anyone
+    // who exports CZ_INSTANCE — even naming the profile's own instance — paid a
+    // serviceInstanceList round trip on every single command, forever.
+    const changed = src.instance !== target.instance
+    target.instance = src.instance
+    if (src.instanceId !== undefined) target.instanceId = src.instanceId
+    else if (changed) target.instanceId = undefined
+  }
+  // Deliberately no `else if (src.instanceId)`: an id without a name is not a state worth
+  // carrying. Every path that reaches a job requires config.instance first (exec.ts), so the
+  // id would be unusable, and the only way to produce the combination is hand-editing a
+  // profile that already cannot run a command.
   if (src.workspace) target.workspace = src.workspace
   if (src.schema) target.schema = src.schema
   if (src.vcluster) target.vcluster = src.vcluster

--- a/packages/cz-cli/src/connection/instance-id.ts
+++ b/packages/cz-cli/src/connection/instance-id.ts
@@ -22,7 +22,25 @@ export async function resolveInstanceIdByName(
   tokens: TokenSource,
   accountId: number,
   instanceName: string,
-  opts?: { customHeaders?: Record<string, string>; fallbackId?: number; debug?: boolean },
+  opts?: {
+    customHeaders?: Record<string, string>
+    fallbackId?: number
+    debug?: boolean
+    /**
+     * Called when the lookup FAILED, as opposed to succeeding with no match. Without it
+     * both collapse into `fallbackId` and a caller cannot tell "this account does not have
+     * that instance" from "the portal was unreachable" — so a transient blip silently
+     * looked like a definitive answer.
+     */
+    onError?: (err: unknown) => void
+    /**
+     * Called when the lookup SUCCEEDED and no row matched the name. Distinct from onError
+     * on purpose: "this account does not own an instance by that name" is a definitive
+     * answer and the more serious one, while a failed request says nothing at all. Folding
+     * both into `fallbackId` let the definitive case be the quiet one.
+     */
+    onNotFound?: () => void
+  },
 ): Promise<number> {
   const fallbackId = opts?.fallbackId ?? 0
   try {
@@ -37,16 +55,25 @@ export async function resolveInstanceIdByName(
       undefined,
       "GET",
     )
+    // serviceId 1 is the Lakehouse instance, which is the only kind a job can run on — so
+    // narrowing here is right even though login-time discovery (login-browser.ts) lists every
+    // instance: that enumeration builds the profile matrix, this resolves the id a JobID needs.
     const match = (payload.data ?? []).find((row) =>
       String(row.name ?? row.instanceName ?? "") === instanceName
       && numeric(row.serviceId ?? 1) === 1,
     )
+    // Only "no row matched" is a statement about what the account owns. A row that matched
+    // but carried no usable id is a malformed payload, and reporting THAT as not-owned would
+    // hand the caller a definitive answer it has no basis for — the caller turns this into a
+    // hard failure.
+    if (!match) opts?.onNotFound?.()
     const resolved = numeric(match?.id ?? match?.instanceId)
     if (opts?.debug) {
       process.stderr.write(`[debug] resolveInstanceIdByName: name=${instanceName} matched=${resolved || "none"} fallback=${fallbackId}\n`)
     }
     return resolved || fallbackId
-  } catch {
+  } catch (err) {
+    opts?.onError?.(err)
     return fallbackId
   }
 }

--- a/packages/cz-cli/src/connection/profile-store.ts
+++ b/packages/cz-cli/src/connection/profile-store.ts
@@ -39,6 +39,17 @@ export interface AgentProfileEntry {
   instanceId?: number
 }
 
+/**
+ * Numeric coercion for a raw TOML value; undefined when it is not a finite number.
+ *
+ * Exported as `numericField` so callers outside this module stop growing their own copies —
+ * exec.ts had a third one whose docstring described THIS behaviour while its body returned
+ * 0 and accepted whitespace-only strings.
+ */
+export function numericField(val: unknown): number | undefined {
+  return num(val)
+}
+
 function num(val: unknown): number | undefined {
   if (typeof val === "number" && Number.isFinite(val)) return val
   if (typeof val === "string" && val.trim() !== "") {
@@ -278,6 +289,9 @@ export function getProfileConfig(profileName?: string): Partial<ConnectionConfig
     service: str(profileData.service, DEFAULT_CONNECTION.service),
     protocol: normalizeProtocol(str(profileData.protocol, undefined)),
     instance: str(profileData.instance, ""),
+    // Absent on profiles written before instance_id moved off the token; getExecContext
+    // resolves it by name and writes it back, so this fills in on first use.
+    ...(num(profileData.instance_id) !== undefined ? { instanceId: num(profileData.instance_id) } : {}),
     workspace: str(profileData.workspace, ""),
     schema: str(profileData.schema, DEFAULT_CONNECTION.schema),
     vcluster: str(profileData.vcluster, DEFAULT_CONNECTION.vcluster),
@@ -424,6 +438,35 @@ export function patchProfileUserId(profileName: string | undefined, userId: numb
 }
 
 /**
+ * Backfill a profile's numeric `instance_id`, resolved from its instance NAME.
+ *
+ * Only for profiles written before the id moved off the token — a login now records it
+ * from the enumeration it already has (see provisionOAuthProfiles), so this runs once
+ * per stale profile and then never again. Best-effort like patchProfileUserId: the CLI
+ * has the value in hand either way, and failing to cache it must not fail the command.
+ *
+ * Writes only when absent, so it can never overwrite a value the server told a login.
+ */
+export function patchProfileInstanceId(profileName: string | undefined, instanceId: number): void {
+  if (!Number.isFinite(instanceId) || instanceId <= 0) return
+  try {
+    const text = readFileSync(profilesFile(), "utf-8")
+    const data = parseTOML(text) as Record<string, unknown>
+    const profiles = (data.profiles ?? {}) as Record<string, Record<string, unknown>>
+    const name = profileName
+      ?? (typeof data.default_profile === "string" ? data.default_profile : undefined)
+      ?? Object.keys(profiles)[0]
+    if (!name || !profiles[name]) return
+    if (profiles[name]["instance_id"] != null) return
+    profiles[name]["instance_id"] = instanceId
+    data.profiles = profiles
+    writeProfilesFile(stringifyTOML(data))
+  } catch {
+    // best-effort: never block the CLI
+  }
+}
+
+/**
  * Merge logged-in connection context into the active profile entry so a later
  * `resolveConnectionConfig` picks up the instance/workspace/schema/etc. the
  * user actually authenticated against (requirement 11.6/11.7). Resolves the
@@ -439,6 +482,8 @@ export function patchProfileConnection(
     service?: string
     protocol?: string
     instance?: string
+    /** Numeric id of `instance`. A login already knows it; see ConnectionConfig.instanceId. */
+    instanceId?: number
     workspace?: string
     schema?: string
     vcluster?: string
@@ -468,6 +513,10 @@ export function patchProfileConnection(
     assign("account_name", fields.accountName)
     assign("aimeshEndpointBaseUrl", fields.aimeshEndpointBaseUrl)
     if (typeof fields.userId === "number" && fields.userId > 0) profile["user_id"] = fields.userId
+    // Written unconditionally, unlike patchProfileInstanceId's write-only-if-absent: this
+    // is a login reporting what the server just said, so it also CORRECTS a value an older
+    // version cached from the wrong source.
+    if (typeof fields.instanceId === "number" && fields.instanceId > 0) profile["instance_id"] = fields.instanceId
     if (typeof fields.accountId === "number" && fields.accountId > 0) profile["account_id"] = fields.accountId
 
     data.profiles = profiles
@@ -577,32 +626,60 @@ export function sanitizeOAuthId(name: string): string {
   return cleaned.length > 0 ? cleaned : "default"
 }
 
+/**
+ * The `instance_id` an OLDER version wrote into `[oauth.<id>]`, read on purpose.
+ *
+ * parseOAuthEntry deliberately ignores that field — it is per-profile data in a section
+ * shared across profiles, which is the whole defect. This reader exists for exactly one
+ * case: the profile has no `instance_id` yet and the portal cannot be reached, so the only
+ * number on disk is the one this change stopped trusting. Using it keeps a command working
+ * offline where it used to work; the caller must say out loud that it may belong to a
+ * different instance. Not a source of truth, and never cached forward.
+ */
+export function legacyOAuthInstanceId(profileName: string | undefined): number | undefined {
+  try {
+    const data = parseTOML(readFileSync(profilesFile(), "utf-8")) as Record<string, unknown>
+    const name = resolveProfileName(data, profileName)
+    const profiles = (data.profiles ?? {}) as Record<string, Record<string, unknown>>
+    const id = name ? profileOAuthPointer(profiles[name]) : undefined
+    if (!id) return undefined
+    const shared = (data.oauth ?? {}) as Record<string, Record<string, unknown> | undefined>
+    return num(shared[id]?.instance_id)
+  } catch {
+    return undefined
+  }
+}
+
 /** Parse a raw `[oauth.<id>]` entry into an AuthToken, or undefined if invalid. */
 function parseOAuthEntry(entry: Record<string, unknown> | undefined): AuthToken | undefined {
   if (!entry) return undefined
   const token = str(entry.access_token, undefined)
   const expireTimeMs = num(entry.expire_time_ms)
   const obtainedAt = num(entry.obtained_at)
-  const instanceId = num(entry.instance_id)
   const userId = num(entry.user_id)
+  // entry.instance_id is deliberately NOT read. Older versions wrote one here and REQUIRED
+  // it, which is why dropping it needs this to change in the same commit: a reader that
+  // still demanded it would treat every newly written section as invalid.
   if (token === undefined || expireTimeMs === undefined || obtainedAt === undefined) return undefined
-  if (instanceId === undefined || userId === undefined) return undefined
+  if (userId === undefined) return undefined
   const refreshToken = str(entry.refresh_token, undefined)
   // OAuth issuer host — required to target `/oauth2/token` on refresh (the
   // region business host in the profile's `service` returns invalid_grant).
   const issuer = str(entry.issuer, undefined)
-  const result: AuthToken = { token, instanceId, userId, expireTimeMs, obtainedAt }
+  const result: AuthToken = { token, userId, expireTimeMs, obtainedAt }
   if (refreshToken !== undefined) result.refreshToken = refreshToken
   if (issuer !== undefined) result.issuer = issuer
   return result
 }
 
 function tokenToEntry(token: AuthToken): Record<string, unknown> {
+  // No instance_id: this section is SHARED by every profile the login can reach, and an
+  // instance is per-profile — see ConnectionConfig.instanceId. Sections written by older
+  // versions still carry one; parseOAuthEntry ignores it.
   const entry: Record<string, unknown> = {
     access_token: token.token,
     expire_time_ms: token.expireTimeMs,
     obtained_at: token.obtainedAt,
-    instance_id: token.instanceId,
     user_id: token.userId,
   }
   if (token.refreshToken !== undefined) entry.refresh_token = token.refreshToken

--- a/packages/cz-cli/src/connection/provision.ts
+++ b/packages/cz-cli/src/connection/provision.ts
@@ -591,6 +591,9 @@ export function provisionProfilesFromOAuthCombos(
         service: combo.service,
         protocol,
         instance: combo.instance,
+        // The enumeration already carries it (oauth-enumerate.ts), so a login never needs
+        // the name→id lookup getExecContext does for older profiles.
+        instanceId: combo.instanceId,
         workspace: combo.workspace,
         userId: token.userId || undefined,
         accountId: userInfo?.accountId,
@@ -624,6 +627,7 @@ export function provisionProfilesFromOAuthCombos(
       service: combo.service,
       protocol,
       instance: combo.instance,
+      instanceId: combo.instanceId,
       workspace: combo.workspace,
       userId: token.userId || undefined,
       accountId: userInfo?.accountId,

--- a/packages/cz-cli/src/connection/token-source.ts
+++ b/packages/cz-cli/src/connection/token-source.ts
@@ -35,7 +35,7 @@ export function profileTokenSource(config: ConnectionConfig): TokenSource {
         token
           ? {
               token: token.token,
-              instanceId: token.instanceId,
+              instanceId: token.instanceId ?? 0,
               userId: token.userId,
               // The Cookie travels WITH the credential: a session credential is
               // only accepted alongside it, and the transport merges these.

--- a/packages/cz-cli/src/llm/clickzetta-entry.ts
+++ b/packages/cz-cli/src/llm/clickzetta-entry.ts
@@ -1,0 +1,100 @@
+/**
+ * Which ClickZetta llm.json entry is the session's — the ONE answer to that question.
+ *
+ * It lived in the TUI plugin's data module until three copies of the same chain existed
+ * (here, `ai-gateway quota`, and `resolveDefaultKey`) and two of them disagreed: this one
+ * refuses to pick between several ClickZetta entries, the command guessed the first. So
+ * `cz-cli ai-gateway quota` reported one tenant's allowance while the sidebar, looking at
+ * the same llm.json, showed nothing — and a comment in the command claimed the two "never
+ * disagree about the same key". They can only not disagree if they ask the same code.
+ *
+ * NOT the same question as `resolveDefaultKey` in commands/ai-gateway.ts, which picks *a*
+ * key to authenticate an admin call with; any usable key does there. This picks *the*
+ * key the session is spending, where guessing misreports whose quota the user is seeing.
+ */
+import { readLlmEntries } from "./native-config.js"
+
+/**
+ * Resolve which ClickZetta LLM entry the indicator should report on.
+ *
+ * LLM entries and connection Profiles are independent configuration domains.
+ * This resolver only selects the LLM/API key; fetchQuotaSnapshot separately uses
+ * Profiles as Portal credentials and never treats the entry name as a Profile.
+ *
+ * Candidates, most to least specific:
+ *   1. `providerID` — what the TUI currently has selected, when known.
+ *   2. `config.model`'s provider prefix — set by `cz-cli agent llm use`. Often
+ *      absent: with no pinned model the TUI auto-selects, so this cannot be the
+ *      only source or the indicator stays blank for everyone who never ran `use`.
+ *   3. The sole ClickZetta entry, if there is exactly one. Unambiguous by
+ *      definition; skipped when several exist rather than guessing a tenant.
+ *
+ * Returns undefined when nothing resolves to a ClickZetta entry (the user is on
+ * anthropic/openai/…), which is the signal to render nothing at all.
+ */
+export function resolveClickzettaEntry(providerID?: string): { name: string; apiKey: string } | undefined {
+  const resolved = classifyClickzettaEntry(providerID)
+  return resolved.kind === "clickzetta" ? { name: resolved.name, apiKey: resolved.apiKey } : undefined
+}
+
+/**
+ * Why this is a three-way answer and not `entry | undefined`.
+ *
+ * Cash balance belongs to the connection Profile; token quota belongs to the LLM
+ * key. Collapsing "not a ClickZetta key" with "user is on another provider" into
+ * one `undefined` made fetchQuotaSnapshot bail before it read profiles at all, so
+ * ANY failure to pin an LLM entry also silently removed the cash balance — a
+ * reading that never depended on the LLM entry in the first place.
+ *
+ *   - `clickzetta` — a specific ClickZetta key. Report balance and quota.
+ *   - `foreign`    — the session is demonstrably on a non-ClickZetta provider
+ *                    (anthropic/openai/…), or there is no ClickZetta entry at all.
+ *                    Report nothing; a ¥ figure next to a Claude model would name
+ *                    money that model is not spending. This is the case the
+ *                    original `undefined` was meant for.
+ *   - `ambiguous`  — this IS a ClickZetta user, but which key is in play cannot be
+ *                    pinned (several entries, none selected or pinned; or the
+ *                    matched entry carries no api_key). Report the balance, skip
+ *                    the quota — guessing a tenant's key would misreport usage.
+ */
+export type ClickzettaEntryResolution =
+  | { kind: "clickzetta"; name: string; apiKey: string; baseUrl?: string }
+  | { kind: "foreign" }
+  | { kind: "ambiguous" }
+
+export function classifyClickzettaEntry(providerID?: string): ClickzettaEntryResolution {
+  const { llm, model } = readLlmEntries()
+  const isClickzetta = (name: string | undefined) => (name ? llm[name]?.provider === "clickzetta" : false)
+  const usable = (name: string | undefined): ClickzettaEntryResolution | undefined => {
+    if (!name) return undefined
+    const entry = llm[name]
+    if (entry?.provider !== "clickzetta") return undefined
+    // A ClickZetta entry with no key is still a ClickZetta user — quota is
+    // unknowable, the balance is not.
+    if (!entry.api_key) return { kind: "ambiguous" }
+    return { kind: "clickzetta", name, apiKey: entry.api_key, ...(entry.base_url ? { baseUrl: entry.base_url } : {}) }
+  }
+
+  const selected = usable(providerID)
+  if (selected) return selected
+
+  // An explicit selection that is not a ClickZetta entry ends the search: the
+  // provider may come from environment/plugin discovery and need not appear in
+  // llm.json, and falling through would report the sole ClickZetta key while the
+  // prompt visibly names a different provider.
+  if (providerID) return { kind: "foreign" }
+
+  const configured = typeof model === "string" && model.includes("/") ? model.slice(0, model.indexOf("/")) : undefined
+  const inferred = usable(configured)
+  if (inferred) return inferred
+
+  const clickzetta = Object.entries(llm).filter(([, entry]) => entry.provider === "clickzetta" && entry.api_key)
+  if (clickzetta.length === 1) {
+    const [name, entry] = clickzetta[0]!
+    return { kind: "clickzetta", name, apiKey: entry.api_key!, ...(entry.base_url ? { baseUrl: entry.base_url } : {}) }
+  }
+  // Several ClickZetta entries and nothing to choose between them is ambiguous,
+  // not foreign — as is a pinned model naming a ClickZetta entry we could not use.
+  if (clickzetta.length > 1 || isClickzetta(configured)) return { kind: "ambiguous" }
+  return { kind: "foreign" }
+}

--- a/packages/cz-cli/src/llm/gateway-error.ts
+++ b/packages/cz-cli/src/llm/gateway-error.ts
@@ -1,3 +1,18 @@
+// cz-cli's seam onto @clickzetta/ai-gateway for everything that interprets the AIGW
+// wire format: the error classifier this file is named for, and now the response-header
+// quota reader plus its cross-process store. Prefer importing from here over reaching
+// into the package directly.
+//
+// Not the ONLY seam: llm/clickzetta-provider.ts re-exports normalizeClickzettaGatewayUrl
+// from "@clickzetta/ai-gateway/url", and callers that need the URL normalizer take it
+// from there. Two seams because they are two concerns — that file owns "which provider
+// package and endpoint", this one owns "what the gateway's responses mean" — but if a
+// third appears, collapse them.
+// Three narrow subpaths, not the root `@clickzetta/ai-gateway` barrel. The barrel's
+// first import is `createOpenAICompatible` from "@ai-sdk/openai-compatible", and
+// tui-quota-data.ts reaches this file from tui-quota-runtime.ts, which build.ts
+// pre-bundles with no `external` — so importing the barrel here inlined the whole
+// openai-compatible provider into an asset that only needs node:fs and node:crypto.
 export {
   rewriteClickzettaGatewayError,
   clickzettaGatewayCode,
@@ -10,4 +25,18 @@ export {
   type GatewayErrorCode,
   type GatewayErrorInput,
   type GatewayErrorRewrite,
-} from "@clickzetta/ai-gateway"
+} from "@clickzetta/ai-gateway/gateway-error"
+
+export {
+  parseClickzettaQuota,
+  formatClickzettaQuota,
+  type ClickzettaQuota,
+  type ClickzettaQuotaPeriod,
+} from "@clickzetta/ai-gateway/quota"
+
+export {
+  readGatewayQuota,
+  recordGatewayQuota,
+  gatewayQuotaCacheKey,
+  type GatewayQuotaEntry,
+} from "@clickzetta/ai-gateway/quota-store"

--- a/packages/cz-cli/src/opencode-plugin/tui-quota-data.ts
+++ b/packages/cz-cli/src/opencode-plugin/tui-quota-data.ts
@@ -26,11 +26,10 @@
 // tui-title-brand.ts.
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
-import { getToken, toServiceUrl } from "@clickzetta/sdk"
+import { toServiceUrl } from "@clickzetta/sdk"
 import { resolveConnectionConfig } from "../connection/config.js"
 import * as Profile from "../connection/profile-context.js"
 import { deriveAuthType, explicitAuthType, loadProfiles } from "../connection/profile-store.js"
-import { readLlmEntries } from "../llm/native-config.js"
 // Re-exported, not redefined: tui-quota-runtime.ts publishes these to the .tsx renderer,
 // and commands/ai-gateway.ts needs the same answer — see llm/clickzetta-entry.ts.
 import { classifyClickzettaEntry, resolveClickzettaEntry } from "../llm/clickzetta-entry.js"
@@ -185,6 +184,27 @@ function knownRegion(service: string): string | undefined {
 }
 
 /**
+ * Which profile a session-scoped panel may speak for — the ONE place that rule lives.
+ *
+ * Substitute the first TOML profile only when NOTHING is pinned (`current === undefined`,
+ * which Profile.current() documents as "no profile configured"). A `current` that names a
+ * profile absent from the file — a stale CZ_PROFILE, a deleted default_profile — resolves to
+ * undefined, because silently swapping in another row would attribute one tenant's identity,
+ * and one tenant's MONEY, to a session pointed somewhere else.
+ *
+ * Extracted because it was stated twice, byte for byte, in readProfileInfo and
+ * fetchQuotaSnapshot — and collapsing the profile walk had already dropped it from the
+ * balance half once, which is exactly how a rule with a security consequence goes missing.
+ */
+function panelProfileName(
+  current: string | undefined,
+  profiles: Record<string, unknown>,
+): string | undefined {
+  if (current === undefined) return Object.keys(profiles)[0]
+  return profiles[current] ? current : undefined
+}
+
+/**
  * Read the active profile's identity and connection target from profiles.toml.
  *
  * Synchronous and network-free on purpose: this is the half of the sidebar that
@@ -202,7 +222,7 @@ export function readProfileInfo(): ProfileInfo | undefined {
   // from the file (stale CZ_PROFILE, deleted profile) must render nothing rather
   // than silently swap in a different tenant's identity — this panel's whole job
   // is telling the user which lakehouse they're pointed at.
-  const name = current === undefined ? Object.keys(profiles)[0] : profiles[current] ? current : undefined
+  const name = panelProfileName(current, profiles)
   if (!name) return undefined
   const profile = profiles[name]!
   const str = (value: unknown) => (typeof value === "string" && value.trim() ? value.trim() : undefined)
@@ -242,9 +262,10 @@ export function clearUserNameCacheForTest(): void {
  * covered by `accountName` elsewhere. Nothing else from this payload is used — it
  * also carries a phone number and an email, which have no place in a status panel.
  *
- * The one call site both `fetchProfileUserName` and `fetchProfileSnapshot` share,
- * so the envelope check (four-part: record / isPortalOk / record data / string
- * name) is written once rather than kept in sync by hand in two places.
+ * `fetchProfileUserName`'s only caller now — fetchProfileSnapshot stopped needing a user
+ * name when the token half moved to response headers. The four-part envelope check (record /
+ * isPortalOk / record data / string name) stays here rather than inline because that shape
+ * is the portal's, not this function's, and it was written once for two callers.
  */
 async function readCurrentUserName(
   baseUrl: string,
@@ -566,9 +587,10 @@ async function portalRead(
  * transport/auth failure so the caller can keep showing the previous value rather
  * than replacing a good reading with an error.
  *
- * Token handling goes through the SDK's `getToken`, which owns cache/expiry/
- * refresh/persist. Reading `access_token` out of profiles.toml directly would
- * work for at most an hour (60-minute OAuth TTL) and then start 401-ing.
+ * The credential comes from `profileTokenSource(config).get()`, the one seam that owns
+ * cache/expiry/refresh/persist — reading `access_token` out of profiles.toml directly
+ * would bypass all four — good for at most an hour (the 60-minute OAuth TTL) and 401 after
+ * that (fetchProfileUserName's note says the same).
  */
 export async function fetchQuotaSnapshot(
   input: {
@@ -591,7 +613,7 @@ export async function fetchQuotaSnapshot(
   // version of this function got that right by a different route (it gated the
   // billing read on `name === current` in two places); collapsing the profile walk
   // dropped both gates, so it is spelled out here.
-  const name = current === undefined ? Object.keys(profiles)[0] : profiles[current] ? current : undefined
+  const name = panelProfileName(current, profiles)
   if (!name) return {}
 
   return fetchProfileSnapshot({ name, profile: profiles[name]!, signal: input.signal })

--- a/packages/cz-cli/src/opencode-plugin/tui-quota-data.ts
+++ b/packages/cz-cli/src/opencode-plugin/tui-quota-data.ts
@@ -1,14 +1,22 @@
 // cz_change: data source for the TUI quota indicator (see tui-quota.tsx).
 //
-// Two portal endpoints, both authenticated with the profile's portal token:
-//   - cash balance: /clickzetta-portal/hornhub/account/billing/account/{accountId}
-//   - token quota:  /clickzetta-portal/user/listApiKeys?userName=<name>
+// Two halves, from two places, on two cadences:
 //
-// The quota half MUST come from the portal route, not the gateway-admin route
-// (/llm-gateway-admin/v2/virtual-key/listWithAuth) that `cz-cli ai-gateway key
-// list` uses: the complimentary `cz-code_auto_*` key — the one a fresh login
-// actually writes into llm.json — is absent from the admin listing but present
-// here. Querying the admin route would report "no key" for most users.
+//   - cash balance, from the portal:
+//     /clickzetta-portal/hornhub/account/billing/account/{accountId}, authenticated
+//     with the current profile's portal token. Money moves slowly, so this is read
+//     on the busy -> idle edge of a turn.
+//   - token quota, from the AI gateway's own response headers, cached by the
+//     provider into ~/.clickzetta/gateway-quota.json (see quota-store.ts in
+//     @clickzetta/ai-gateway). Read synchronously, once per LLM request.
+//
+// The quota half used to be a second portal call, /clickzetta-portal/user/listApiKeys.
+// It was retired because the header source is strictly better for this display: it
+// needs no portal token and no ownership of the key, it reports EVERY configured
+// period rather than one, and it is current as of the request that just finished
+// instead of whenever the last poll landed. The one thing it cannot do is answer for
+// a gateway that does not send the headers (cn-shanghai-alicloud, as of 2026-09-01),
+// where the token rows are simply absent and the balance row still paints.
 //
 // Lives in a plain .ts module (no JSX, no @opentui, no solid-js) for two reasons:
 // it stays unit-testable under `bun test`, and it can be pre-bundled into a
@@ -23,10 +31,16 @@ import { resolveConnectionConfig } from "../connection/config.js"
 import * as Profile from "../connection/profile-context.js"
 import { deriveAuthType, explicitAuthType, loadProfiles } from "../connection/profile-store.js"
 import { readLlmEntries } from "../llm/native-config.js"
+// Re-exported, not redefined: tui-quota-runtime.ts publishes these to the .tsx renderer,
+// and commands/ai-gateway.ts needs the same answer — see llm/clickzetta-entry.ts.
+import { classifyClickzettaEntry, resolveClickzettaEntry } from "../llm/clickzetta-entry.js"
+export { classifyClickzettaEntry, resolveClickzettaEntry } from "../llm/clickzetta-entry.js"
+export type { ClickzettaEntryResolution } from "../llm/clickzetta-entry.js"
+import { readGatewayQuota, type ClickzettaQuota, type ClickzettaQuotaPeriod } from "../llm/gateway-error.js"
+import { CLICKZETTA_DEFAULT_GATEWAY_URL, normalizeClickzettaGatewayUrl } from "../llm/clickzetta-provider.js"
 import { profileTokenSource } from "../connection/token-source.js"
 
 const BILLING_PATH = "/clickzetta-portal/hornhub/account/billing/account"
-const API_KEYS_PATH = "/clickzetta-portal/user/listApiKeys"
 const CURRENT_USER_PATH = "/clickzetta-portal/user/getCurrentUser"
 
 /**
@@ -80,29 +94,19 @@ export function readRecentProviders(statePath: string): Array<{ providerID?: unk
   }
 }
 
-/** Quota window a virtual key is rate-limited on. */
-export type QuotaPeriod = "daily" | "weekly" | "monthly" | "total"
-
-const RATE_LIMIT_PERIOD: Record<string, QuotaPeriod> = {
-  quota_pdo: "daily",
-  quota_pwo: "weekly",
-  quota_pmo: "monthly",
-  quota_total: "total",
-}
+/** Quota window a virtual key is rate-limited on. The gateway's own vocabulary. */
+export type QuotaPeriod = ClickzettaQuotaPeriod
 
 export interface QuotaSnapshot {
   /** Account cash balance, in CNY. */
   cash?: number
   /** Outstanding amount owed, in CNY. Non-zero means requests are at risk. */
   owe?: number
-  /** Tokens consumed on the active virtual key within its quota window. */
-  used?: number
-  /** Token ceiling for that window. */
-  limit?: number
-  /** Which window `used`/`limit` describe. */
-  period?: QuotaPeriod
-  /** Alias of the matched virtual key, for diagnostics. */
-  alias?: string
+  /**
+   * Token allowance per configured period, newest reading from the gateway's
+   * response headers. A key with both a lifetime and a daily cap reports both.
+   */
+  quotas?: ClickzettaQuota[]
 }
 
 /**
@@ -313,132 +317,81 @@ export function isPortalOk(code: unknown): boolean {
   return code === 0 || code === "0" || code === 200 || code === "200"
 }
 
-/**
- * Mask an API key the way the portal reports it: first four and last four
- * characters around a literal `****`. Keys are 32 chars, so this is stable —
- * and it means we never send or log the plaintext key to match on.
- */
-export function maskApiKey(apiKey: string): string | undefined {
-  if (apiKey.length < 8) return undefined
-  return `${apiKey.slice(0, 4)}****${apiKey.slice(-4)}`
-}
 
 /**
- * Pick the virtual key matching `apiKey` out of a listApiKeys payload and
- * project the fields the indicator needs.
+ * The token quota the gateway last reported for the selected entry's key.
  *
- * Exported for tests: the shape here (`vapiKeyMasked` / `rateLimitValue` /
- * `usage`, lowercase-a spelling) is the portal's, and differs from the
- * gateway-admin route's `vApiKeyMasked`, so both spellings are accepted.
+ * Synchronous and local — no network, no portal token — so the caller can run it on
+ * every `step-finish` part, i.e. once per LLM request, which is the whole point of
+ * sourcing this from headers instead of a poll.
+ *
+ * `undefined` covers every "nothing to show" case alike: a foreign provider, a
+ * ClickZetta entry with no key or no base_url, a gateway that sends no quota headers,
+ * and a reading left over from an earlier session. Callers keep whatever they had.
  */
-export function matchKeyUsage(
-  payload: unknown,
-  apiKey: string,
-): Pick<QuotaSnapshot, "used" | "limit" | "period" | "alias"> {
-  const masked = maskApiKey(apiKey)
-  if (!masked || !isRecord(payload) || !Array.isArray(payload.data)) return {}
-  const hit = payload.data.filter(isRecord).find((key) => (key.vapiKeyMasked ?? key.vApiKeyMasked) === masked)
-  if (!hit) return {}
-  const rateLimitType = typeof hit.rateLimitType === "string" ? hit.rateLimitType : undefined
-  const alias = hit.vapiKeyAlias ?? hit.vApiKeyAlias
-  return {
-    used: num(hit.usage),
-    limit: num(hit.rateLimitValue),
-    period: rateLimitType ? RATE_LIMIT_PERIOD[rateLimitType] : undefined,
-    alias: typeof alias === "string" ? alias : undefined,
-  }
-}
-
-/**
- * Resolve which ClickZetta LLM entry the indicator should report on.
- *
- * LLM entries and connection Profiles are independent configuration domains.
- * This resolver only selects the LLM/API key; fetchQuotaSnapshot separately uses
- * Profiles as Portal credentials and never treats the entry name as a Profile.
- *
- * Candidates, most to least specific:
- *   1. `providerID` — what the TUI currently has selected, when known.
- *   2. `config.model`'s provider prefix — set by `cz-cli agent llm use`. Often
- *      absent: with no pinned model the TUI auto-selects, so this cannot be the
- *      only source or the indicator stays blank for everyone who never ran `use`.
- *   3. The sole ClickZetta entry, if there is exactly one. Unambiguous by
- *      definition; skipped when several exist rather than guessing a tenant.
- *
- * Returns undefined when nothing resolves to a ClickZetta entry (the user is on
- * anthropic/openai/…), which is the signal to render nothing at all.
- */
-export function resolveClickzettaEntry(providerID?: string): { name: string; apiKey: string } | undefined {
+export function readHeaderQuota(providerID?: string, now = Date.now()): ClickzettaQuota[] | undefined {
   const resolved = classifyClickzettaEntry(providerID)
-  return resolved.kind === "clickzetta" ? { name: resolved.name, apiKey: resolved.apiKey } : undefined
+  if (resolved.kind !== "clickzetta") return undefined
+  // The SAME default the writer applies. providerFromInput (native-config.ts) fills an
+  // absent baseURL with CLICKZETTA_DEFAULT_GATEWAY_URL, so a hand-written llm.json entry
+  // with no base_url still chats — and the provider still files a real reading, under the
+  // default endpoint's key. Bailing out here on a missing base_url meant the sidebar could
+  // never find that reading and the token rows stayed blank with nothing to explain why.
+  const baseUrl = resolved.baseUrl ?? CLICKZETTA_DEFAULT_GATEWAY_URL
+  // Freshness is decided here, in full: the store hands back whatever it has plus the
+  // timestamp, and one `now` governs both rules below, which also lets a test pin it.
+  const entry = readGatewayQuota({
+    baseURL: normalizeClickzettaGatewayUrl(baseUrl),
+    apiKey: resolved.apiKey,
+  })
+  if (!entry || now - entry.updated_at > HEADER_QUOTA_MAX_AGE_MS) return undefined
+  const fresh = entry.quotas.filter((quota) => !periodResetSince(quota.period, entry.updated_at, now))
+  return fresh.length > 0 ? fresh : undefined
 }
 
 /**
- * Why this is a three-way answer and not `entry | undefined`.
+ * Has this period's counter reset since the reading was taken?
  *
- * Cash balance belongs to the connection Profile; token quota belongs to the LLM
- * key. Collapsing "not a ClickZetta key" with "user is on another provider" into
- * one `undefined` made fetchQuotaSnapshot bail before it read profiles at all, so
- * ANY failure to pin an LLM entry also silently removed the cash balance — a
- * reading that never depended on the LLM entry in the first place.
+ * Only `daily` can be answered. A fixed duration cannot express this — ANY window
+ * shorter than a day still straddles a reset, so a 23:00 reading shown at 04:00 would
+ * report yesterday's near-exhausted spend against today's fresh limit. That is the
+ * worst direction to be wrong in: it tells a user with a full day's allowance that they
+ * are out.
  *
- *   - `clickzetta` — a specific ClickZetta key. Report balance and quota.
- *   - `foreign`    — the session is demonstrably on a non-ClickZetta provider
- *                    (anthropic/openai/…), or there is no ClickZetta entry at all.
- *                    Report nothing; a ¥ figure next to a Claude model would name
- *                    money that model is not spending. This is the case the
- *                    original `undefined` was meant for.
- *   - `ambiguous`  — this IS a ClickZetta user, but which key is in play cannot be
- *                    pinned (several entries, none selected or pinned; or the
- *                    matched entry carries no api_key). Report the balance, skip
- *                    the quota — guessing a tenant's key would misreport usage.
+ * The gateway does not say which zone its day rolls over in, so both are treated as
+ * boundaries: a different calendar date in EITHER local or UTC time counts as reset.
+ * Deliberately conservative — dropping a still-valid reading costs one blank paint
+ * until the next request refreshes it, while keeping a reset one misinforms.
+ *
+ * `weekly`/`monthly` are left to the duration bound: their boundaries are the gateway's
+ * own (and a week's start is a convention), so a guess here could discard good readings
+ * for days. `total` never resets.
  */
-export type ClickzettaEntryResolution =
-  | { kind: "clickzetta"; name: string; apiKey: string }
-  | { kind: "foreign" }
-  | { kind: "ambiguous" }
-
-export function classifyClickzettaEntry(providerID?: string): ClickzettaEntryResolution {
-  const { llm, model } = readLlmEntries()
-  const isClickzetta = (name: string | undefined) => (name ? llm[name]?.provider === "clickzetta" : false)
-  const usable = (name: string | undefined): ClickzettaEntryResolution | undefined => {
-    if (!name) return undefined
-    const entry = llm[name]
-    if (entry?.provider !== "clickzetta") return undefined
-    // A ClickZetta entry with no key is still a ClickZetta user — quota is
-    // unknowable, the balance is not.
-    if (!entry.api_key) return { kind: "ambiguous" }
-    return { kind: "clickzetta", name, apiKey: entry.api_key }
-  }
-
-  const selected = usable(providerID)
-  if (selected) return selected
-
-  // An explicit selection that is not a ClickZetta entry ends the search: the
-  // provider may come from environment/plugin discovery and need not appear in
-  // llm.json, and falling through would report the sole ClickZetta key while the
-  // prompt visibly names a different provider.
-  if (providerID) return { kind: "foreign" }
-
-  const configured = typeof model === "string" && model.includes("/") ? model.slice(0, model.indexOf("/")) : undefined
-  const inferred = usable(configured)
-  if (inferred) return inferred
-
-  const clickzetta = Object.entries(llm).filter(([, entry]) => entry.provider === "clickzetta" && entry.api_key)
-  if (clickzetta.length === 1) {
-    const [name, entry] = clickzetta[0]!
-    return { kind: "clickzetta", name, apiKey: entry.api_key! }
-  }
-  // Several ClickZetta entries and nothing to choose between them is ambiguous,
-  // not foreign — as is a pinned model naming a ClickZetta entry we could not use.
-  if (clickzetta.length > 1 || isClickzetta(configured)) return { kind: "ambiguous" }
-  return { kind: "foreign" }
+function periodResetSince(period: QuotaPeriod | undefined, readAt: number, now: number): boolean {
+  if (period !== "daily") return false
+  const then = new Date(readAt)
+  const current = new Date(now)
+  return (
+    then.toDateString() !== current.toDateString() ||
+    then.toISOString().slice(0, 10) !== current.toISOString().slice(0, 10)
+  )
 }
+
+/**
+ * Upper bound on how old a cached reading may be, whatever its period.
+ *
+ * Long enough that a session sitting idle keeps showing the figure from its last
+ * request. It does NOT by itself keep yesterday's daily figure off today's screen —
+ * no fixed duration can, since any window under a day still straddles a reset. That
+ * job belongs to periodResetSince above; this is only the coarse ceiling.
+ */
+const HEADER_QUOTA_MAX_AGE_MS = 6 * 60 * 60 * 1000
 
 // The portal is method-sensitive per endpoint, and gets them backwards from what
 // the URLs suggest: `getCurrentUser` only answers to POST (GET returns error
-// code 8888), while `listApiKeys` and the billing account route only answer to
-// GET (POST returns 8888). Callers pass the method each endpoint actually wants;
-// the default stays GET so the two read routes need no change.
+// code 8888), while the billing account route only answers to GET (POST returns
+// 8888). Callers pass the method each endpoint actually wants; the default stays
+// GET so the billing read needs no change.
 async function portalCall(
   baseUrl: string,
   path: string,
@@ -508,10 +461,10 @@ export function centralPortalHost(baseUrl: string): string | undefined {
  * busy→idle edge — once per agent turn — so without this a session on such a
  * profile pays double the portal requests for as long as it runs, not once
  * while the fallback is discovered. Keyed per-route rather than per-host
- * because the three routes this module reads (billing, listApiKeys,
- * getCurrentUser) are independent endpoints — a region host observed to fail
- * one is not proof it fails the other two, and a coarser host-wide key would
- * stop asking a route that host actually serves.
+ * because the two routes this module reads (billing, getCurrentUser) are
+ * independent endpoints — a region host observed to fail one is not proof it
+ * fails the other, and a coarser host-wide key would stop asking a route that
+ * host actually serves.
  *
  * Promotion requires TWO CONSECUTIVE proven business-code failures on that
  * route, never a bare transport/auth error. One such response is not enough:
@@ -598,16 +551,20 @@ async function portalRead(
 }
 
 /**
- * Fetch balance + quota for the given provider selection without coupling the
- * selected LLM entry to a same-named connection Profile.
+ * Fetch the account cash balance for the current connection Profile.
  *
- * Cash belongs to the current CLI Profile. Token quota belongs to the selected
- * LLM/API key; Profiles are only credentials for querying Portal, so all locally
- * available Profiles may be checked until the key is found.
+ * Only the balance: token quota comes from readHeaderQuota, off the gateway's own
+ * response headers. That split removed a whole mechanism from this function — it
+ * used to walk every locally configured Profile hunting the one whose portal knew
+ * the selected virtual key, because an LLM entry and a Profile are independent
+ * configuration domains and only some Profile's portal could answer for the key.
+ * The headers answer for the key directly, so the balance needs exactly one
+ * Profile: the current one, which is whose money it is.
  *
- * Returns undefined when the selection is not a ClickZetta entry. Throws on
- * transport/auth failure so the caller can keep showing the previous value
- * rather than replacing a good reading with an error.
+ * Returns undefined when the selection is a demonstrably foreign provider, so the
+ * whole indicator stays out of a non-ClickZetta user's sidebar. Throws on
+ * transport/auth failure so the caller can keep showing the previous value rather
+ * than replacing a good reading with an error.
  *
  * Token handling goes through the SDK's `getToken`, which owns cache/expiry/
  * refresh/persist. Reading `access_token` out of profiles.toml directly would
@@ -620,63 +577,31 @@ export async function fetchQuotaSnapshot(
   } = {},
 ): Promise<QuotaSnapshot | undefined> {
   // cz_change: only a demonstrably foreign provider suppresses the whole
-  // indicator. "Could not pin a ClickZetta key" used to take this same exit,
-  // which silently removed the cash balance too — see classifyClickzettaEntry.
-  const resolved = classifyClickzettaEntry(input.providerID)
-  if (resolved.kind === "foreign") return undefined
-  const entry = resolved.kind === "clickzetta" ? resolved : undefined
+  // indicator. "Could not pin a ClickZetta key" must not take this exit — that
+  // would silently remove the cash balance too, which does not depend on the key.
+  if (classifyClickzettaEntry(input.providerID).kind === "foreign") return undefined
 
   const profiles = loadProfiles()
   const current = Profile.current()
-  const ordered =
-    current && profiles[current]
-      ? [current, ...Object.keys(profiles).filter((name) => name !== current)]
-      : Object.keys(profiles)
-  // Scanning past the current profile only ever serves the quota read (hunting the
-  // profile whose portal knows this key). With no key there is nothing to hunt, and
-  // continuing would be actively harmful: a later profile returns an empty-but-
-  // successful snapshot, which lands in `loaded` and swallows the current profile's
-  // real error — turning "the balance read failed" into a silent blank that the
-  // caller cannot distinguish from "nothing to show".
-  const names = entry ? ordered : ordered.slice(0, 1)
-  if (names.length === 0) return {}
+  // Same policy as readProfileInfo, and for the same reason: substitute the first
+  // TOML profile ONLY when nothing is pinned (genuinely unconfigured). A `current`
+  // that names a profile absent from the file — stale CZ_PROFILE, or a
+  // default_profile pointing at a deleted profile — must report no balance rather
+  // than silently bill a DIFFERENT tenant's account to the user. The pre-header
+  // version of this function got that right by a different route (it gated the
+  // billing read on `name === current` in two places); collapsing the profile walk
+  // dropped both gates, so it is spelled out here.
+  const name = current === undefined ? Object.keys(profiles)[0] : profiles[current] ? current : undefined
+  if (!name) return {}
 
-  const loaded: Array<{ name: string; billing: Pick<QuotaSnapshot, "cash" | "owe">; usage: Pick<QuotaSnapshot, "used" | "limit" | "period" | "alias"> }> = []
-  const errors: unknown[] = []
-  for (const name of names) {
-    try {
-      const snapshot = await fetchProfileSnapshot({
-        name,
-        profile: profiles[name]!,
-        // No pinned key: skip the quota read entirely rather than scan profiles
-        // for a key we cannot name. The balance below still resolves.
-        apiKey: entry?.apiKey,
-        includeBilling: name === current,
-        signal: input.signal,
-      })
-      loaded.push({ name, ...snapshot })
-      if (Object.keys(snapshot.usage).length > 0) break
-    } catch (error) {
-      if (input.signal?.aborted) throw error
-      errors.push(error)
-    }
-  }
-  if (loaded.length === 0) throw errors[0]
-
-  return {
-    ...(loaded.find((item) => item.name === current)?.billing ?? {}),
-    ...(loaded.map((item) => item.usage).find((usage) => Object.keys(usage).length > 0) ?? {}),
-  }
+  return fetchProfileSnapshot({ name, profile: profiles[name]!, signal: input.signal })
 }
 
 async function fetchProfileSnapshot(input: {
   name: string
   profile: Record<string, unknown>
-  /** Undefined when no ClickZetta key could be pinned — billing still applies. */
-  apiKey?: string
-  includeBilling: boolean
   signal?: AbortSignal
-}) {
+}): Promise<QuotaSnapshot> {
   const config = resolveConnectionConfig({
     profile: input.name,
     ...(typeof input.profile.service === "string" ? { service: input.profile.service } : {}),
@@ -685,53 +610,24 @@ async function fetchProfileSnapshot(input: {
       : {}),
     ...(typeof input.profile.instance === "string" ? { instance: input.profile.instance } : {}),
   })
-  const credential = await profileTokenSource(config).get()
-  const baseUrl = toServiceUrl(config.service, config.protocol)
   const accountId = num(input.profile.account_id)
-  const profileUserName = typeof input.profile.username === "string" ? input.profile.username.trim() : ""
-  const [billing, keys] = await Promise.allSettled([
-    !input.includeBilling
-      ? Promise.resolve(undefined)
-      : accountId === undefined
-        ? Promise.reject(new Error("profile has no account_id"))
-        : portalRead(baseUrl, `${BILLING_PATH}/${accountId}`, credential.token, { signal: input.signal }),
-    (async () => {
-      // No key to match against — skip the read rather than spend two portal
-      // round-trips on a result nothing can consume.
-      if (!input.apiKey) return undefined
-      // getCurrentUser is a POST route (see portalCall). Resolving the user name
-      // lets us pass it through, but listApiKeys ignores the userName value and
-      // scopes to the token identity regardless, so a failed/empty lookup still
-      // returns the caller's keys — fall back to an empty name rather than bail.
-      const userName = profileUserName || (await readCurrentUserName(baseUrl, credential.token, input.signal)) || ""
-      return portalRead(baseUrl, `${API_KEYS_PATH}?userName=${encodeURIComponent(userName)}`, credential.token, {
-        signal: input.signal,
-      })
-    })(),
-  ])
-  // Surface a failure only when nothing usable came back. With no api_key the
-  // quota half resolves to undefined rather than rejecting, so this reduces to
-  // "the billing read failed", which the caller reports by keeping the last value.
-  if (keys.status === "rejected" && (!input.includeBilling || billing.status === "rejected")) throw keys.reason
-  if (!input.apiKey && input.includeBilling && billing.status === "rejected") throw billing.reason
-
-  const billingData =
-    billing.status === "fulfilled" &&
-    isRecord(billing.value) &&
-    isPortalOk(billing.value.code) &&
-    isRecord(billing.value.data)
-      ? billing.value.data
-      : undefined
-  const cash = num(billingData?.cashAmount)
-  const owe = num(billingData?.oweAmount)
+  // No account_id means the profile cannot name whose balance to read. Report
+  // nothing rather than throwing: the caller treats a rejection as "keep the last
+  // good value", which for a profile that can never answer would pin a stale
+  // balance from a different account forever.
+  if (accountId === undefined) return {}
+  const credential = await profileTokenSource(config).get()
+  const payload = await portalRead(
+    toServiceUrl(config.service, config.protocol),
+    `${BILLING_PATH}/${accountId}`,
+    credential.token,
+    { signal: input.signal },
+  )
+  const data = isRecord(payload) && isPortalOk(payload.code) && isRecord(payload.data) ? payload.data : undefined
+  const cash = num(data?.cashAmount)
+  const owe = num(data?.oweAmount)
   return {
-    billing: {
-      ...(cash !== undefined ? { cash } : {}),
-      ...(owe !== undefined ? { owe } : {}),
-    },
-    usage:
-      input.apiKey && keys.status === "fulfilled" && isRecord(keys.value) && isPortalOk(keys.value.code)
-        ? matchKeyUsage(keys.value, input.apiKey)
-        : {},
+    ...(cash !== undefined ? { cash } : {}),
+    ...(owe !== undefined ? { owe } : {}),
   }
 }

--- a/packages/cz-cli/src/opencode-plugin/tui-quota-format.ts
+++ b/packages/cz-cli/src/opencode-plugin/tui-quota-format.ts
@@ -15,6 +15,9 @@ export type QuotaTone = "text" | "textMuted" | "success" | "warning" | "error"
 export function abbreviate(value: number): string {
   if (!Number.isFinite(value)) return "?"
   const abs = Math.abs(value)
+  // A lifetime (PTO) ceiling is routinely 1e9+, and without this tier it renders as
+  // `1000.0M` — six characters of noise in a 42-column sidebar.
+  if (abs >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`
   if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
   if (abs >= 1_000) return `${(value / 1_000).toFixed(1)}K`
   return String(Math.round(value))
@@ -93,23 +96,53 @@ export interface QuotaRow {
  */
 export function quotaRows(snapshot: QuotaSnapshot | undefined): QuotaRow[] {
   if (!snapshot) return []
-  const rows: QuotaRow[] = []
+  const cash =
+    snapshot.cash === undefined
+      ? []
+      : [{ text: `${formatCash(snapshot.cash)} balance`, tone: cashTone(snapshot.cash, snapshot.owe ?? 0) }]
 
-  if (snapshot.cash !== undefined) {
-    rows.push({ text: `${formatCash(snapshot.cash)} balance`, tone: cashTone(snapshot.cash, snapshot.owe ?? 0) })
-  }
+  // A key can cap several periods at once (a lifetime grant plus a daily rate, say),
+  // and the binding one is whichever runs out first — so each gets its own pair of
+  // rows rather than picking one to show. Shortest period first, because that is the
+  // one a user is most likely to hit inside this session.
+  // Both numbers required, deliberately narrower than formatClickzettaQuota's one-line
+  // CLI form, which will report a spend with no ceiling or a ceiling with no spend. The
+  // sidebar's two rows are a ratio and a percentage; with either half missing there is
+  // no ratio to draw, and a lone figure in this column would read as one.
+  const usable = [...(snapshot.quotas ?? [])].filter(
+    (quota) => quota.used !== undefined && quota.limit !== undefined && quota.limit > 0,
+  )
+  // parseClickzettaQuota captures whatever limiter the header named, not just `api-key`,
+  // so a deployment reporting a tenant-wide cap alongside the key's own would produce two
+  // identical-looking pairs in an order set by header arrival — a duplicated figure with
+  // no way to tell which ceiling binds. Name the scope only when there is more than one,
+  // so the common single-scope case stays clean.
+  const scopes = new Set(usable.map((quota) => quota.scope))
+  const label = (quota: (typeof usable)[number]) =>
+    `${periodSuffix(quota.period)}${scopes.size > 1 ? ` (${quota.scope})` : ""}`
 
-  const { used, limit } = snapshot
-  if (used !== undefined && limit !== undefined && limit > 0) {
-    const tone = quotaTone(remainingRatio(used, limit))
-    // Both numbers, not just a percentage: seeing the ceiling is what tells you
-    // whether the percentage is worth acting on.
-    rows.push({ text: `${abbreviate(used)} / ${abbreviate(limit)} tokens${periodSuffix(snapshot.period)}`, tone })
-    rows.push({ text: `${formatPercentLeft(remainingRatio(used, limit))} left`, tone })
-  }
+  const quotas = usable
+    // Sort by scope too, so the pairs group stably instead of following header order.
+    .sort(
+      (a, b) =>
+        PERIOD_ORDER.indexOf(a.period) - PERIOD_ORDER.indexOf(b.period) || a.scope.localeCompare(b.scope),
+    )
+    .flatMap((quota) => {
+      const ratio = remainingRatio(quota.used!, quota.limit!)
+      const tone = quotaTone(ratio)
+      // Both numbers, not just a percentage: seeing the ceiling is what tells you
+      // whether the percentage is worth acting on.
+      return [
+        { text: `${abbreviate(quota.used!)} / ${abbreviate(quota.limit!)} tokens${label(quota)}`, tone },
+        { text: `${formatPercentLeft(ratio)} left${label(quota)}`, tone },
+      ]
+    })
 
-  return rows
+  return [...cash, ...quotas]
 }
+
+/** Shortest window first; an unknown period code sorts last rather than ahead of everything. */
+const PERIOD_ORDER: Array<QuotaPeriod | undefined> = ["daily", "weekly", "monthly", "total", undefined]
 
 /**
  * Percentage still available, floored so a nearly-spent quota never rounds up to a

--- a/packages/cz-cli/src/opencode-plugin/tui-quota-runtime.ts
+++ b/packages/cz-cli/src/opencode-plugin/tui-quota-runtime.ts
@@ -12,9 +12,8 @@
 export {
   fetchQuotaSnapshot,
   isPortalOk,
-  maskApiKey,
   fetchProfileUserName,
-  matchKeyUsage,
+  readHeaderQuota,
   readProfileInfo,
   readRecentProviders,
   resolveClickzettaEntry,
@@ -23,6 +22,11 @@ export {
   type QuotaPeriod,
   type QuotaSnapshot,
 } from "./tui-quota-data.js"
+
+// Re-exported through this bundle rather than imported from @clickzetta/ai-gateway by
+// the renderer: tui-quota.tsx ships as raw .tsx next to the bundle and can only
+// resolve `./tui-quota-runtime.js`.
+export type { ClickzettaQuota } from "../llm/gateway-error.js"
 
 export {
   abbreviate,

--- a/packages/cz-cli/src/opencode-plugin/tui-quota.tsx
+++ b/packages/cz-cli/src/opencode-plugin/tui-quota.tsx
@@ -35,8 +35,10 @@ import {
   fetchQuotaSnapshot,
   profileRows,
   quotaRows,
+  readHeaderQuota,
   readProfileInfo,
   type ActiveModelContext,
+  type ClickzettaQuota,
   type QuotaRow,
   type QuotaSnapshot,
 } from "./tui-quota-runtime.js"
@@ -119,6 +121,25 @@ function View(props: {
 
 export function installQuotaIndicator(api: TuiPluginApi, activeModel: ActiveModelContext) {
   const [snapshot, setSnapshot] = createSignal<QuotaSnapshot | undefined>(undefined)
+  // Token quota is tracked apart from the balance because the two arrive on
+  // different cadences: the balance costs a portal round-trip and is read on the
+  // busy→idle edge, while this is a local file read the gateway refreshes on every
+  // response, so it updates once per LLM request. Merged for display below.
+  const [headerQuota, setHeaderQuota] = createSignal<ClickzettaQuota[] | undefined>(undefined)
+  // Two readers, because "nothing cached" means different things at different moments.
+  // Per REQUEST (step-finish) it usually means this gateway sends no quota headers, so
+  // blanking a live figure would be wrong — keep the last reading.
+  const refreshHeaderQuota = () => {
+    const quotas = readHeaderQuota(activeModel.providerID())
+    if (quotas) setHeaderQuota(quotas)
+  }
+  // Per CONTEXT (mount, session switch, provider switch — all of which route through
+  // onContext -> controller.refresh -> load) it means the figure on screen belongs to a
+  // credential that is no longer the active one, so it must go. Without this the sticky
+  // reader alone would carry a ClickZetta reading into a session running a foreign
+  // provider, where the balance is undefined and the merge below would still paint the
+  // stale token rows.
+  const syncHeaderQuota = () => setHeaderQuota(readHeaderQuota(activeModel.providerID()))
   const [userName, setUserName] = createSignal<{ profile: string; name: string } | undefined>(undefined)
   // Deferred until the sidebar section first mounts, not fired at install: a
   // portal round-trip (token acquisition included) here would run on every TUI
@@ -185,6 +206,10 @@ export function installQuotaIndicator(api: TuiPluginApi, activeModel: ActiveMode
     // fetchQuotaSnapshot already pays for the network call.
     load: () => {
       setProfileInfoSignal(readProfileInfo())
+      // Paint whatever the last request already cached, so a fresh mount is not
+      // blank until the next LLM call — and drop it when the now-active credential
+      // has nothing cached.
+      syncHeaderQuota()
       return fetchQuotaSnapshot({
         providerID: activeModel.providerID(),
         signal: api.lifecycle.signal,
@@ -197,11 +222,23 @@ export function installQuotaIndicator(api: TuiPluginApi, activeModel: ActiveMode
     api.event.on("session.status", (event) => {
       controller.observeStatus(event.properties.sessionID, event.properties.status)
     }),
+    // One step-finish part per LLM request, which is exactly when the gateway has
+    // reported a new quota — and the only response-adjacent signal a TUI plugin can
+    // observe (the plugin API exposes no response hook, and opencode's processor
+    // drops the finish metadata). Reading the cache here is local and synchronous,
+    // so it costs nothing to do per request instead of per turn.
+    api.event.on("message.part.updated", (event) => {
+      if (event.properties.part?.type !== "step-finish") return
+      refreshHeaderQuota()
+    }),
     // Which provider is active is tracked by the shared context (see active-model
     // .ts); this only reacts to it. Quota is charged to the active provider's key,
     // so a change means the reading is for the wrong key until refreshed.
     activeModel.onChange(({ sessionID }) => {
       if (sessionID !== currentSessionID(api)) return
+      // The cache is keyed by endpoint+key, so a provider switch means the figure on
+      // screen belongs to the wrong credential until re-read.
+      setHeaderQuota(undefined)
       controller.refresh()
     }),
   ]
@@ -234,7 +271,12 @@ export function installQuotaIndicator(api: TuiPluginApi, activeModel: ActiveMode
             api={api}
             activeModel={activeModel}
             sessionID={props.session_id}
-            snapshot={snapshot}
+            snapshot={() => {
+              const quotas = headerQuota()
+              const balance = snapshot()
+              if (!quotas) return balance
+              return { ...balance, quotas }
+            }}
             profileInfo={activeProfileInfo}
             userName={userName}
             onContext={onContext}

--- a/packages/cz-cli/src/opencode-plugin/tui-quota.tsx
+++ b/packages/cz-cli/src/opencode-plugin/tui-quota.tsx
@@ -225,8 +225,12 @@ export function installQuotaIndicator(api: TuiPluginApi, activeModel: ActiveMode
     // One step-finish part per LLM request, which is exactly when the gateway has
     // reported a new quota — and the only response-adjacent signal a TUI plugin can
     // observe (the plugin API exposes no response hook, and opencode's processor
-    // drops the finish metadata). Reading the cache here is local and synchronous,
-    // so it costs nothing to do per request instead of per turn.
+    // drops the finish metadata). The read is local and synchronous, but not free: it parses
+    // llm.json to resolve the entry and then gateway-quota.json, so two file reads per LLM
+    // request on the TUI's own thread. Cheap enough for once-per-request, and deliberately
+    // NOT session-scoped like its two siblings above: readHeaderQuota keys on the ACTIVE
+    // provider, so a step-finish from another session costs this read and cannot produce
+    // wrong data. Scoping it would trade that cost for a way to miss a refresh.
     api.event.on("message.part.updated", (event) => {
       if (event.properties.part?.type !== "step-finish") return
       refreshHeaderQuota()

--- a/packages/cz-cli/test/agent-llm-test-gateway-error.test.ts
+++ b/packages/cz-cli/test/agent-llm-test-gateway-error.test.ts
@@ -17,7 +17,7 @@
  * Bun.serve needs in order to accept the child's connection, so the two deadlock:
  * the symptom is a test that hangs to its timeout with the server never once hit.
  */
-import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -30,6 +30,8 @@ let server: ReturnType<typeof Bun.serve>
 let gatewayUrl: string
 /** Set per test; the server replays it as the probe's response. */
 let nextFailure: { status: number; body: unknown }
+/** Set per test; response headers the probe should read the quota off. */
+let nextHeaders: Record<string, string> | undefined
 
 beforeAll(() => {
   home = join(tmpdir(), `cz-llmtest-${Date.now()}-${Math.random().toString(36).slice(2)}`)
@@ -41,7 +43,7 @@ beforeAll(() => {
       if (new URL(request.url).pathname.endsWith("/models")) {
         return Response.json({ object: "list", data: [{ id: "deepseek/deepseek-v4-pro" }] })
       }
-      return Response.json(nextFailure.body, { status: nextFailure.status })
+      return Response.json(nextFailure.body, { status: nextFailure.status, headers: nextHeaders })
     },
   })
   // The probe appends /chat/completions to the configured base, and cz-cli
@@ -85,12 +87,21 @@ async function runLlmTest() {
     .map((line) => line.trim())
     .find((line) => line.startsWith("{"))
   if (!line) throw new Error(`no JSON in CLI output:\n${out}\n${err}`)
+  // An error is reported at the top level; a success is wrapped in `data`.
   return JSON.parse(line) as {
     error?: { code?: string; message?: string; gateway_code?: string; status?: number }
+    data?: {
+      sample_response?: string
+      quotas?: Array<{ period?: string; periodCode?: string; limit?: number; used?: number; remaining?: number; scope?: string }>
+    }
   }
 }
 
 describe("agent llm test — gateway failures", () => {
+  beforeEach(() => {
+    nextHeaders = undefined
+  })
+
   test("an exhausted complimentary key gets the create-your-own-key guidance", async () => {
     // GATEWAY_TOO_MANY_REQUESTS is absent from the documented code table; this body
     // is verbatim from the live gateway, where the alias prefix marks the grant.
@@ -154,5 +165,63 @@ describe("agent llm test — gateway failures", () => {
     expect(json.error?.gateway_code).toBeUndefined()
     expect(json.error?.message).toContain("HTTP 400")
     expect(json.error?.message).toContain("GATEWAY_MODEL_NOT_RESOLVED")
+  })
+})
+
+/**
+ * The same probe that proves a key works also reports how much of it is left: the
+ * gateway puts the allowance on every successful completion's headers, so this costs
+ * no extra request. `quotas` is part of the `--format json` payload, so it is a
+ * contract, not a debug aid — these cases pin its shape.
+ */
+describe("agent llm test — token quota", () => {
+  const COMPLETION = {
+    id: "chatcmpl-1",
+    object: "chat.completion",
+    choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+  }
+
+  test("a successful probe reports the quota the headers carried", async () => {
+    nextFailure = { status: 200, body: COMPLETION }
+    nextHeaders = {
+      "x-czgw-ratelimit-api-key-token-period": "PDO",
+      "x-czgw-ratelimit-api-key-token-limit": "10000000",
+      "x-czgw-ratelimit-api-key-token-used": "238",
+      "x-czgw-ratelimit-api-key-token-remaining": "9999762",
+    }
+
+    const json = await runLlmTest()
+    expect(json.error).toBeUndefined()
+    expect(json.data?.quotas).toEqual([
+      { period: "daily", periodCode: "PDO", limit: 10000000, used: 238, remaining: 9999762, scope: "api-key" },
+    ])
+  })
+
+  test("every configured period is reported, not just the first", async () => {
+    nextFailure = { status: 200, body: COMPLETION }
+    nextHeaders = {
+      "x-czgw-ratelimit-api-key-token-period": "PTO, PDO",
+      "x-czgw-ratelimit-api-key-token-limit": "1000000000, 10000000",
+      "x-czgw-ratelimit-api-key-token-used": "21306417, 238",
+      "x-czgw-ratelimit-api-key-token-remaining": "978693583, 9999762",
+    }
+
+    const json = await runLlmTest()
+    expect(json.data?.quotas?.map((quota) => quota.period)).toEqual(["total", "daily"])
+  })
+
+  /**
+   * A gateway that sends no quota headers is not a failure and not a zero — the probe
+   * still passed, and the key omits the field entirely rather than reporting an empty
+   * allowance. cn-shanghai-alicloud-aimesh behaved this way as of 2026-09-01.
+   */
+  test("a gateway that reports no quota still passes, with the field absent", async () => {
+    nextFailure = { status: 200, body: COMPLETION }
+    nextHeaders = undefined
+
+    const json = await runLlmTest()
+    expect(json.error).toBeUndefined()
+    expect(json.data?.sample_response).toBe("ok")
+    expect(json.data && "quotas" in json.data).toBe(false)
   })
 })

--- a/packages/cz-cli/test/e2e-help-runner.ts
+++ b/packages/cz-cli/test/e2e-help-runner.ts
@@ -28,6 +28,12 @@ export interface HelpCase {
   expectHeader: string
   expectOptions?: string[]
   expectCommands?: string[]
+  /**
+   * Prose the help text must contain — epilogue wording, an example, a warning. Kept
+   * separate from expectCommands so a failure says "missing help text", not "missing
+   * subcommand", and so expectCommands keeps meaning "this is a subcommand".
+   */
+  expectText?: string[]
   forbid?: string[]
   issues?: string
 }
@@ -48,6 +54,12 @@ function check(c: HelpCase): { pass: boolean; detail?: string } {
   for (const cmd of c.expectCommands ?? []) {
     if (!combined.includes(cmd)) {
       return { pass: false, detail: `missing subcommand "${cmd}" in help output` }
+    }
+  }
+
+  for (const text of c.expectText ?? []) {
+    if (!combined.includes(text)) {
+      return { pass: false, detail: `missing help text "${text}" in help output` }
     }
   }
 

--- a/packages/cz-cli/test/e2e-help/agent-gateway-cases.ts
+++ b/packages/cz-cli/test/e2e-help/agent-gateway-cases.ts
@@ -85,7 +85,14 @@ export const agentGatewayHelpCases: HelpCase[] = [
   {
     args: ["ai-gateway", "--help"],
     expectHeader: "cz-cli ai-gateway",
-    expectCommands: ["key", "model"],
+    expectCommands: ["quota", "key", "model"],
+  },
+  {
+    args: ["ai-gateway", "quota", "--help"],
+    expectHeader: "cz-cli ai-gateway quota",
+    expectOptions: ["--model"],
+    // Prose from the epilogue, not a subcommand — `quota` has none.
+    expectText: ["x-czgw-ratelimit-api-key-token-*"],
   },
   {
     args: ["ai-gateway", "key", "--help"],

--- a/packages/cz-cli/test/exec-instance-id.test.ts
+++ b/packages/cz-cli/test/exec-instance-id.test.ts
@@ -1,0 +1,311 @@
+/**
+ * getExecContext resolves the instance id from the CONNECTION, and does it for the profile
+ * the connection actually came from.
+ * Run: bun test test/exec-instance-id.test.ts
+ *
+ * Both cases here are review findings on the commit that moved the id off the shared OAuth
+ * token, and both were reachable:
+ *
+ *  - `Profile.current()` is `CZ_PROFILE ?? default_profile`, but `readProfileEntry(undefined)`
+ *    and `patchProfileInstanceId(undefined, …)` only consult `default_profile`. Passing
+ *    `undefined` therefore read one profile's account_id and cached the answer onto ANOTHER
+ *    profile whenever the two disagreed.
+ *  - the `token.instanceId` fallback is unreachable for an OAuth profile, because the same
+ *    commit stopped storing an id in `[oauth.<id>]`. An unresolvable id would have become 0
+ *    — a job submitted against instance zero — instead of a stated failure.
+ *
+ * Network boundary only: stubStudioContext answers the login/getCurrentUser calls
+ * getExecContext makes on the way, and each case overrides serviceInstanceList.
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { onFetch, onStudio, requireTestHome, studioOk, stubStudioContext } from "./support/cz-fixtures"
+
+const { getExecContext, execInstanceId } = await import("../src/commands/exec.ts")
+
+const previousProfile = process.env.CZ_PROFILE
+
+const profilesPath = () => join(requireTestHome(), ".clickzetta", "profiles.toml")
+
+/** Two profiles with different accounts and instances; default_profile is NOT the CZ_PROFILE one. */
+function writeTwoProfiles() {
+  writeFileSync(
+    profilesPath(),
+    [
+      'default_profile = "other"',
+      "",
+      "[profiles.other]",
+      'pat = "pat-other"',
+      'service = "uat-api.clickzetta.com"',
+      'instance = "other-inst"',
+      'workspace = "w"',
+      "account_id = 999",
+      "",
+      "[profiles.wanted]",
+      'pat = "pat-wanted"',
+      'service = "uat-api.clickzetta.com"',
+      'instance = "wanted-inst"',
+      'workspace = "w"',
+      "account_id = 124213",
+      "",
+    ].join("\n"),
+    "utf-8",
+  )
+}
+
+function writeOneProfile(extra: string[]) {
+  writeFileSync(
+    profilesPath(),
+    ['default_profile = "solo"', "", "[profiles.solo]", 'pat = "p"',
+     'service = "uat-api.clickzetta.com"', 'instance = "i"', 'workspace = "w"', ...extra, ""].join("\n"),
+    "utf-8",
+  )
+}
+
+beforeEach(() => {
+  delete process.env.CZ_PROFILE
+  delete process.env.CZ_INSTANCE
+})
+
+/**
+ * The fetch boundary answers with the FIRST matching handler, and stubStudioContext
+ * registers its own serviceInstanceList — so a case that needs a different instance list
+ * must register before it, not after.
+ */
+function stubInstances(rows: Array<Record<string, unknown>>) {
+  onStudio("/clickzetta-portal/service/serviceInstanceList", () => studioOk(rows))
+  stubStudioContext()
+}
+
+/** A profile whose credential carries NO instance id — which every OAuth login now is. */
+function writeOAuthProfile(extra: string[]) {
+  writeFileSync(
+    profilesPath(),
+    [
+      'default_profile = "sess_0"', "",
+      "[oauth.sess]",
+      'access_token = "at"',
+      'refresh_token = "rt"',
+      "expire_time_ms = 3600000",
+      `obtained_at = ${Date.now()}`,
+      "user_id = 7",
+      "",
+      "[profiles.sess_0]",
+      'service = "uat-api.clickzetta.com"',
+      'instance = "wanted-inst"',
+      'workspace = "w"',
+      'oauth = "sess"',
+      'auth_type = "oauth"',
+      ...extra,
+      "",
+    ].join("\n"),
+    "utf-8",
+  )
+}
+
+afterEach(() => {
+  if (previousProfile === undefined) delete process.env.CZ_PROFILE
+  else process.env.CZ_PROFILE = previousProfile
+})
+
+test("resolves and caches against the profile the connection came from, not default_profile", async () => {
+  writeTwoProfiles()
+  process.env.CZ_PROFILE = "wanted"
+  const seen: string[] = []
+  onFetch({ match: (url) => { seen.push(url); return false }, respond: () => ({}) })
+  // Only the wanted profile's account owns the instance the connection names.
+  stubInstances([{ id: 160813, name: "wanted-inst", serviceId: 1 }])
+
+  const ctx = await getExecContext({})
+  expect(execInstanceId(ctx)).toBe(160813)
+  // Looked up with the CZ_PROFILE profile's account, not default_profile's 999.
+  expect(seen.some((url) => url.includes("accountId=124213"))).toBe(true)
+  expect(seen.some((url) => url.includes("accountId=999"))).toBe(false)
+  // Cached onto the profile it belongs to, and NOT onto default_profile.
+  const toml = readFileSync(profilesPath(), "utf-8")
+  const wanted = toml.slice(toml.indexOf("[profiles.wanted]"))
+  const other = toml.slice(toml.indexOf("[profiles.other]"), toml.indexOf("[profiles.wanted]"))
+  expect(wanted).toContain("instance_id = 160813")
+  expect(other).not.toContain("instance_id")
+})
+
+test("an unresolvable instance id is an error, never a silent zero", async () => {
+  // An OAuth profile on purpose: a PAT/password credential still carries an id from its
+  // login response, so the fallback would absorb the failure. OAuth is the case with
+  // nothing to fall back to — the id is no longer stored in [oauth.<id>].
+  writeOAuthProfile(["account_id = 124213"])
+  // The account has instances, none of them the one this profile names.
+  stubInstances([{ id: 271502, name: "someone-elses-inst", serviceId: 1 }])
+
+  // The profile's OWN name, so not the explicit-override throw: it falls to the catch-all,
+  // which still refuses rather than inventing an id, and says which of the causes it was.
+  await expect(getExecContext({})).rejects.toThrow(/does not list it for this account/)
+})
+
+test("a profile with no account_id says so rather than looking nothing up", async () => {
+  writeOAuthProfile([])
+  stubInstances([{ id: 271502, name: "whatever", serviceId: 1 }])
+  await expect(getExecContext({})).rejects.toThrow(/no account_id/)
+})
+
+test("an instance_id already on the profile is used as-is, with no lookup", async () => {
+  writeOneProfile(["account_id = 124213", "instance_id = 160813"])
+  const seen: string[] = []
+  onFetch({ match: (url) => { seen.push(url); return false }, respond: () => ({}) })
+  stubStudioContext()
+  const ctx = await getExecContext({})
+  expect(execInstanceId(ctx)).toBe(160813)
+  expect(seen.some((url) => url.includes("/serviceInstanceList"))).toBe(false)
+})
+
+/**
+ * A cached id is only valid for the instance it was resolved for. Both of these were
+ * review findings: the `--instance` guard compared the value to itself and so never fired,
+ * and clearing on ANY supplied name (rather than a different one) made an exported
+ * CZ_INSTANCE pay a portal round trip on every command forever.
+ */
+test("--instance naming a different instance discards the profile's cached id", async () => {
+  writeOneProfile(["account_id = 124213", "instance_id = 160813"])
+  const seen: string[] = []
+  onFetch({ match: (url) => { seen.push(url); return false }, respond: () => ({}) })
+  stubInstances([{ id: 271502, name: "other-inst", serviceId: 1 }])
+
+  const ctx = await getExecContext({ instance: "other-inst" })
+  expect(execInstanceId(ctx)).toBe(271502)
+  expect(seen.some((url) => url.includes("/serviceInstanceList"))).toBe(true)
+})
+
+test("CZ_INSTANCE naming the profile's own instance keeps the cached id and asks nothing", async () => {
+  writeOneProfile(["account_id = 124213", "instance_id = 160813"])
+  process.env.CZ_INSTANCE = "i"
+  const seen: string[] = []
+  onFetch({ match: (url) => { seen.push(url); return false }, respond: () => ({}) })
+  stubStudioContext()
+  try {
+    const ctx = await getExecContext({})
+    expect(execInstanceId(ctx)).toBe(160813)
+    expect(seen.some((url) => url.includes("/serviceInstanceList"))).toBe(false)
+  } finally {
+    delete process.env.CZ_INSTANCE
+  }
+})
+
+/**
+ * The id resolved for an OVERRIDDEN instance name must not be cached onto the profile.
+ * patchProfileInstanceId only writes when the field is absent, so one `--instance` run
+ * against a not-yet-backfilled profile would pin it to another instance's id permanently,
+ * with nothing to correct it. The `--instance` case above cannot catch this: its fixture
+ * already carries an instance_id, so there is nothing for the write to fill in.
+ */
+test("--instance resolves for this run but never caches onto the profile", async () => {
+  writeOneProfile(["account_id = 124213"])
+  stubInstances([{ id: 271502, name: "other-inst", serviceId: 1 }])
+
+  const ctx = await getExecContext({ instance: "other-inst" })
+  expect(execInstanceId(ctx)).toBe(271502)
+  // The profile still names "i" and must not have acquired the override's id.
+  const toml = readFileSync(profilesPath(), "utf-8")
+  expect(toml).not.toContain("instance_id")
+  expect(toml).not.toContain("271502")
+})
+
+test("resolving the profile's own name does cache it", async () => {
+  writeOneProfile(["account_id = 124213"])
+  stubInstances([{ id: 160813, name: "i", serviceId: 1 }])
+
+  const ctx = await getExecContext({})
+  expect(execInstanceId(ctx)).toBe(160813)
+  expect(readFileSync(profilesPath(), "utf-8")).toContain("instance_id = 160813")
+})
+
+/**
+ * A definitive "this account has no instance by that name" is fatal even when the credential
+ * carries an id of its own. The first version of the warning fired only on a lookup ERROR, so
+ * this — the case where the credential's id is almost certainly for a different instance —
+ * was the one that passed silently, while the sibling OAuth branch treated the same answer as
+ * fatal. Severity must not depend on whether a credential happens to carry an id.
+ */
+test("a name the account does not list is fatal even for a PAT credential", async () => {
+  writeOneProfile(["account_id = 124213"])
+  stubInstances([{ id: 160813, name: "i", serviceId: 1 }])
+
+  await expect(getExecContext({ instance: "not-mine" })).rejects.toThrow(
+    /Instance 'not-mine' is not listed for this account/,
+  )
+})
+
+/** A JWT whose payload carries the ids cookie auth reads out of it. No signature check. */
+function cookieJwt(payload: Record<string, unknown>) {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url")
+  return `${b64({ alg: "none" })}.${b64({ exp: Math.floor(Date.now() / 1000) + 3600, ...payload })}.x`
+}
+
+/**
+ * Cookie auth's id comes from the cookie's own JWT and is authoritative — the cookie is
+ * scoped to an instance. A lookup that does not list the profile's instance name must not
+ * discard it: that name can miss for reasons other than ownership (a rename, or an instance
+ * that is not serviceId 1), and failing there would break a setup that works.
+ */
+test("a cookie credential's definitive id survives a lookup that lists nothing matching", async () => {
+  writeFileSync(
+    profilesPath(),
+    [
+      'default_profile = "ck"', "", "[profiles.ck]",
+      'service = "uat-api.clickzetta.com"',
+      'instance = "renamed-inst"',
+      'workspace = "w"',
+      "account_id = 124213",
+      `"header.Cookie" = "X-ClickZetta-Token=${cookieJwt({ userId: 7, accountId: 124213, instanceId: 445566 })}"`,
+      "",
+    ].join("\n"),
+    "utf-8",
+  )
+  stubInstances([{ id: 160813, name: "something-else", serviceId: 1 }])
+
+  const ctx = await getExecContext({})
+  expect(execInstanceId(ctx)).toBe(445566)
+})
+
+/**
+ * The legacy read: an OAuth profile with no cached id and no usable lookup falls back to the
+ * id an older version wrote into the SHARED `[oauth.<id>]` section. Wrong shape, but it is
+ * the number that used to answer offline, so a portal outage does not block the command.
+ */
+test("an OAuth profile falls back to the legacy shared-section id rather than failing", async () => {
+  writeFileSync(
+    profilesPath(),
+    [
+      'default_profile = "sess_0"', "",
+      "[oauth.sess]",
+      'access_token = "at"', 'refresh_token = "rt"',
+      "expire_time_ms = 3600000", `obtained_at = ${Date.now()}`,
+      "instance_id = 271502", "user_id = 7", "",
+      "[profiles.sess_0]",
+      'service = "uat-api.clickzetta.com"', 'instance = "wanted-inst"', 'workspace = "w"',
+      'oauth = "sess"', 'auth_type = "oauth"', "account_id = 124213", "",
+    ].join("\n"),
+    "utf-8",
+  )
+  // Lookup fails outright, so neither a resolved id nor a not-listed answer.
+  onStudio("/clickzetta-portal/service/serviceInstanceList", () => {
+    throw new Error("portal unreachable")
+  })
+  stubStudioContext()
+
+  const ctx = await getExecContext({})
+  expect(execInstanceId(ctx)).toBe(271502)
+})
+
+/** A PAT credential keeps working through a portal outage, and says that it could not verify. */
+test("a failed lookup warns and proceeds on the credential's id", async () => {
+  writeOneProfile(["account_id = 124213"])
+  onStudio("/clickzetta-portal/service/serviceInstanceList", () => {
+    throw new Error("portal unreachable")
+  })
+  stubStudioContext()
+
+  const ctx = await getExecContext({})
+  // stubStudioContext's login response carries the id.
+  expect(execInstanceId(ctx)).toBeGreaterThan(0)
+})

--- a/packages/cz-cli/test/gateway.test.ts
+++ b/packages/cz-cli/test/gateway.test.ts
@@ -214,3 +214,148 @@ describe("ai-gateway key add-to-llm", () => {
     expect(readLlmEntries().llm["demo-key"]).toBeUndefined()
   })
 })
+
+/**
+ * `ai-gateway quota` reads the allowance off a completion's response headers, so its
+ * whole contract is "what the gateway said", including when the gateway said something
+ * that is not about the quota at all.
+ */
+describe("ai-gateway quota", () => {
+  const BASE = "https://uat-aimesh.clickzetta.com/gateway/v1"
+  const KEY = "k".repeat(32)
+
+  function withClickzettaEntry() {
+    writeLlmEntries({ llm: { cz: { provider: "clickzetta", api_key: KEY, base_url: BASE } } })
+  }
+
+  /** Answer the model catalog, then the probe, with whatever the case needs. */
+  function stubGateway(input: { models?: unknown; completion: () => Response }) {
+    onFetch({
+      match: (url) => url.startsWith(BASE),
+      respond: (url) => {
+        if (url.endsWith("/models")) {
+          return input.models === undefined ? new Response("nope", { status: 503 }) : input.models
+        }
+        return input.completion()
+      },
+    })
+  }
+
+  test("reports every period the headers carried", async () => {
+    withClickzettaEntry()
+    stubGateway({
+      models: { object: "list", data: [{ id: "deepseek/deepseek-v4-pro" }] },
+      completion: () =>
+        new Response(JSON.stringify({ choices: [{ message: { role: "assistant", content: "ok" } }] }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-czgw-ratelimit-api-key-token-period": "PTO, PDO",
+            "x-czgw-ratelimit-api-key-token-limit": "1000000000, 10000000",
+            "x-czgw-ratelimit-api-key-token-used": "21306417, 238",
+            "x-czgw-ratelimit-api-key-token-remaining": "978693583, 9999762",
+          },
+        }),
+    })
+
+    const result = await execute("ai-gateway quota cz")
+    const json = firstJson(result.output)
+    expect(result.exitCode).toBe(0)
+    const data = json.data as { quotas?: Array<{ period?: string }> }
+    expect(data.quotas?.map((quota) => quota.period)).toEqual(["total", "daily"])
+  })
+
+  /**
+   * A 404 for a model nobody asked for says nothing about the quota — the catalog could
+   * not be listed, so the probe fell back to a hardcoded id this tenant does not serve.
+   * Collapsing that into GATEWAY_QUOTA_UNAVAILABLE is the "two surfaces, two verdicts"
+   * defect probe.ts documents, so it gets its own code and names the remedy.
+   */
+  test("a 404 on a fallback probe model is not reported as an unreadable quota", async () => {
+    withClickzettaEntry()
+    stubGateway({
+      completion: () => new Response(JSON.stringify({ error: { message: "model not found" } }), { status: 404 }),
+    })
+
+    const result = await execute("ai-gateway quota cz")
+    const json = firstJson(result.output)
+    const error = json.error as { code?: string; message?: string }
+    expect(error.code).toBe("GATEWAY_PROBE_MODEL_UNAVAILABLE")
+    expect(error.message).toContain("--model")
+    expect(error.message).toContain("says nothing about the quota")
+  })
+
+  test("a 404 on a model the caller named IS reported as an unreadable quota", async () => {
+    withClickzettaEntry()
+    stubGateway({
+      completion: () => new Response(JSON.stringify({ error: { message: "model not found" } }), { status: 404 }),
+    })
+
+    const result = await execute("ai-gateway quota cz --model mine/does-not-exist")
+    const json = firstJson(result.output)
+    expect((json.error as { code?: string }).code).toBe("GATEWAY_QUOTA_UNAVAILABLE")
+  })
+
+  /**
+   * Two ClickZetta entries and nothing pinned is exactly where this command used to guess
+   * the first one while the sidebar refused to choose — same llm.json, two answers. It now
+   * asks for a name and lists the candidates.
+   */
+  test("with two candidates and nothing pinned it asks for a name instead of guessing", async () => {
+    writeLlmEntries({
+      llm: {
+        prod: { provider: "clickzetta", api_key: KEY, base_url: BASE },
+        staging: { provider: "clickzetta", api_key: "s".repeat(32), base_url: BASE },
+      },
+    })
+    const result = await execute("ai-gateway quota")
+    const message = ((firstJson(result.output).error as { message?: string }) ?? {}).message ?? ""
+    expect(message).toContain("naming one is required")
+    expect(message).toContain("prod")
+    expect(message).toContain("staging")
+  })
+
+  test("naming one of several is answered directly", async () => {
+    writeLlmEntries({
+      llm: {
+        prod: { provider: "clickzetta", api_key: KEY, base_url: BASE },
+        staging: { provider: "clickzetta", api_key: "s".repeat(32), base_url: BASE },
+      },
+    })
+    stubGateway({
+      models: { object: "list", data: [{ id: "deepseek/deepseek-v4-pro" }] },
+      completion: () =>
+        new Response(JSON.stringify({ choices: [{ message: { role: "assistant", content: "ok" } }] }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-czgw-ratelimit-api-key-token-period": "PDO",
+            "x-czgw-ratelimit-api-key-token-limit": "10000000",
+            "x-czgw-ratelimit-api-key-token-used": "238",
+            "x-czgw-ratelimit-api-key-token-remaining": "9999762",
+          },
+        }),
+    })
+    const result = await execute("ai-gateway quota prod")
+    expect(result.exitCode).toBe(0)
+    expect((firstJson(result.output).data as { llm?: string }).llm).toBe("prod")
+  })
+
+  test("a gateway that sends no quota headers is not reported as zero", async () => {
+    withClickzettaEntry()
+    stubGateway({
+      models: { object: "list", data: [{ id: "deepseek/deepseek-v4-pro" }] },
+      completion: () =>
+        new Response(JSON.stringify({ choices: [{ message: { role: "assistant", content: "ok" } }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    })
+
+    const result = await execute("ai-gateway quota cz")
+    const json = firstJson(result.output)
+    expect(result.exitCode).toBe(0)
+    expect((json.data as Record<string, unknown>).quotas).toBeUndefined()
+    expect(String(json.ai_message)).toContain("reported no quota headers")
+  })
+})

--- a/packages/cz-cli/test/installer-windows.test.ts
+++ b/packages/cz-cli/test/installer-windows.test.ts
@@ -1,0 +1,247 @@
+/**
+ * The curl installer must actually install on Windows, not just recognise it.
+ * Run: bun test test/installer-windows.test.ts
+ *
+ * A Windows user's first move is `curl -fsSL https://cz-cli.ai/install.sh | bash` in Git
+ * Bash, and that answered `unsupported platform: mingw64_nt-10.0-26200-x64` — the raw
+ * `uname -s` string, because platform() had no mapping for the MSYS family. It reads as
+ * "there is no Windows build" when in fact the win32 archives are published like every
+ * other platform.
+ *
+ * This runs the GENERATED script end to end against a fixture archive, with `uname` and
+ * `curl` stubbed, because the interesting parts are all shell: the platform mapping, the
+ * zip extraction fallback (Git Bash has no unzip), and passing BINARY_NAME through to
+ * setup.sh so it installs cz-cli.exe. It cannot prove the .exe runs — that needs Windows.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { createHash } from "node:crypto"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+// @ts-expect-error — plain .mjs release script, no types
+import { renderBootstrapSh } from "../../../scripts/cos-release.mjs"
+
+const ROOT = join(import.meta.dir, "..", "..", "..")
+let work: string
+
+/** A stand-in for the published archive: bin/ zipped, exactly as archivePlatform does. */
+function fixtureArchive(binaryName: string) {
+  const staging = join(work, "staging")
+  mkdirSync(staging, { recursive: true })
+  writeFileSync(join(staging, binaryName), "#!/bin/sh\necho 2.0.4\n")
+  chmodSync(join(staging, binaryName), 0o755)
+  writeFileSync(join(staging, "setup.sh"), readFileSync(join(ROOT, "scripts", "setup.sh")))
+  // One runtime asset, enough to prove setup.sh's copy loop still runs.
+  writeFileSync(join(staging, "tui-quota-runtime.js"), "// stub\n")
+  const archive = join(work, "cz-cli.zip")
+  // `zip -rq` APPENDS to an existing archive, and the Cygwin/MSYS case builds twice in one
+  // work dir — so remove it first rather than accumulating entries.
+  rmSync(archive, { force: true })
+  const zipped = Bun.spawnSync(["zip", "-rq", archive, "."], { cwd: staging })
+  // Check it. An unchecked fixture build is why this file once flaked: a bad archive makes
+  // the installer fail at verify_checksum, and a case asserting on the EXTRACTION error
+  // then fails with no hint that its input was never valid.
+  if (zipped.exitCode !== 0 || !existsSync(archive) || readFileSync(archive).byteLength === 0) {
+    throw new Error(`fixture archive build failed (exit ${zipped.exitCode}): ${zipped.stderr.toString()}`)
+  }
+  return { archive, checksum: createHash("sha256").update(readFileSync(archive)).digest("hex") }
+}
+
+/**
+ * PATH for one run: the uname/curl stubs, plus whichever extraction tools the case wants.
+ *
+ * `tar` and `powershell` are stubbed rather than taken from the host, because what
+ * extract_zip owns is the ORDER it tries them in — "bsdtar reads zip" is a fact about
+ * Windows' tar.exe, and it cannot be asserted on a Linux runner, where tar is GNU tar and
+ * does not. The first cut of this test used the host tar and so passed only on macOS. Each
+ * stub records that it ran, so a case can prove which link of the chain did the work.
+ */
+function stubs(input: {
+  unameS: string
+  unameM: string
+  archive: string
+  unzip: "real" | "absent"
+  tar?: "extracts" | "fails"
+  powershell?: "extracts"
+  marker: string
+}) {
+  const bin = join(work, `stub-bin-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(bin, { recursive: true })
+  const write = (name: string, body: string) => {
+    writeFileSync(join(bin, name), body)
+    chmodSync(join(bin, name), 0o755)
+  }
+  const realUnzip = Bun.spawnSync(["sh", "-c", "command -v unzip"]).stdout.toString().trim()
+
+  write("uname", `#!/bin/sh\ncase "$1" in\n  -s) echo "${input.unameS}" ;;\n  -m) echo "${input.unameM}" ;;\n  *) echo "${input.unameS}" ;;\nesac\n`)
+  // download() calls: curl -fL --progress-bar URL -o DEST
+  write("curl", `#!/bin/sh\nDEST=""\nwhile [ $# -gt 0 ]; do\n  if [ "$1" = "-o" ]; then DEST="$2"; fi\n  shift\ndone\ncp ${JSON.stringify(input.archive)} "$DEST"\n`)
+
+  if (input.tar === "fails") write("tar", "#!/bin/sh\nexit 1\n")
+  // extract_zip calls: tar -xf ARCHIVE -C DIR
+  if (input.tar === "extracts")
+    write("tar", `#!/bin/sh\necho tar >> ${JSON.stringify(input.marker)}\nexec ${JSON.stringify(realUnzip)} -qo "$2" -d "$4"\n`)
+  if (input.powershell === "extracts") {
+    write("cygpath", '#!/bin/sh\necho "$2"\n')
+    write(
+      "powershell",
+      `#!/bin/sh\necho powershell >> ${JSON.stringify(input.marker)}\nSRC=$(printf '%s' "$4" | sed -n "s/.*-LiteralPath '\\([^']*\\)'.*/\\1/p")\nDST=$(printf '%s' "$4" | sed -n "s/.*-DestinationPath '\\([^']*\\)'.*/\\1/p")\nexec ${JSON.stringify(realUnzip)} -qo "$SRC" -d "$DST"\n`,
+    )
+  }
+  if (input.unzip === "real") return `${bin}:${process.env.PATH}`
+
+  // A sandbox of symlinks to exactly the tools the two scripts need, unzip excluded —
+  // dropping the real PATH is not enough, because /usr/bin is both where unzip lives and
+  // where everything else does. A case below asserts unzip really is out of reach, so this
+  // cannot quietly stop testing what it claims to.
+  const sandbox = join(work, "sandbox-bin")
+  mkdirSync(sandbox, { recursive: true })
+  const tools = [
+    "sh", "cp", "rm", "mkdir", "chmod", "cat", "date", "grep", "tr", "awk", "sed", "env",
+    "mktemp", "shasum", "sha256sum", "dirname", "basename", "printf", "echo", "test",
+  ]
+  for (const tool of input.tar ? tools : [...tools, "tar"]) {
+    const found = Bun.spawnSync(["sh", "-c", `command -v ${tool} || true`]).stdout.toString().trim()
+    // The Cygwin/MSYS case runs twice in one work dir, so this must be re-entrant.
+    if (found && !existsSync(join(sandbox, tool))) symlinkSync(found, join(sandbox, tool))
+  }
+  return `${bin}:${sandbox}`
+}
+
+function runInstaller(input: {
+  platformKey: string
+  binaryName: string
+  unameS: string
+  unzip?: "real" | "absent"
+  tar?: "extracts" | "fails"
+  powershell?: "extracts"
+}) {
+  const { archive, checksum } = fixtureArchive(input.binaryName)
+  const script = join(work, "install.sh")
+  writeFileSync(
+    script,
+    renderBootstrapSh({
+      version: "2.0.4",
+      channel: "stable",
+      platforms: { [input.platformKey]: { url: "https://example.invalid/cz-cli.zip", archive: "cz-cli.zip", format: "zip", checksum } },
+    }),
+  )
+  const home = join(work, "home")
+  const installDir = join(home, ".local", "bin")
+  const marker = join(work, "extractor-used")
+  mkdirSync(home, { recursive: true })
+  const path = stubs({
+    unameS: input.unameS,
+    unameM: "x86_64",
+    archive,
+    unzip: input.unzip ?? "real",
+    ...(input.tar ? { tar: input.tar } : {}),
+    ...(input.powershell ? { powershell: input.powershell } : {}),
+    marker,
+  })
+  const result = Bun.spawnSync(["sh", script], {
+    env: { PATH: path, HOME: home, INSTALL_DIR: installDir, NON_INTERACTIVE: "1" },
+  })
+  return {
+    installDir,
+    home,
+    path,
+    extractorUsed: existsSync(marker) ? readFileSync(marker, "utf-8").trim() : "",
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+    exitCode: result.exitCode,
+  }
+}
+
+beforeEach(() => {
+  work = mkdtempSync(join(tmpdir(), "cz-installer-"))
+})
+afterEach(() => {
+  rmSync(work, { recursive: true, force: true })
+})
+
+describe("install.sh on Git Bash", () => {
+  test("installs cz-cli.exe instead of reporting an unsupported platform", () => {
+    const r = runInstaller({ platformKey: "win32-x64", binaryName: "cz-cli.exe", unameS: "MINGW64_NT-10.0-26200" })
+    expect(r.stderr).not.toContain("unsupported platform")
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain("win32-x64")
+    expect(existsSync(join(r.installDir, "cz-cli.exe"))).toBe(true)
+    // The POSIX wrapper for Git Bash and the .cmd shim for cmd/PowerShell.
+    expect(existsSync(join(r.installDir, "cz-agent"))).toBe(true)
+    expect(readFileSync(join(r.installDir, "cz-agent.cmd"), "utf-8")).toContain("agent %*")
+    // Runtime assets still land beside the binary — the thing that broke silently before.
+    expect(existsSync(join(r.installDir, "tui-quota-runtime.js"))).toBe(true)
+    const metadata = JSON.parse(readFileSync(join(r.home, ".clickzetta", "install.json"), "utf-8"))
+    expect(metadata.installed_path.endsWith("cz-cli.exe")).toBe(true)
+  })
+
+  test("MSYS and Cygwin map onto the same build", () => {
+    for (const unameS of ["MSYS_NT-10.0-26200", "CYGWIN_NT-10.0-26200"]) {
+      const r = runInstaller({ platformKey: "win32-x64", binaryName: "cz-cli.exe", unameS })
+      expect(r.exitCode).toBe(0)
+      expect(existsSync(join(r.installDir, "cz-cli.exe"))).toBe(true)
+    }
+  })
+
+  /**
+   * The three links of extract_zip, in order. Git Bash ships no unzip, so which of the
+   * others runs there depends on the host — the point being tested is that the chain falls
+   * through rather than aborting, which is ours to get right.
+   */
+  test("falls through to tar when unzip is missing", () => {
+    const r = runInstaller({
+      platformKey: "win32-x64",
+      binaryName: "cz-cli.exe",
+      unameS: "MINGW64_NT-10.0-26200",
+      unzip: "absent",
+      tar: "extracts",
+    })
+    // Prove the sandbox is what it claims: an unzip in reach would make this vacuous.
+    expect(Bun.spawnSync(["sh", "-c", "command -v unzip || true"], { env: { PATH: r.path } }).stdout.toString().trim()).toBe("")
+    expect(r.extractorUsed).toBe("tar")
+    expect(r.exitCode).toBe(0)
+    expect(existsSync(join(r.installDir, "cz-cli.exe"))).toBe(true)
+  })
+
+  test("falls through to powershell when neither unzip nor a zip-capable tar is there", () => {
+    const r = runInstaller({
+      platformKey: "win32-x64",
+      binaryName: "cz-cli.exe",
+      unameS: "MINGW64_NT-10.0-26200",
+      unzip: "absent",
+      tar: "fails",
+      powershell: "extracts",
+    })
+    expect(r.extractorUsed).toBe("powershell")
+    expect(r.exitCode).toBe(0)
+    expect(existsSync(join(r.installDir, "cz-cli.exe"))).toBe(true)
+  })
+
+  test("with no extractor at all it says which tools would do", () => {
+    const r = runInstaller({
+      platformKey: "win32-x64",
+      binaryName: "cz-cli.exe",
+      unameS: "MINGW64_NT-10.0-26200",
+      unzip: "absent",
+      tar: "fails",
+    })
+    expect(r.exitCode).toBe(1)
+    expect(r.stderr).toContain("needs one of: unzip")
+  })
+
+  test("a platform with no published build still says so", () => {
+    const r = runInstaller({ platformKey: "win32-arm64", binaryName: "cz-cli.exe", unameS: "MINGW64_NT-10.0-26200" })
+    expect(r.exitCode).toBe(1)
+    expect(r.stderr).toContain("unsupported platform: win32-x64")
+  })
+
+  /** The POSIX path must be untouched: same script, same delegation, no .exe. */
+  test("a POSIX host still installs the extensionless binary", () => {
+    const r = runInstaller({ platformKey: "darwin-x64", binaryName: "cz-cli", unameS: "Darwin", unzip: "real" })
+    expect(r.exitCode).toBe(0)
+    expect(existsSync(join(r.installDir, "cz-cli"))).toBe(true)
+    expect(existsSync(join(r.installDir, "cz-cli.exe"))).toBe(false)
+    expect(existsSync(join(r.installDir, "cz-agent.cmd"))).toBe(false)
+  })
+})

--- a/packages/cz-cli/test/login-command.test.ts
+++ b/packages/cz-cli/test/login-command.test.ts
@@ -29,7 +29,13 @@ const KNOWN_TOKEN: AuthToken = {
 // After login, provisioning stamps the OAuth issuer (the login entry host,
 // api.example.com per makeTarget) onto the persisted token so refresh can
 // target /oauth2/token there. That's what load() returns.
-const PERSISTED_TOKEN: AuthToken = { ...KNOWN_TOKEN, issuer: "api.example.com" }
+//
+// Without instanceId, though KNOWN_TOKEN has one: a browser login does learn an instance
+// id, but `[oauth.<id>]` is SHARED by every profile the login provisions — one section
+// cannot hold a per-profile fact — so it is not persisted there. It goes on each profile
+// instead (see the instance_id assertions below).
+const { instanceId: _loginInstanceId, ...KNOWN_TOKEN_WITHOUT_INSTANCE } = KNOWN_TOKEN
+const PERSISTED_TOKEN: AuthToken = { ...KNOWN_TOKEN_WITHOUT_INSTANCE, issuer: "api.example.com" }
 
 const KNOWN_RESULT: BrowserLoginResult = {
   token: KNOWN_TOKEN,
@@ -235,6 +241,10 @@ describe("runLogin", () => {
     expect(text).toContain(`[profiles.${PROFILE}_2]`)
     // Each combo's workspace landed on its profile.
     expect(text).toContain('workspace = "analytics"')
+    // Each profile carries its OWN instance_id, from the combo — the whole point of moving
+    // it off the shared token. Two of these combos are one instance, the third another.
+    expect(text.match(/^instance_id = 159973$/gm)?.length).toBe(2)
+    expect(text.match(/^instance_id = 271876$/gm)?.length).toBe(1)
     // A single shared section named after the session, and every profile points at it.
     expect(text).toContain(`[oauth.${PROFILE}]`)
     const oauthSections = text.match(/\[oauth\.[^\]]+\]/g) ?? []

--- a/packages/cz-cli/test/oauth-section-hygiene.test.ts
+++ b/packages/cz-cli/test/oauth-section-hygiene.test.ts
@@ -14,7 +14,7 @@
  *   - pruneOrphanOAuthSections sweeps sections no profile references
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdtempSync, rmSync, readFileSync } from "node:fs"
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { AuthToken } from "@clickzetta/sdk"
@@ -45,12 +45,16 @@ const readProfiles = () => readFileSync(profilesPath(), "utf-8")
 const oauthIds = () =>
   Array.from(readProfiles().matchAll(/^\[oauth\.([^\]]+)\]/gm)).map((m) => m[1]!)
 
+/**
+ * No instanceId. It is a property of the CONNECTION, not the credential — a shared
+ * `[oauth.<id>]` cannot hold one id for profiles on different instances — so it is neither
+ * written nor read here any more. See ConnectionConfig.instanceId.
+ */
 const TOKEN: AuthToken = {
   token: "access-abc",
   refreshToken: "refresh-xyz",
   expireTimeMs: 3_600_000,
   obtainedAt: 1_700_000_000_000,
-  instanceId: 42,
   userId: 7,
 }
 
@@ -204,5 +208,50 @@ describe("pruneOrphanOAuthSections", () => {
     pruneOrphanOAuthSections()
 
     expect(readProfiles()).toBe(before)
+  })
+})
+
+/**
+ * The instance id moving off the credential has to be safe in BOTH directions on one
+ * disk: a section written by an older version still carries `instance_id`, and a reader
+ * that demanded it — as this one used to — would have judged every newly written section
+ * invalid and silently signed the user out.
+ */
+describe("[oauth.*] and the instance id", () => {
+  test("a section written now carries no instance_id, even from a token that has one", () => {
+    saveProfiles({ robert_0: { instance: "i", service: "s" } })
+    // A standalone SDK login still puts an id on the token (the login response is its only
+    // source), so the token being SAVED is the one shape that can regress this. Asserting
+    // with a token that has no instanceId proves nothing: the write would serialize
+    // `undefined` and TOML would drop the key either way.
+    makeProfileTokenStore("robert_0", "robert").save({ ...TOKEN, instanceId: 271502 })
+    expect(readProfiles()).not.toContain("instance_id")
+    expect(readProfiles()).not.toContain("271502")
+    // Everything else still round-trips — and the id does not come back.
+    expect(makeProfileTokenStore("robert_0").load()).toEqual(TOKEN)
+  })
+
+  test("a section written by an older version still loads, its instance_id ignored", () => {
+    saveProfiles({ robert_0: { instance: "i", service: "s", oauth: "robert" } })
+    // Exactly what the buggy version wrote: the shared section carrying one instance id.
+    writeFileSync(
+      profilesPath(),
+      [
+        readProfiles().trimEnd(),
+        "",
+        "[oauth.robert]",
+        `access_token = "${TOKEN.token}"`,
+        `refresh_token = "${TOKEN.refreshToken}"`,
+        `expire_time_ms = ${TOKEN.expireTimeMs}`,
+        `obtained_at = ${TOKEN.obtainedAt}`,
+        "instance_id = 271502",
+        `user_id = ${TOKEN.userId}`,
+        "",
+      ].join("\n"),
+      "utf-8",
+    )
+    const loaded = makeProfileTokenStore("robert_0").load()
+    expect(loaded).toEqual(TOKEN)
+    expect(loaded && "instanceId" in loaded).toBe(false)
   })
 })

--- a/packages/cz-cli/test/profile-delete-oauth.test.ts
+++ b/packages/cz-cli/test/profile-delete-oauth.test.ts
@@ -46,7 +46,7 @@ const TOKEN: AuthToken = {
   refreshToken: "refresh-xyz",
   expireTimeMs: 3_600_000,
   obtainedAt: 1_700_000_000_000,
-  instanceId: 42,
+  // No instanceId: it belongs to the profile, not the shared token (ConnectionConfig.instanceId).
   userId: 7,
 }
 

--- a/packages/cz-cli/test/profile-token-store.test.ts
+++ b/packages/cz-cli/test/profile-token-store.test.ts
@@ -34,7 +34,7 @@ const sampleToken: AuthToken = {
   refreshToken: "refresh-xyz",
   expireTimeMs: 3600_000,
   obtainedAt: 1_700_000_000_000,
-  instanceId: 42,
+  // No instanceId: it belongs to the profile, not the shared token (ConnectionConfig.instanceId).
   userId: 7,
 }
 
@@ -72,7 +72,6 @@ test("legacy token without refreshToken round-trips without the field", () => {
     token: "legacy-token",
     expireTimeMs: 1_000,
     obtainedAt: 1_700_000_000_000,
-    instanceId: 1,
     userId: 2,
   }
   makeProfileTokenStore("czcli").save(legacy)

--- a/packages/cz-cli/test/provision.test.ts
+++ b/packages/cz-cli/test/provision.test.ts
@@ -181,7 +181,7 @@ describe("provisionProfileFromOAuth", () => {
     refreshToken: "refresh-xyz",
     expireTimeMs: 3600 * 1000,
     obtainedAt: Date.now(),
-    instanceId: 159973,
+  // No instanceId: it belongs to the profile, not the shared token (ConnectionConfig.instanceId).
     userId: 110000011361,
   }
   const USERINFO = {
@@ -275,7 +275,6 @@ describe("provisionProfilesFromOAuthCombos re-login", () => {
     refreshToken: "refresh-1",
     expireTimeMs: 3600 * 1000,
     obtainedAt: Date.now(),
-    instanceId: 1,
     userId: 42,
   }
   const combo = (instance: string, workspace: string) => ({

--- a/packages/cz-cli/test/resolve-token-store.test.ts
+++ b/packages/cz-cli/test/resolve-token-store.test.ts
@@ -49,7 +49,7 @@ const sampleToken: AuthToken = {
   refreshToken: "refresh-xyz",
   expireTimeMs: 3600_000,
   obtainedAt: 1_700_000_000_000,
-  instanceId: 42,
+  // No instanceId: it belongs to the profile, not the shared token (ConnectionConfig.instanceId).
   userId: 7,
 }
 

--- a/packages/cz-cli/test/sql-error-job-id.test.ts
+++ b/packages/cz-cli/test/sql-error-job-id.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { onFetch, sqlFailure, sqlSuccess, stubStudioContext } from "./support/cz-fixtures.js"
+import { writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+// Network-boundary test: the real exec path runs (getExecContext → submitJob →
+// parseJobResponse → handleFailure/emitResult) and only /lh/submitJob is stubbed.
+// The job id is client-generated (commands/exec.ts:113), so the fixture reads it
+// back off the submit payload and the assertion compares against that exact id.
+
+const { execute } = await import("../src/execute.ts")
+
+let submittedJobId: string | undefined
+
+function firstJson(output: string) {
+  return JSON.parse(output.trim().split("\n")[0] ?? "{}") as {
+    error?: { code?: string; message?: string }
+    job_id?: string
+  }
+}
+
+function stubSubmit(respond: () => unknown) {
+  onFetch({
+    match: (url) => url.includes("/lh/submitJob"),
+    respond: (_url, _method, body) => {
+      const desc = (body as { jobDesc?: { jobId?: { id?: string } } })?.jobDesc
+      submittedJobId = desc?.jobId?.id
+      return respond()
+    },
+  })
+}
+
+beforeEach(() => {
+  submittedJobId = undefined
+  stubStudioContext()
+  writeFileSync(
+    join(process.env.CLICKZETTA_TEST_HOME!, ".clickzetta", "profiles.toml"),
+    [
+      'default_profile = "test"',
+      "[profiles.test]",
+      'pat = "pat"',
+      'service = "uat-api.clickzetta.com"',
+      'instance = "inst"',
+      'workspace = "ws0"',
+    ].join("\n"),
+  )
+})
+
+describe("sql emits job_id on failure", () => {
+  test("a FAILED job carries job_id alongside the error", async () => {
+    stubSubmit(() =>
+      sqlFailure("CZLH-42000", "CZLH-42000:[1,8] Semantic analysis exception - cannot resolve column 'aaaa'"),
+    )
+
+    const result = await execute('sql "select aaaa from t1" --sync')
+    const json = firstJson(result.output)
+
+    expect(result.exitCode).toBe(1)
+    expect(json.error?.code).toBe("CZLH-42000")
+    expect(submittedJobId).toBeTruthy()
+    expect(json.job_id).toBe(submittedJobId!)
+  })
+
+  test("a successful job still carries the same job_id shape", async () => {
+    stubSubmit(() => sqlSuccess(["a"], [[1]]))
+
+    const result = await execute('sql "select a from t1" --sync')
+    const json = firstJson(result.output)
+
+    expect(result.exitCode).toBe(0)
+    expect(json.job_id).toBe(submittedJobId!)
+  })
+})

--- a/packages/cz-cli/test/sql-error-job-id.test.ts
+++ b/packages/cz-cli/test/sql-error-job-id.test.ts
@@ -71,3 +71,27 @@ describe("sql emits job_id on failure", () => {
     expect(json.job_id).toBe(submittedJobId!)
   })
 })
+
+/**
+ * An intermediate statement of a multi-statement run now reports through the same helper as
+ * every other failure, so it gains what that helper does: job_id, the schema hint when one
+ * is available, ai_message, and timeMs on the telemetry record. Before this it had its own
+ * inline reporter and got none of them — which is what made the two failure paths drift.
+ *
+ * Pinned because the change is observable: a new stderr line for row formats, a new key for
+ * json, and one extra query on the failure path.
+ */
+describe("multi-statement intermediate failure", () => {
+  test("reports through the shared helper, carrying job_id", async () => {
+    stubSubmit(() => sqlFailure("CZLH-42000", "CZLH-42000:[1,8] Semantic analysis exception - cannot resolve column 'aaaa'"))
+
+    // Two statements: the FIRST fails, so it takes the intermediate path rather than
+    // executeSingle (which handles only the last one).
+    const result = await execute('sql "select aaaa from t1; select 1" --sync')
+    const json = firstJson(result.output)
+
+    expect(result.exitCode).toBe(1)
+    expect(json.error?.code).toBe("CZLH-42000")
+    expect(json.job_id).toBe(submittedJobId!)
+  })
+})

--- a/packages/cz-cli/test/tui-quota-data.test.ts
+++ b/packages/cz-cli/test/tui-quota-data.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, test } from "bun:test"
-import { writeFileSync } from "node:fs"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { onFetch, onPath } from "./support/fetch-boundary"
 import { requireTestHome } from "./support/cz-fixtures"
 import { clearTokenCache } from "@clickzetta/sdk"
 import { setActiveModel, writeLlmEntries } from "../src/llm/native-config"
+import { CLICKZETTA_DEFAULT_GATEWAY_URL } from "../src/llm/clickzetta-provider"
+import { gatewayQuotaCacheKey, recordGatewayQuota, type ClickzettaQuota } from "../src/llm/gateway-error"
 import {
   centralPortalHost,
   clearUnservedHostForTest,
@@ -12,8 +14,7 @@ import {
   fetchProfileUserName,
   fetchQuotaSnapshot,
   isPortalOk,
-  maskApiKey,
-  matchKeyUsage,
+  readHeaderQuota,
   readProfileInfo,
   readRecentProviders,
   resolveClickzettaEntry,
@@ -95,48 +96,9 @@ function stubPortal() {
           data: { id: dev ? 4 : 2, accountId: dev ? 112407 : 228044, name: dev ? "wynptmks" : "pdiaxzjq", instanceId: 1 },
         }
       }
-      if (url.includes("/user/listApiKeys")) {
-        const userName = new URL(url).searchParams.get("userName")
-        if (userName !== (dev ? "wynptmks" : "pdiaxzjq")) throw new Error(`wrong userName ${userName}`)
-        return {
-          code,
-          data: dev
-            ? [
-                {
-                  id: 10018,
-                  status: 1,
-                  type: "free",
-                  rateLimitType: "quota_pdo",
-                  rateLimitValue: 10_000_000,
-                  usage: 0,
-                  vapiKeyAlias: "cz-code_auto_wynptmks",
-                  vapiKeyMasked: "dfce****18e4",
-                },
-              ]
-            : [
-                {
-                  id: 1256,
-                  status: 1,
-                  type: "standard",
-                  rateLimitType: "quota_total",
-                  rateLimitValue: 10_000_000,
-                  usage: 68_131,
-                  vapiKeyAlias: "my-key",
-                  vapiKeyMasked: "9367****a9cf",
-                },
-                {
-                  id: 587,
-                  status: 1,
-                  type: "free",
-                  rateLimitType: "quota_total",
-                  rateLimitValue: 10_000_000,
-                  usage: 10_082_801,
-                  vapiKeyAlias: "cz-code_auto_pdiaxzjq",
-                  vapiKeyMasked: "ff52****9bc8",
-                },
-              ],
-        }
-      }
+      // listApiKeys is deliberately NOT stubbed: the token quota now comes from the
+      // gateway's response headers, and any call to this route would be a regression
+      // back to the retired portal poll. Reaching the throw below is the assertion.
       throw new Error(`unexpected portal path ${url}`)
     },
   })
@@ -156,6 +118,9 @@ beforeEach(() => {
   clearUnservedHostForTest()
   // Same reasoning as above, for fetchProfileUserName's per-profile name cache.
   clearUserNameCacheForTest()
+  // The header-quota cache is a file under the same test home, so a reading left by
+  // one test would otherwise answer another test's "nothing recorded" case.
+  rmSync(join(requireTestHome(), ".clickzetta", "gateway-quota.json"), { force: true })
 })
 
 describe("isPortalOk", () => {
@@ -167,62 +132,6 @@ describe("isPortalOk", () => {
 
   test("rejects business error codes", () => {
     for (const code of [500, 8888, "7777", undefined, null]) expect(isPortalOk(code)).toBe(false)
-  })
-})
-
-describe("maskApiKey", () => {
-  test("produces the portal's masked form", () => {
-    expect(maskApiKey(PROD_KEY)).toBe("ff52****9bc8")
-  })
-
-  test("declines to mask a key too short to disambiguate", () => {
-    expect(maskApiKey("abc")).toBeUndefined()
-  })
-})
-
-describe("matchKeyUsage", () => {
-  const payload = {
-    code: 0,
-    data: [
-      {
-        rateLimitType: "quota_total",
-        rateLimitValue: 10_000_000,
-        usage: 68_131,
-        vapiKeyAlias: "my-key",
-        vapiKeyMasked: "9367****a9cf",
-      },
-      {
-        rateLimitType: "quota_pdo",
-        rateLimitValue: 1_000,
-        usage: 7,
-        vapiKeyAlias: "free",
-        vapiKeyMasked: "ff52****9bc8",
-      },
-    ],
-  }
-
-  test("picks the entry matching the active key, not merely the first", () => {
-    expect(matchKeyUsage(payload, PROD_KEY)).toEqual({ used: 7, limit: 1_000, period: "daily", alias: "free" })
-  })
-
-  test("returns nothing when no key matches", () => {
-    expect(matchKeyUsage(payload, "0000aaaaaaaaaaaaaaaaaaaaaaaa0000")).toEqual({})
-  })
-
-  // The gateway-admin route spells it vApiKeyMasked; accept both so a caller
-  // switching sources doesn't silently stop matching.
-  test("accepts the gateway-admin capitalisation", () => {
-    const admin = {
-      data: [
-        { rateLimitType: "quota_total", rateLimitValue: 5, usage: 1, vApiKeyAlias: "a", vApiKeyMasked: "ff52****9bc8" },
-      ],
-    }
-    expect(matchKeyUsage(admin, PROD_KEY)).toEqual({ used: 1, limit: 5, period: "total", alias: "a" })
-  })
-
-  test("tolerates a malformed payload", () => {
-    expect(matchKeyUsage(undefined, PROD_KEY)).toEqual({})
-    expect(matchKeyUsage({ code: 0, data: null }, PROD_KEY)).toEqual({})
   })
 })
 
@@ -364,35 +273,25 @@ describe("readRecentProviders", () => {
 })
 
 describe("fetchQuotaSnapshot", () => {
-  test("reports current Profile balance and the selected LLM key's usage independently", async () => {
+  test("reports the current Profile's balance", async () => {
     stubPortal()
-    const snapshot = await fetchQuotaSnapshot({ providerID: "prod_0" })
-    expect(snapshot).toEqual({
-      cash: 0,
-      owe: 0,
-      used: 10_082_801,
-      limit: 10_000_000,
-      period: "total",
-      alias: "cz-code_auto_pdiaxzjq",
-    })
+    expect(await fetchQuotaSnapshot({ providerID: "prod_0" })).toEqual({ cash: 0, owe: 0 })
   })
 
-  test("finds an LLM key even when no same-named Profile exists", async () => {
+  /**
+   * The balance belongs to the current Profile and to nothing else. This used to walk
+   * every configured Profile hunting the portal that knew the selected virtual key —
+   * a search that existed only for the token quota, which now arrives on the
+   * gateway's own response headers. One Profile, one read.
+   */
+  test("reads only the current Profile, whatever LLM entry is selected", async () => {
     const seen = stubPortal()
-    const snapshot = await fetchQuotaSnapshot({ providerID: "cc-sh" })
+    await fetchQuotaSnapshot({ providerID: "prod_0" })
     expect(seen.some((url) => url.includes("dev-api.clickzetta.com"))).toBe(true)
-    expect(seen.some((url) => url.includes("cn-shanghai-alicloud.api.clickzetta.com"))).toBe(true)
-    expect(snapshot).toMatchObject({ cash: 0, alias: "cz-code_auto_pdiaxzjq", used: 10_082_801 })
-  })
-
-  test("handles the dev portal's 200 success code and daily window", async () => {
-    const seen = stubPortal()
-    const snapshot = await fetchQuotaSnapshot({ providerID: "dev_0" })
-    expect(snapshot).toMatchObject({ cash: 0, used: 0, limit: 10_000_000, period: "daily" })
     expect(seen.some((url) => url.includes("cn-shanghai-alicloud.api.clickzetta.com"))).toBe(false)
   })
 
-  test("honors CZ_PROFILE for balance without changing which LLM key is measured", async () => {
+  test("honors CZ_PROFILE for which account's balance is read", async () => {
     const previous = {
       profile: process.env.CZ_PROFILE,
       service: process.env.CZ_SERVICE,
@@ -403,10 +302,8 @@ describe("fetchQuotaSnapshot", () => {
     process.env.CZ_INSTANCE = "inst-prod"
     try {
       const seen = stubPortal()
-      const snapshot = await fetchQuotaSnapshot({ providerID: "dev_0" })
-      expect(seen.some((url) => url.includes("dev-api.clickzetta.com"))).toBe(true)
+      expect(await fetchQuotaSnapshot({ providerID: "dev_0" })).toMatchObject({ cash: 51.2772 })
       expect(seen.some((url) => url.includes("cn-shanghai-alicloud.api.clickzetta.com"))).toBe(true)
-      expect(snapshot).toMatchObject({ cash: 51.2772, alias: "cz-code_auto_wynptmks", used: 0 })
     } finally {
       for (const [key, value] of [
         ["CZ_PROFILE", previous.profile],
@@ -416,6 +313,34 @@ describe("fetchQuotaSnapshot", () => {
         if (value === undefined) delete process.env[key]
         else process.env[key] = value
       }
+    }
+  })
+
+  /**
+   * A `current` that names a profile absent from profiles.toml — stale CZ_PROFILE, or a
+   * default_profile pointing at a deleted profile — must not fall back to whichever
+   * profile happens to be first in the file: that paints ANOTHER TENANT'S cash balance
+   * under the user's own Profile section, which readProfileInfo (same file) already
+   * refuses to do for the identity rows. No request either — there is no account to ask
+   * about.
+   */
+  test("a current profile absent from the file reports no balance, and sends no request", async () => {
+    const previous = process.env.CZ_PROFILE
+    process.env.CZ_PROFILE = "deleted_profile"
+    try {
+      const seen: string[] = []
+      onFetch({
+        match: (url) => {
+          seen.push(url)
+          return false
+        },
+        respond: () => ({}),
+      })
+      expect(await fetchQuotaSnapshot({ providerID: "prod_0" })).toEqual({})
+      expect(seen).toEqual([])
+    } finally {
+      if (previous === undefined) delete process.env.CZ_PROFILE
+      else process.env.CZ_PROFILE = previous
     }
   })
 
@@ -432,103 +357,84 @@ describe("fetchQuotaSnapshot", () => {
     expect(seen).toEqual([])
   })
 
-  // Independent reads: an account with no billing record still has a usable quota.
-  test("still reports quota when the billing read fails", async () => {
+  // A rejection is what tells the caller to keep the last good reading instead of
+  // replacing it with an empty one.
+  test("throws when the billing read fails", async () => {
     onFetch({
       match: (url) => url.includes("/hornhub/account/billing/"),
       respond: () => new Response("nope", { status: 500 }),
     })
     stubPortal()
-    const snapshot = await fetchQuotaSnapshot({ providerID: "prod_0" })
-    expect(snapshot?.cash).toBeUndefined()
-    expect(snapshot?.used).toBe(10_082_801)
-  })
-
-  test("still reports balance when the key listing fails", async () => {
-    onFetch({
-      match: (url) => url.includes("/user/listApiKeys"),
-      respond: () => new Response("nope", { status: 500 }),
-    })
-    stubPortal()
-    const snapshot = await fetchQuotaSnapshot({ providerID: "prod_0" })
-    expect(snapshot?.cash).toBe(0)
-    expect(snapshot?.used).toBeUndefined()
-  })
-
-  // A total outage must surface as a rejection so the caller keeps the last good
-  // reading instead of replacing it with an empty one.
-  test("throws when both reads fail", async () => {
-    onPath("/clickzetta-portal/user/loginSingle", () => ({
-      code: 0,
-      data: { token: "portal-token", instanceId: 1, userId: 2, expireTime: 3_600_000 },
-    }))
-    onFetch({
-      match: (url) => url.includes("/clickzetta-portal/"),
-      respond: () => new Response("nope", { status: 503 }),
-    })
     await expect(fetchQuotaSnapshot({ providerID: "prod_0" })).rejects.toThrow()
+  })
+
+  /**
+   * A profile with no account_id can never name whose balance to read. Resolving to
+   * nothing is right; throwing would make the caller pin the previous profile's
+   * balance — someone else's money — for the rest of the session.
+   */
+  /**
+   * Nothing pinned at all — no CZ_PROFILE, no default_profile — is the one input where the
+   * old code showed no balance: it gated billing on `name === current`, and with `current`
+   * undefined that was false for every profile. Now the first TOML profile's balance is
+   * read, which is deliberate: readProfileInfo already names that same profile as the
+   * session's identity, so a figure beside it belongs to the account being shown. Pinned
+   * here because it is the one place old and new differ.
+   */
+  test("with nothing pinned, the first profile's balance is read", async () => {
+    const previous = process.env.CZ_PROFILE
+    delete process.env.CZ_PROFILE
+    writeFileSync(
+      join(requireTestHome(), ".clickzetta", "profiles.toml"),
+      [
+        "[profiles.first]",
+        "pat = 'pat-first'",
+        "service = 'dev-api.clickzetta.com'",
+        "instance = 'i'",
+        "account_id = 112407",
+        "",
+      ].join("\n"),
+    )
+    try {
+      const seen = stubPortal()
+      expect(await fetchQuotaSnapshot({ providerID: "prod_0" })).toMatchObject({ cash: 0 })
+      expect(seen.some((url) => url.includes("dev-api.clickzetta.com"))).toBe(true)
+    } finally {
+      if (previous === undefined) delete process.env.CZ_PROFILE
+      else process.env.CZ_PROFILE = previous
+    }
+  })
+
+  test("resolves to nothing, without a request, when the profile has no account_id", async () => {
+    writeFileSync(
+      join(requireTestHome(), ".clickzetta", "profiles.toml"),
+      ["default_profile = 'bare'", "", "[profiles.bare]", "pat = 'pat-bare'", "service = 'dev-api.clickzetta.com'", "instance = 'i'", ""].join("\n"),
+    )
+    const seen = stubPortal()
+    expect(await fetchQuotaSnapshot({ providerID: "prod_0" })).toEqual({})
+    expect(seen).toEqual([])
   })
 })
 
-// The live portal is method-sensitive and inverts what the URLs imply:
-// getCurrentUser only answers to POST, while listApiKeys and the billing route
-// only answer to GET; the wrong verb yields code 8888 with data:null. The
-// original stubPortal ignores method, so it could not catch a read issued with
-// the wrong verb — the exact defect that left the quota indicator blank.
+// The live portal is method-sensitive and inverts what the URLs imply: getCurrentUser
+// only answers to POST while the billing route only answers to GET; the wrong verb
+// yields code 8888 with data:null. stubPortal ignores method, so it cannot catch a
+// read issued with the wrong verb — the exact defect that left the indicator blank.
 describe("fetchQuotaSnapshot — portal method sensitivity", () => {
-  function stubMethodStrictPortal(opts: { currentUserPostFails?: boolean } = {}) {
+  test("reads billing with the verb it requires", async () => {
     onPath("/clickzetta-portal/user/loginSingle", () => ({
       code: 0,
       data: { token: "portal-token", instanceId: 1, userId: 2, expireTime: 3_600_000 },
     }))
-    const err8888 = { code: 8888, message: "unknown error", data: null }
     onFetch({
       match: (url) => url.includes("/clickzetta-portal/"),
       respond: (url, method) => {
-        if (url.includes("/user/getCurrentUser")) {
-          if (method !== "POST") return err8888
-          if (opts.currentUserPostFails) return err8888
-          return { code: 0, data: { id: 2, accountId: 228044, name: "pdiaxzjq", instanceId: 1 } }
-        }
-        if (url.includes("/hornhub/account/billing/account/")) {
-          if (method !== "GET") return err8888
-          return { code: 0, data: { cashAmount: 51.2772, oweAmount: 0, accountName: "pdiaxzjq" } }
-        }
-        if (url.includes("/user/listApiKeys")) {
-          if (method !== "GET") return err8888
-          return {
-            code: 0,
-            data: [
-              {
-                id: 587,
-                status: 1,
-                type: "free",
-                rateLimitType: "quota_total",
-                rateLimitValue: 10_000_000,
-                usage: 10_082_801,
-                vapiKeyAlias: "cz-code_auto_pdiaxzjq",
-                vapiKeyMasked: "ff52****9bc8",
-              },
-            ],
-          }
-        }
-        throw new Error(`unexpected portal path ${url}`)
+        if (!url.includes("/hornhub/account/billing/account/")) throw new Error(`unexpected portal path ${url}`)
+        if (method !== "GET") return { code: 8888, message: "unknown error", data: null }
+        return { code: 0, data: { cashAmount: 51.2772, oweAmount: 0, accountName: "pdiaxzjq" } }
       },
     })
-  }
-
-  test("resolves usage when each endpoint is called with the verb it requires", async () => {
-    stubMethodStrictPortal()
-    const snapshot = await fetchQuotaSnapshot({ providerID: "prod_0" })
-    expect(snapshot).toMatchObject({ used: 10_082_801, limit: 10_000_000, period: "total" })
-  })
-
-  // listApiKeys scopes to the token identity and ignores the userName value, so
-  // a failed getCurrentUser must not sink the whole quota read.
-  test("falls back to an empty userName when getCurrentUser fails", async () => {
-    stubMethodStrictPortal({ currentUserPostFails: true })
-    const snapshot = await fetchQuotaSnapshot({ providerID: "prod_0" })
-    expect(snapshot).toMatchObject({ used: 10_082_801, limit: 10_000_000 })
+    expect(await fetchQuotaSnapshot({ providerID: "prod_0" })).toMatchObject({ cash: 51.2772 })
   })
 })
 
@@ -545,20 +451,14 @@ describe("balance survives an unresolvable LLM entry", () => {
     // key can be named. Pre-fix this returned undefined and skipped every read.
     setActiveModel("")
     stubPortal()
-    const snapshot = await fetchQuotaSnapshot({})
-    expect(snapshot).toMatchObject({ cash: 0 })
-    // Quota is genuinely unknowable here — absent, not guessed from another tenant.
-    expect(snapshot?.used).toBeUndefined()
-    expect(snapshot?.limit).toBeUndefined()
+    expect(await fetchQuotaSnapshot({})).toMatchObject({ cash: 0 })
   })
 
   test("reports the balance when the pinned ClickZetta entry has no api_key", async () => {
     writeLlmEntries({ llm: { keyless: { provider: "clickzetta", base_url: "https://aimesh.example.com/gateway/v1" } } })
     setActiveModel("keyless/deepseek-v3.2")
     stubPortal()
-    const snapshot = await fetchQuotaSnapshot({})
-    expect(snapshot).toMatchObject({ cash: 0 })
-    expect(snapshot?.used).toBeUndefined()
+    expect(await fetchQuotaSnapshot({})).toMatchObject({ cash: 0 })
   })
 
   // The one case that SHOULD hide everything: a ¥ figure next to a Claude model
@@ -574,27 +474,126 @@ describe("balance survives an unresolvable LLM entry", () => {
     stubPortal()
     expect(await fetchQuotaSnapshot({})).toBeUndefined()
   })
+})
+
+/**
+ * The token half. No portal, no network, no credentials — just what the gateway
+ * already told the provider, read back out of ~/.clickzetta/gateway-quota.json.
+ */
+/**
+ * Write the cache directly so both `updated_at` and the `now` it is read against are
+ * fixed. recordGatewayQuota stamps the real clock, which cannot express "taken at 23:00
+ * and read at 04:00" — the gap the reset rule exists for.
+ */
+function seedQuotaCache(input: { baseURL: string; apiKey: string; updatedAt: number; quotas: ClickzettaQuota[] }) {
+  const home = requireTestHome()
+  mkdirSync(join(home, ".clickzetta"), { recursive: true })
+  writeFileSync(
+    join(home, ".clickzetta", "gateway-quota.json"),
+    JSON.stringify({
+      entries: { [gatewayQuotaCacheKey(input.baseURL, input.apiKey)]: { updated_at: input.updatedAt, quotas: input.quotas } },
+    }),
+    "utf-8",
+  )
+}
+
+/** 23:00 local on an arbitrary fixed day, and 04:00 the next morning — five hours apart. */
+const BEFORE_RESET = new Date(2026, 5, 15, 23, 0, 0).getTime()
+const AFTER_RESET = new Date(2026, 5, 16, 4, 0, 0).getTime()
+
+const DAILY = { period: "daily" as const, periodCode: "PDO", limit: 10_000_000, used: 9_999_000, remaining: 1_000, scope: "api-key" }
+const TOTAL = { period: "total" as const, periodCode: "PTO", limit: 1_000_000_000, used: 21_306_417, remaining: 978_693_583, scope: "api-key" }
+
+describe("readHeaderQuota", () => {
+  const QUOTAS = [
+    { period: "daily" as const, periodCode: "PDO", limit: 10_000_000, used: 238, remaining: 9_999_762, scope: "api-key" },
+  ]
+
+  test("reads back what the provider recorded for the selected entry", () => {
+    recordGatewayQuota({ baseURL: "https://aimesh.example.com/gateway/v1", apiKey: PROD_KEY, quotas: QUOTAS })
+    expect(readHeaderQuota("prod_0")).toEqual(QUOTAS)
+  })
 
   /**
-   * Walking past the current profile only serves the quota hunt (finding the portal
-   * that knows this key). With no key there is nothing to hunt, and continuing hides
-   * failures: a later profile's empty-but-successful snapshot lands in `loaded` and
-   * swallows the current profile's real error, so a broken balance read renders as a
-   * silent blank indistinguishable from "nothing to show". Caught on a live config
-   * where the default profile's host was unreachable and the result was `{}`.
+   * llm.json may hold the endpoint in its bare form (`https://host/`) while the
+   * provider recorded against the normalized `/gateway/v1` one. Both sides run the
+   * same normalizer, so the two still meet — without this the indicator silently
+   * reported nothing for every entry written by `agent llm add`.
    */
-  test("surfaces the balance error instead of masking it with another profile", async () => {
-    // dev_0 is the default profile; make only ITS billing read fail. prod_0 would
-    // otherwise answer successfully and hide it.
-    onFetch({
-      match: (url) => url.includes("dev-api.clickzetta.com") && url.includes("/hornhub/account/billing/"),
-      respond: () => {
-        throw new Error("billing unreachable")
-      },
+  test("an un-normalized base_url resolves to the same reading", () => {
+    writeLlmEntries({
+      llm: { prod_0: { provider: "clickzetta", api_key: PROD_KEY, base_url: "https://aimesh.example.com/" } },
     })
-    stubPortal()
-    setActiveModel("")
-    await expect(fetchQuotaSnapshot({})).rejects.toThrow("billing unreachable")
+    recordGatewayQuota({ baseURL: "https://aimesh.example.com/gateway/v1", apiKey: PROD_KEY, quotas: QUOTAS })
+    expect(readHeaderQuota("prod_0")).toEqual(QUOTAS)
+  })
+
+  test("the reading is per key, so another entry's quota is not borrowed", () => {
+    recordGatewayQuota({ baseURL: "https://aimesh.example.com/gateway/v1", apiKey: PROD_KEY, quotas: QUOTAS })
+    expect(readHeaderQuota("dev_0")).toBeUndefined()
+  })
+
+  /**
+   * A daily figure from before the reset is worse than no figure: it reports yesterday's
+   * near-exhausted spend against today's fresh limit, i.e. "you are out" to a user who
+   * has a full day. A duration bound cannot catch this — 23:00 to 04:00 is five hours.
+   */
+  test("a daily reading taken before the reset is dropped, a total one survives it", () => {
+    seedQuotaCache({
+      baseURL: "https://aimesh.example.com/gateway/v1",
+      apiKey: PROD_KEY,
+      updatedAt: BEFORE_RESET,
+      quotas: [DAILY, TOTAL],
+    })
+    expect(readHeaderQuota("prod_0", AFTER_RESET)?.map((quota) => quota.period)).toEqual(["total"])
+  })
+
+  test("both periods survive a five-hour gap inside one day", () => {
+    seedQuotaCache({
+      baseURL: "https://aimesh.example.com/gateway/v1",
+      apiKey: PROD_KEY,
+      updatedAt: new Date(2026, 5, 16, 9, 0, 0).getTime(),
+      quotas: [DAILY, TOTAL],
+    })
+    expect(readHeaderQuota("prod_0", new Date(2026, 5, 16, 14, 0, 0).getTime())?.map((quota) => quota.period)).toEqual([
+      "daily",
+      "total",
+    ])
+  })
+
+  test("a reading past the coarse ceiling is gone whatever its period", () => {
+    seedQuotaCache({
+      baseURL: "https://aimesh.example.com/gateway/v1",
+      apiKey: PROD_KEY,
+      updatedAt: BEFORE_RESET,
+      quotas: [TOTAL],
+    })
+    expect(readHeaderQuota("prod_0", BEFORE_RESET + 7 * 60 * 60 * 1000)).toBeUndefined()
+  })
+
+  test("nothing recorded reads as nothing, not zero", () => {
+    expect(readHeaderQuota("prod_0")).toBeUndefined()
+  })
+
+  // A gateway that sends no quota headers, a foreign provider, and an entry with no
+  // base_url all reduce to the same "no token rows" outcome.
+  test("resolves to nothing for a foreign provider", () => {
+    recordGatewayQuota({ baseURL: "https://aimesh.example.com/gateway/v1", apiKey: PROD_KEY, quotas: QUOTAS })
+    expect(readHeaderQuota("claude")).toBeUndefined()
+  })
+
+  /**
+   * An entry with no base_url still reaches a gateway — providerFromInput fills the absent
+   * baseURL with the default, so the provider files its reading under THAT endpoint's key.
+   * The reader has to apply the same default or it looks in the wrong place and the token
+   * rows stay blank on an entry that demonstrably works.
+   */
+  test("an entry with no base_url finds the reading filed under the default endpoint", () => {
+    writeLlmEntries({ llm: { bare: { provider: "clickzetta", api_key: PROD_KEY } } })
+    setActiveModel("bare/whatever")
+    expect(readHeaderQuota()).toBeUndefined()
+    recordGatewayQuota({ baseURL: CLICKZETTA_DEFAULT_GATEWAY_URL, apiKey: PROD_KEY, quotas: QUOTAS })
+    expect(readHeaderQuota()?.map((quota) => quota.periodCode)).toEqual(QUOTAS.map((quota) => quota.periodCode))
   })
 })
 
@@ -811,7 +810,6 @@ describe("portal reads fall back to the central host", () => {
         if (url.includes("/hornhub/account/billing/account/")) {
           return { code: 0, data: { cashAmount: 12.5, oweAmount: 0 } }
         }
-        if (url.includes("/user/listApiKeys")) return { code: 0, data: [] }
         if (url.includes("/user/getCurrentUser")) return { code: 0, data: { name: "who" } }
         throw new Error(`unexpected portal path ${url}`)
       },
@@ -845,7 +843,6 @@ describe("portal reads fall back to the central host", () => {
         if (url.includes("/hornhub/account/billing/account/")) {
           return { code: 0, data: { cashAmount: 7, oweAmount: 0 } }
         }
-        if (url.includes("/user/listApiKeys")) return { code: 0, data: [] }
         if (url.includes("/user/getCurrentUser")) return { code: 0, data: { name: "who" } }
         throw new Error(`unexpected portal path ${url}`)
       },
@@ -918,14 +915,6 @@ describe("portal reads fall back to the central host", () => {
         if (url.includes("/hornhub/account/billing/account/")) {
           return { code: 0, data: { cashAmount: 12.5, oweAmount: 0 } }
         }
-        // A key matching PROD_KEY, so the scan stops at prod_0 (usage found) rather
-        // than continuing to dev_0's host and polluting `seen` with an unrelated call.
-        if (url.includes("/user/listApiKeys")) {
-          return {
-            code: 0,
-            data: [{ rateLimitType: "quota_total", rateLimitValue: 10_000_000, usage: 0, vapiKeyMasked: "ff52****9bc8" }],
-          }
-        }
         if (url.includes("/user/getCurrentUser")) return { code: 0, data: { name: "who" } }
         throw new Error(`unexpected portal path ${url}`)
       },
@@ -969,12 +958,6 @@ describe("portal reads fall back to the central host", () => {
         if (url.includes("/hornhub/account/billing/account/")) {
           return { code: 0, data: { cashAmount: 12.5, oweAmount: 0 } }
         }
-        if (url.includes("/user/listApiKeys")) {
-          return {
-            code: 0,
-            data: [{ rateLimitType: "quota_total", rateLimitValue: 10_000_000, usage: 0, vapiKeyMasked: "ff52****9bc8" }],
-          }
-        }
         if (url.includes("/user/getCurrentUser")) return { code: 0, data: { name: "who" } }
         throw new Error(`unexpected portal path ${url}`)
       },
@@ -986,7 +969,9 @@ describe("portal reads fall back to the central host", () => {
       await fetchQuotaSnapshot({ providerID: "prod_0" }) // one failure, then the direct retry (region host) succeeds
       seen.length = 0
       await fetchQuotaSnapshot({ providerID: "prod_0" }) // must still try the region host — one strike, not two
-      expect(seen.some((url) => url.includes("cn-shanghai-alicloud.api.clickzetta.com") && url.includes("/user/listApiKeys"))).toBe(true)
+      expect(
+        seen.some((url) => url.includes("cn-shanghai-alicloud.api.clickzetta.com") && url.includes("/hornhub/account/billing/")),
+      ).toBe(true)
     } finally {
       if (previous === undefined) delete process.env.CZ_PROFILE
       else process.env.CZ_PROFILE = previous
@@ -994,9 +979,10 @@ describe("portal reads fall back to the central host", () => {
   })
 
   // unservedHost is keyed by baseUrl + path, not by host alone: a region host
-  // that fails ONE route (listApiKeys, business code 8888) must not stop being
-  // asked for a DIFFERENT route (getCurrentUser) it actually serves. A host-wide
-  // key would make the first failure redirect every later call for every route.
+  // that fails ONE route (the billing account read, business code 8888) must not
+  // stop being asked for a DIFFERENT route (getCurrentUser) it actually serves. A
+  // host-wide key would make the first failure redirect every later call for every
+  // route.
   test("marking one route unserved does not redirect a different route on the same host", async () => {
     const seen: string[] = []
     onPath("/clickzetta-portal/user/loginSingle", () => ({
@@ -1007,17 +993,11 @@ describe("portal reads fall back to the central host", () => {
       match: (url) => url.includes("/clickzetta-portal/"),
       respond: (url) => {
         seen.push(url)
-        if (url.includes("cn-shanghai-alicloud.api.clickzetta.com") && url.includes("/user/listApiKeys")) {
+        if (url.includes("cn-shanghai-alicloud.api.clickzetta.com") && url.includes("/hornhub/account/billing/")) {
           return { code: 8888, message: "未知异常", data: null }
         }
         if (url.includes("/hornhub/account/billing/account/")) {
           return { code: 0, data: { cashAmount: 12.5, oweAmount: 0 } }
-        }
-        if (url.includes("/user/listApiKeys")) {
-          return {
-            code: 0,
-            data: [{ rateLimitType: "quota_total", rateLimitValue: 10_000_000, usage: 0, vapiKeyMasked: "ff52****9bc8" }],
-          }
         }
         if (url.includes("/user/getCurrentUser")) return { code: 0, data: { name: "who" } }
         throw new Error(`unexpected portal path ${url}`)
@@ -1027,7 +1007,7 @@ describe("portal reads fall back to the central host", () => {
     const previous = process.env.CZ_PROFILE
     process.env.CZ_PROFILE = "prod_0"
     try {
-      // First call: listApiKeys against the region host fails (8888), promotes
+      // First call: the billing read against the region host fails (8888), promotes
       // that ROUTE to unserved and falls back to central for it.
       await fetchQuotaSnapshot({ providerID: "prod_0" })
 

--- a/packages/cz-cli/test/tui-quota-format.test.ts
+++ b/packages/cz-cli/test/tui-quota-format.test.ts
@@ -10,12 +10,20 @@ import {
   quotaTone,
   remainingRatio,
 } from "../src/opencode-plugin/tui-quota-format"
+import type { ClickzettaQuota } from "../src/llm/gateway-error"
 
 describe("abbreviate", () => {
   test("abbreviates millions and thousands like the prompt's context counter", () => {
     expect(abbreviate(10_082_801)).toBe("10.1M")
     expect(abbreviate(10_000_000)).toBe("10.0M")
     expect(abbreviate(1_500)).toBe("1.5K")
+  })
+
+  /** Header-reported lifetime (PTO) ceilings run to 1e9+, where an M tier reads badly. */
+  test("abbreviates billions rather than emitting a four-digit M", () => {
+    expect(abbreviate(1_000_000_000)).toBe("1.0B")
+    expect(abbreviate(978_693_583)).toBe("978.7M")
+    expect(abbreviate(21_306_417_000)).toBe("21.3B")
   })
 
   test("leaves small counts exact", () => {
@@ -156,9 +164,14 @@ describe("profileRows", () => {
   })
 })
 
+/** A quota as the gateway's headers report it, which is what the snapshot now carries. */
+function quota(input: Partial<ClickzettaQuota> & { used: number; limit: number }): ClickzettaQuota {
+  return { periodCode: "PTO", period: "total", scope: "api-key", ...input }
+}
+
 describe("quotaRows", () => {
   test("renders balance, used/total and remaining for a healthy account", () => {
-    expect(quotaRows({ cash: 51.2772, owe: 0, used: 1_000_000, limit: 10_000_000, period: "total" })).toEqual([
+    expect(quotaRows({ cash: 51.2772, owe: 0, quotas: [quota({ used: 1_000_000, limit: 10_000_000 })] })).toEqual([
       { text: "¥51.28 balance", tone: "textMuted" },
       { text: "1.0M / 10.0M tokens", tone: "textMuted" },
       { text: "90% left", tone: "textMuted" },
@@ -166,21 +179,85 @@ describe("quotaRows", () => {
   })
 
   test("marks an over-quota key red while keeping both numbers visible", () => {
-    expect(quotaRows({ cash: 51.2772, used: 10_082_801, limit: 10_000_000, period: "total" }).slice(1)).toEqual([
+    expect(
+      quotaRows({ cash: 51.2772, quotas: [quota({ used: 10_082_801, limit: 10_000_000 })] }).slice(1),
+    ).toEqual([
       { text: "10.1M / 10.0M tokens", tone: "error" },
       { text: "0% left", tone: "error" },
     ])
   })
 
   test("distinguishes a daily cap from a lifetime one", () => {
-    expect(quotaRows({ used: 0, limit: 10_000_000, period: "daily" })[0]).toEqual({
-      text: "0 / 10.0M tokens today",
-      tone: "textMuted",
-    })
-    expect(quotaRows({ used: 0, limit: 10_000_000, period: "total" })[0]).toEqual({
+    expect(quotaRows({ quotas: [quota({ used: 0, limit: 10_000_000, period: "daily", periodCode: "PDO" })] })).toEqual([
+      { text: "0 / 10.0M tokens today", tone: "textMuted" },
+      { text: "100% left today", tone: "textMuted" },
+    ])
+    expect(quotaRows({ quotas: [quota({ used: 0, limit: 10_000_000 })] })[0]).toEqual({
       text: "0 / 10.0M tokens",
       tone: "textMuted",
     })
+  })
+
+  /**
+   * The reason the snapshot carries a list instead of one period: a key can cap a
+   * lifetime grant and a daily rate at once, and the binding one is whichever runs
+   * out first. Showing only one would hide the limit actually about to stop the user,
+   * so both are rendered — shortest window first, and each labelled, or two bare
+   * "N% left" rows would be unattributable.
+   */
+  test("renders every configured period, shortest window first", () => {
+    expect(
+      quotaRows({
+        quotas: [
+          quota({ used: 21_306_657, limit: 1_000_000_000 }),
+          quota({ used: 875, limit: 1_000, period: "daily", periodCode: "PDO" }),
+        ],
+      }),
+    ).toEqual([
+      { text: "875 / 1.0K tokens today", tone: "warning" },
+      { text: "12% left today", tone: "warning" },
+      { text: "21.3M / 1.0B tokens", tone: "textMuted" },
+      { text: "97% left", tone: "textMuted" },
+    ])
+  })
+
+  /**
+   * parseClickzettaQuota captures whatever limiter the header named, so a deployment can
+   * report a tenant-wide cap next to the key's own. Unnamed, the two produce identical
+   * rows in header order and the user cannot tell which ceiling binds.
+   */
+  test("names the scope only when more than one limiter reports", () => {
+    expect(
+      quotaRows({
+        quotas: [
+          quota({ used: 3, limit: 4, period: "daily", periodCode: "PDO", scope: "tenant" }),
+          quota({ used: 1, limit: 4, period: "daily", periodCode: "PDO", scope: "api-key" }),
+        ],
+      }).map((row) => row.text),
+    ).toEqual([
+      "1 / 4 tokens today (api-key)",
+      "75% left today (api-key)",
+      "3 / 4 tokens today (tenant)",
+      "25% left today (tenant)",
+    ])
+  })
+
+  test("a single limiter keeps the rows unqualified", () => {
+    expect(
+      quotaRows({ quotas: [quota({ used: 1, limit: 4, period: "daily", periodCode: "PDO" })] }).map((row) => row.text),
+    ).toEqual(["1 / 4 tokens today", "75% left today"])
+  })
+
+  /** An unrecognised period code still reports its numbers, just without a phrase. */
+  test("an unmapped period sorts last and renders unlabelled", () => {
+    expect(
+      quotaRows({
+        quotas: [
+          quota({ used: 1, limit: 10, period: undefined, periodCode: "PYO" }),
+          quota({ used: 2, limit: 10, period: "monthly", periodCode: "PMO" }),
+        ],
+      }).map((row) => row.text),
+    ).toEqual(["2 / 10 tokens this month", "80% left this month", "1 / 10 tokens", "90% left"])
   })
 
   // No rows means the renderer draws no section — better than a "Quota" heading
@@ -189,16 +266,23 @@ describe("quotaRows", () => {
     expect(quotaRows(undefined)).toEqual([])
   })
 
-  test("renders nothing when the key could not be matched and billing is absent", () => {
+  test("renders nothing when neither the gateway nor billing reported anything", () => {
     expect(quotaRows({})).toEqual([])
+    expect(quotaRows({ quotas: [] })).toEqual([])
   })
 
-  // The observed real case: balance resolves, the virtual key does not.
-  test("still shows the balance when the key could not be matched", () => {
+  // The observed real case: balance resolves, the gateway sends no quota headers
+  // (cn-shanghai-alicloud, as of 2026-09-01).
+  test("still shows the balance when the gateway reported no quota", () => {
     expect(quotaRows({ cash: 51.2772 })).toEqual([{ text: "¥51.28 balance", tone: "textMuted" }])
   })
 
-  test("omits the quota rows when the ceiling is unusable", () => {
-    expect(quotaRows({ cash: 1, used: 5, limit: 0 })).toEqual([{ text: "¥1.00 balance", tone: "warning" }])
+  test("omits a quota whose ceiling is unusable, or whose usage is unknown", () => {
+    expect(quotaRows({ cash: 1, quotas: [quota({ used: 5, limit: 0 })] })).toEqual([
+      { text: "¥1.00 balance", tone: "warning" },
+    ])
+    expect(quotaRows({ cash: 1, quotas: [{ periodCode: "PTO", period: "total", scope: "api-key", limit: 10 }] })).toEqual([
+      { text: "¥1.00 balance", tone: "warning" },
+    ])
   })
 })

--- a/packages/opencode/src/cli/cmd/run/footer.subagent.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.subagent.tsx
@@ -1,12 +1,14 @@
 /** @jsxImportSource @opentui/solid */
 import type { ScrollBoxRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/solid"
-import "opentui-spinner/solid"
+import { registerOpencodeSpinner } from "@opencode-ai/tui/component/register-spinner"
 import { Show, createMemo, indexArray } from "solid-js"
 import { SPINNER_FRAMES } from "@opencode-ai/tui/component/spinner"
 import { RunEntryContent, separatorRows } from "./scrollback.writer"
 import type { FooterSubagentDetail, FooterSubagentTab, RunDiffStyle } from "./types"
 import type { RunFooterTheme, RunTheme } from "./theme"
+
+registerOpencodeSpinner()
 
 export const SUBAGENT_INSPECTOR_ROWS = 14
 

--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -10,7 +10,7 @@
 /** @jsxImportSource @opentui/solid */
 import { useTerminalDimensions } from "@opentui/solid"
 import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
-import "opentui-spinner/solid"
+import { registerOpencodeSpinner } from "@opencode-ai/tui/component/register-spinner"
 import { createColors, createFrames } from "@opencode-ai/tui/ui/spinner"
 import {
   RUN_SUBAGENT_PANEL_ROWS,
@@ -55,6 +55,8 @@ import type {
 } from "./types"
 import type { RunTheme } from "./theme"
 import { modelInfo } from "./variant.shared"
+
+registerOpencodeSpinner()
 
 const EMPTY_BORDER = {
   topLeft: "",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -44,7 +44,8 @@
     "./ui/dialog": "./src/ui/dialog.tsx",
     "./ui/spinner": "./src/ui/spinner.ts",
     "./ui/toast": "./src/ui/toast.tsx",
-    "./component/spinner": "./src/component/spinner.tsx"
+    "./component/spinner": "./src/component/spinner.tsx",
+    "./component/register-spinner": "./src/component/register-spinner.ts"
   },
   "dependencies": {
     "@opencode-ai/core": "workspace:*",

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1,4 +1,5 @@
 import { render, TimeToFirstDraw, useRenderer, useTerminalDimensions } from "@opentui/solid"
+import { registerOpencodeSpinner } from "./component/register-spinner"
 import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
 import { Deferred, Effect } from "effect"
 import { Global } from "@opencode-ai/core/global"
@@ -83,6 +84,8 @@ import * as TuiAudio from "./audio"
 import { win32DisableProcessedInput, win32FlushInputBuffer } from "./terminal-win32"
 import { destroyRenderer } from "./util/renderer"
 import { cliErrorMessage, errorFormat } from "./util/error"
+
+registerOpencodeSpinner()
 
 const appGlobalBindingCommands = [
   "session.list",

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@opentui/core"
 import type { CommandContext } from "@opentui/keymap"
 import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
-import "opentui-spinner/solid"
+import { registerOpencodeSpinner } from "../register-spinner"
 import path from "path"
 import { fileURLToPath } from "url"
 //======================== cz-cli change ========================
@@ -69,6 +69,8 @@ import { useTuiConfig } from "../../config"
 import { usePromptWorkspace } from "./workspace"
 import { usePromptMove } from "./move"
 import { readLocalAttachment } from "./local-attachment"
+
+registerOpencodeSpinner()
 
 export type PromptProps = {
   sessionID?: string

--- a/packages/tui/src/component/register-spinner.ts
+++ b/packages/tui/src/component/register-spinner.ts
@@ -1,0 +1,6 @@
+import { getComponentCatalogue } from "@opentui/solid/components"
+import { registerSpinner } from "opentui-spinner/solid"
+
+export function registerOpencodeSpinner() {
+  if (!getComponentCatalogue().spinner) registerSpinner()
+}

--- a/packages/tui/src/component/spinner.tsx
+++ b/packages/tui/src/component/spinner.tsx
@@ -3,7 +3,9 @@ import { useTheme } from "../context/theme"
 import { useKV } from "../context/kv"
 import type { JSX } from "@opentui/solid"
 import type { RGBA } from "@opentui/core"
-import "opentui-spinner/solid"
+import { registerOpencodeSpinner } from "./register-spinner"
+
+registerOpencodeSpinner()
 
 export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 

--- a/scripts/cos-release.mjs
+++ b/scripts/cos-release.mjs
@@ -355,6 +355,7 @@ function renderShellPlatformCase(platforms) {
       ARCHIVE_NAME=${shellQuote(info.archive)}
       ARCHIVE_FORMAT=${shellQuote(info.format)}
       ARCHIVE_CHECKSUM=${shellQuote(info.checksum)}
+      DEFAULT_BINARY_NAME=${shellQuote(info.binary ?? platformBinary(platform))}
       ;;`,
     )
     .join("\n")
@@ -404,15 +405,22 @@ extract_zip() {
   if tar -xf "$1" -C "$2" 2>/dev/null; then
     return
   fi
-  if command -v powershell > /dev/null 2>&1 && command -v cygpath > /dev/null 2>&1; then
+  # \`powershell\` is the 5.1 stub; PowerShell 7 installs as \`pwsh\` and provides NO
+  # \`powershell\` alias, so probing only the old name made a pwsh-only host fall through to
+  # the error below even though Expand-Archive was right there.
+  PS_EXE=""
+  for candidate in powershell pwsh; do
+    if command -v "$candidate" > /dev/null 2>&1; then PS_EXE="$candidate"; break; fi
+  done
+  if [ -n "$PS_EXE" ] && command -v cygpath > /dev/null 2>&1; then
     # Both paths come from mktemp, which honours \$TMPDIR — so they are environment-supplied,
     # and a \`'\` in one would close the PowerShell single-quoted string early and let the
     # rest parse as commands. PowerShell escapes a literal quote by doubling it.
     PS_SRC=$(cygpath -w "$1" | sed "s/'/''/g")
     PS_DST=$(cygpath -w "$2" | sed "s/'/''/g")
-    powershell -NoProfile -NonInteractive -Command "Expand-Archive -LiteralPath '$PS_SRC' -DestinationPath '$PS_DST' -Force" && return
+    "$PS_EXE" -NoProfile -NonInteractive -Command "Expand-Archive -LiteralPath '$PS_SRC' -DestinationPath '$PS_DST' -Force" && return
   fi
-  print_error "extracting $1 needs one of: unzip, a tar that reads zip (Windows 10+ tar.exe), or powershell"
+  print_error "extracting $1 needs one of: unzip, a tar that reads zip (Windows 10+ tar.exe), or powershell/pwsh"
   exit 1
 }
 
@@ -551,10 +559,9 @@ ${renderShellPlatformCase(platforms)}
   #
   # Keyed off $PLATFORM, not $OS: platform() runs inside a command substitution, so the
   # OS it assigns lives and dies in that subshell and reads empty here.
-  case "$PLATFORM" in
-    win32-*) DEFAULT_BINARY_NAME="cz-cli.exe" ;;
-    *) DEFAULT_BINARY_NAME="cz-cli" ;;
-  esac
+  # DEFAULT_BINARY_NAME comes from the per-platform case above, which the generator writes
+  # from platformBinary() — the same function that decided what to put IN the archive. A
+  # second copy of the win32→.exe rule in shell could disagree with it.
   # \${BINARY_NAME:-…}: setup.sh reads BINARY_NAME as an override, so an environment that
   # already set it keeps winning. For every POSIX platform the default below is the same
   # name setup.sh would have chosen on its own, which makes this line a no-op there.

--- a/scripts/cos-release.mjs
+++ b/scripts/cos-release.mjs
@@ -391,6 +391,31 @@ download() {
   exit 1
 }
 
+# Git Bash ships no \`unzip\`, and the win32 archives are zips — so the one tool the old
+# precheck demanded is the one a Windows user is least likely to have. Try, in order:
+# unzip; bsdtar, which Windows 10 1803+ ships as tar.exe and which reads zip (GNU tar
+# does not, hence discard-on-failure rather than a version test); PowerShell's
+# Expand-Archive, whose arguments must be Windows paths, so cygpath does the translating.
+extract_zip() {
+  if command -v unzip > /dev/null 2>&1; then
+    unzip -qo "$1" -d "$2"
+    return
+  fi
+  if tar -xf "$1" -C "$2" 2>/dev/null; then
+    return
+  fi
+  if command -v powershell > /dev/null 2>&1 && command -v cygpath > /dev/null 2>&1; then
+    # Both paths come from mktemp, which honours \$TMPDIR — so they are environment-supplied,
+    # and a \`'\` in one would close the PowerShell single-quoted string early and let the
+    # rest parse as commands. PowerShell escapes a literal quote by doubling it.
+    PS_SRC=$(cygpath -w "$1" | sed "s/'/''/g")
+    PS_DST=$(cygpath -w "$2" | sed "s/'/''/g")
+    powershell -NoProfile -NonInteractive -Command "Expand-Archive -LiteralPath '$PS_SRC' -DestinationPath '$PS_DST' -Force" && return
+  fi
+  print_error "extracting $1 needs one of: unzip, a tar that reads zip (Windows 10+ tar.exe), or powershell"
+  exit 1
+}
+
 verify_checksum() {
   if command -v shasum > /dev/null 2>&1; then
     ACTUAL=$(shasum -a 256 "$1" | awk '{print $1}')
@@ -432,6 +457,18 @@ platform() {
   case "$ARCH" in
     x86_64|amd64) ARCH="x64" ;;
     aarch64|arm64) ARCH="arm64" ;;
+  esac
+
+  # Git Bash / MSYS2 / Cygwin answer \`uname -s\` with MINGW64_NT-10.0-26200, MSYS_NT-…
+  # or CYGWIN_NT-… — a POSIX shell on a Windows host, which is exactly what this script
+  # runs in when a Windows user pipes it to bash. The win32 archives are built and
+  # published like every other platform, so map onto them instead of letting the raw
+  # uname string fall through to "unsupported platform", which read as "no Windows build
+  # exists". Deliberately matching install.ps1's \`win32-$Arch\`, baseline included: it
+  # does not select the -baseline build either, so a pre-AVX2 Windows CPU is an open gap
+  # in BOTH installers rather than a new one here.
+  case "$OS" in
+    mingw*|msys*|cygwin*) OS="win32" ;;
   esac
 
   SUFFIX=""
@@ -484,10 +521,7 @@ ${renderShellPlatformCase(platforms)}
       }
       ;;
     zip)
-      command -v unzip > /dev/null 2>&1 || {
-        print_error "unzip is required"
-        exit 1
-      }
+      # extract_zip picks between unzip / bsdtar / powershell, so nothing to require here.
       ;;
   esac
 
@@ -503,7 +537,7 @@ ${renderShellPlatformCase(platforms)}
   echo "Extracting..."
   case "$ARCHIVE_FORMAT" in
     tar.gz) tar -xzf "$ARCHIVE_PATH" -C "$EXTRACT_DIR" ;;
-    zip) unzip -qo "$ARCHIVE_PATH" -d "$EXTRACT_DIR" ;;
+    zip) extract_zip "$ARCHIVE_PATH" "$EXTRACT_DIR" ;;
   esac
 
   if [ ! -f "$EXTRACT_DIR/setup.sh" ]; then
@@ -512,6 +546,20 @@ ${renderShellPlatformCase(platforms)}
   fi
 
   chmod +x "$EXTRACT_DIR/setup.sh"
+  # The win32 archives carry cz-cli.exe. setup.sh already takes the name as an env
+  # var, so this is the whole of what it needs to install a Windows build.
+  #
+  # Keyed off $PLATFORM, not $OS: platform() runs inside a command substitution, so the
+  # OS it assigns lives and dies in that subshell and reads empty here.
+  case "$PLATFORM" in
+    win32-*) DEFAULT_BINARY_NAME="cz-cli.exe" ;;
+    *) DEFAULT_BINARY_NAME="cz-cli" ;;
+  esac
+  # \${BINARY_NAME:-…}: setup.sh reads BINARY_NAME as an override, so an environment that
+  # already set it keeps winning. For every POSIX platform the default below is the same
+  # name setup.sh would have chosen on its own, which makes this line a no-op there.
+  BINARY_NAME="\${BINARY_NAME:-$DEFAULT_BINARY_NAME}"
+  BINARY_NAME="$BINARY_NAME" \
   INSTALL_DIR="$INSTALL_DIR" \
   CZ_VERSION="$VERSION" \
   CZ_CHANNEL="$CHANNEL" \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -56,6 +56,18 @@ exec "${TARGET_BINARY}" agent "\$@"
 EOF
 chmod +x "${INSTALL_DIR}/cz-agent"
 
+# On Windows the wrapper above only works from a POSIX shell (Git Bash / MSYS2 /
+# Cygwin), because cmd.exe and PowerShell cannot execute an extensionless sh script.
+# The .cmd shim covers them, so `cz-agent` means the same thing in every Windows shell
+# once INSTALL_DIR is on PATH. `cz-cli` itself needs no shim: MSYS bash appends .exe
+# when resolving a command, and cmd/PowerShell do the same via PATHEXT.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    WIN_TARGET=$(cygpath -w "$TARGET_BINARY" 2>/dev/null || echo "$TARGET_BINARY")
+    printf '@echo off\r\n"%s" agent %%*\r\n' "$WIN_TARGET" > "${INSTALL_DIR}/cz-agent.cmd"
+    ;;
+esac
+
 SKILLS_SRC="${SCRIPT_DIR}/skills"
 BUILTIN_DEST="${HOME}/.clickzetta/skills/.builtin"
 rm -rf "$BUILTIN_DEST"
@@ -99,6 +111,24 @@ EOF
 echo "✓ cz-cli installed to $TARGET_BINARY"
 if ! printf '%s' ":$PATH:" | grep -q ":$INSTALL_DIR:"; then
   echo "Add $INSTALL_DIR to PATH if cz-cli is not found in a new shell."
+  # $PATH here is the POSIX one this shell sees. On Windows that is Git Bash's view, and
+  # adding the directory to it does NOT make cz-cli resolvable from cmd.exe or
+  # PowerShell — those read the Windows PATH, which is a separate list. Say so, since
+  # otherwise "already on PATH" and "command not found" are both true at once.
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+      WIN_DIR=$(cygpath -w "$INSTALL_DIR" 2>/dev/null || echo "$INSTALL_DIR")
+      echo "  For cmd.exe / PowerShell, add the Windows form too:"
+      # Deliberately NOT `setx PATH "%PATH%;…"`. PowerShell does not expand %PATH%, so
+      # pasted there it writes the literal string and the user PATH becomes one bogus
+      # entry — worse than the problem this hint addresses. In cmd.exe %PATH% is the
+      # COMBINED machine+user value while setx writes the USER one, so it permanently
+      # copies the machine PATH into the user PATH, and setx truncates at 1024 chars.
+      # The form below reads and writes only the User scope and has no length cap.
+      echo "    [Environment]::SetEnvironmentVariable('PATH', [Environment]::GetEnvironmentVariable('PATH','User') + ';$WIN_DIR', 'User')"
+      echo "  (or add $WIN_DIR via Settings > Edit environment variables for your account)"
+      ;;
+  esac
 fi
 
 # Offer MCP onboarding for external AI clients (Claude Code / Cursor / Codex).


### PR DESCRIPTION
Everything from this working session, as three commits. Stacked on #86 — the sidebar reads
its portal token through `profileTokenSource`, which only exists on that branch, so this
cannot target `main` until #86 lands. GitHub retargets automatically once #86 merges.

| Commit | What |
|---|---|
| `feat(gateway): read the key's token quota from the response headers` | New feature |
| `fix(tui): preserve spinner registration (backport upstream #35292)` | Windows crash fix (was #88) |
| `fix(sql): report job_id on a failed query, not only a successful one` | Small fix |
| `feat(install): install from Git Bash / MSYS2 / Cygwin on Windows` | Windows install support |
| `fix(auth): keep the instance id on the profile, not on the shared OAuth token` | Wrong-instance fix |

---

## 1. Token quota from the gateway's response headers

"How much token quota is left on this key" now comes from the AI gateway's own response
headers instead of a portal poll. Every successful `/gateway/v1/chat/completions` response
carries the key's allowance for each configured period:

```
x-czgw-ratelimit-api-key-token-period:    PDO
x-czgw-ratelimit-api-key-token-limit:     10000000
x-czgw-ratelimit-api-key-token-used:      238
x-czgw-ratelimit-api-key-token-remaining: 9999762
```

This is the only quota source a plain API key can reach. `ai-gateway key list` reports the
same numbers but needs a portal token and ownership of the key, so it cannot answer "how
much is left on the key I am using right now".

**New in `@clickzetta/ai-gateway`**

- `quota.ts` — parses those headers. A key with several periods repeats all four headers
  once per period, and both `Headers` and the AI SDK's `SharedV3Headers` collapse
  duplicates into one comma-joined value, so the lists are zipped positionally.
  `undefined` means "not reported", never "zero" and never "no limit" — the headers are
  absent on every error response (429 included) and on a gateway that predates the feature.
- `quota-store.ts` — `~/.clickzetta/gateway-quota.json`, keyed by
  `baseURL#sha256(apiKey)[:16]`. Only the provider sees the response headers and it runs in
  the opencode server; the sidebar that displays them runs in the TUI process, and the TUI
  plugin API exposes no response-side hook (`chat.headers` is outbound only, the event bus
  is a fixed set, and opencode's processor drops the `step-finish` metadata). A file was
  preferred over an intrusive patch to that processor — the de-opencode invariant in
  `packages/cz-cli/UPSTREAM-PATCHES.md` is worth more. The store is a cache, never a source
  of truth, with a 7-day retention so it cannot grow without bound.
- The provider shell publishes the reading as `providerMetadata.clickzetta.quota` on
  `doGenerate` and on the stream's `finish` part, and writes the cache as soon as the
  headers exist — for a stream that is when it opens, so an aborted turn does not throw
  away a reading already in hand. When the gateway reports nothing the result comes back
  byte-identical.

**New command** — `cz-cli ai-gateway quota [llm]` sends a 1-token chat request and reads the
headers off the response. No portal credentials, no ownership of the key. A spent key 429s
with no quota headers at all, so that case is reported through the gateway-error classifier
rather than swallowed as "quota unknown"; a 404 for a probe model the caller never named is
reported as its own condition, because it says nothing about the quota.

`cz-cli agent llm test` also prints the quota — the probe already makes a completion, so it
costs nothing extra.

**TUI sidebar** — the token half switches to the local cache, refreshed on each
`step-finish` part (one per LLM request); the balance half keeps its busy→idle portal read.
That removed a whole mechanism from `fetchQuotaSnapshot`: it used to walk every locally
configured Profile hunting the one whose portal knew the selected virtual key, because an
LLM entry and a Profile are independent configuration domains. The headers answer for the
key directly, so the balance needs exactly one Profile — net -144 lines. Every configured
period now gets its own rows, shortest window first, since the binding limit is whichever
runs out first.

`UPSTREAM-PATCHES.md` HOOK entry 5 is updated for what this adds to that section's
dependencies: the `message.part.updated` / `step-finish` event shape, the new on-disk path,
and the fact that the token half no longer touches Portal.

## 2. Windows `<spinner>` crash

On Windows the released binary crashed the session as soon as anything rendered a spinner:

```
[Reconciler] Unknown component type: spinner
```

Reported on cz-cli 2.0.3. Five sites registered `<spinner>` with a bare side-effect import,
`import "opentui-spinner/solid"`. That package declares a whitelist `sideEffects`, so the
module survives tree-shaking only while the bundler matches those POSIX patterns against
the resolved path — and our release build compiles the win32 target **on a
`windows-latest` runner** (`release-cos.yml`: `runner: windows-latest` +
`OPENCODE_HOST_ONLY=1`). There the match fails, `minify` drops an import that binds
nothing, `extend({ spinner })` never runs, and the first spinner render throws.

Release-only and Windows-only: dev `bun run` does not tree-shake, and upstream bundles
every target — Windows included — on Linux (`build-cli` runs on
`blacksmith-4vcpu-ubuntu-2404`; its `windows-2025` runner only signs), which is why
upstream never saw it.

Fixed by backporting https://github.com/anomalyco/opencode/pull/35292 verbatim. Our
baseline v1.17.11 (2026-06-25) predates it by nine days; upstream v1.18.9 and later already
carry it. Recorded as INTRUSIVE #12 in `UPSTREAM-PATCHES.md`, scoped to self-delete once
the baseline reaches v1.18.9, with a substitute grep because the edit deliberately carries
no `cz-cli change` banner (a banner would turn a clean fast-forward into a conflict).

Measured: forcing the `sideEffects` match to fail collapses a bare-import bundle from
935,609 bytes to 27 — registration and all. Cross-compiling with
`--target=bun-windows-x64` from macOS keeps it, confirming the build host rather than the
target decides.

## 4. `job_id` on a failed SQL query

A FAILED query's error payload now carries `job_id`, so it can be traced with
`cz-cli job profile <id>` the same way a successful one can. One duplicated failure path in
`executeSingle` also folds into the existing `handleFailure` helper.

Both failure paths now report through that helper, and both gain what it does. The
single-statement path gains `ai_message` when a schema hint is available (its inlined
predecessor already called `logOperation` with the same fields, so its telemetry is
unchanged). The multi-statement intermediate path — folded in after review — gains more:
`job_id`, the schema hint and `ai_message`, plus `timeMs` on its `logOperation` record, and
it now issues one `fetchSchemaHint` query on failure where it previously issued none. All
additive in the envelope, but it is a new stderr line for row formats and a new key for
json, so scripts diffing either will see it. Both paths are covered by
`test/sql-error-job-id.test.ts`.

## 3. Installing on Windows from a POSIX shell

`curl -fsSL https://cz-cli.ai/install.sh | bash` in Git Bash answered:

```
Error: unsupported platform: mingw64_nt-10.0-26200-x64
```

That is the raw `uname -s`, lowercased and joined to the arch, because `platform()` in the
generated installer had no mapping for the MSYS family. It reads as "there is no Windows
build" when the win32 archives are published like every other platform.

- **Platform mapping** — `mingw*|msys*|cygwin*` now resolves to `win32`, matching
  `install.ps1`'s own `win32-$Arch`. Baseline included: the PowerShell installer does not
  select the `-baseline` build either, so a pre-AVX2 Windows CPU stays an open gap in
  **both** installers rather than becoming a new one here.
- **Zip extraction without `unzip`** — the win32 archives are zips and Git Bash ships no
  `unzip`, so the one tool the old precheck demanded is the one a Windows user is least
  likely to have. `extract_zip` tries `unzip`, then `tar -xf` (Windows 10 1803+ ships
  bsdtar as `tar.exe`, which reads zip; GNU tar does not, hence discard-on-failure rather
  than a version test), then PowerShell's `Expand-Archive` with `cygpath`-translated paths.
- **`BINARY_NAME` passed through** — the win32 archives carry `cz-cli.exe`, and `setup.sh`
  already took the name as an env override, so that is the whole of what it needed. Written
  as `${BINARY_NAME:-…}` so an environment that already set it still wins, and the default
  for every POSIX platform is the same name `setup.sh` would have picked itself.
- **`cz-agent.cmd`** — the existing extensionless sh wrapper cannot be executed by cmd.exe
  or PowerShell, so a `.cmd` shim goes next to it. `cz-cli` itself needs none: MSYS bash
  appends `.exe` when resolving a command, and cmd/PowerShell do the same via PATHEXT.
- **PATH advice** — Git Bash's POSIX PATH is not the Windows PATH, so "already on PATH" and
  "command not found" can both be true at once. The hint now says so and gives the `setx`
  form.
- **`ensureRestartBinaryAtPath`** — its candidate was a hardcoded extensionless
  `~/.local/bin/cz-cli`. Now that install.sh really puts `cz-cli.exe` there, that candidate
  could never exist and every auto-update on such an install ended at the throw. Keyed off
  `process.platform` now.

Blast radius: everything above is gated on the MSYS family or `process.platform === "win32"`,
**except** `extract_zip`, which macOS installs also traverse — their archives are zips too.
For them the executed command is unchanged (`command -v unzip` succeeds, then the same
`unzip -qo`); what changes is that a mac without `unzip` now falls through to bsdtar instead
of aborting at a precheck, and the failure message is more specific. Linux is untouched: the
tar.gz branch is unchanged.

### One behaviour change worth naming

With **nothing** pinned — no `CZ_PROFILE`, no `default_profile` — the balance is now read
and shown for the first profile in `profiles.toml`. The pre-header code showed none on that
path: it gated the billing read on `name === current`, which was false for every profile
when `current` was undefined. The new behaviour is deliberate, since `readProfileInfo`
already names that same profile as the session's identity, so a figure beside it belongs to
the account being shown — but it is a new portal request and a new visible ¥ figure, not a
refactor, and it is pinned by its own test.

## 5. The instance id belongs to the profile, not the shared OAuth token

`AuthToken` carried `instanceId`, and it was persisted into `[oauth.<id>]` — a section that
is **deliberately shared** by every profile one login provisions ("one per instance ×
workspace, all sharing ONE `[oauth.<id>]`"). One section can hold one id, so it is wrong for
every profile but one. And the request path read it from there: `newJobId(workspace,
token.instanceId)` in `sql/session.ts` and `commands/exec.ts`, so a profile submitted jobs
under whatever instance the shared token happened to name.

Measured on a real `profiles.toml`, not inferred:

```
[oauth.robert]  instance_id = 271502          ← one value
profiles.robert_0  instance = "036fe379"  cn-shanghai-alicloud
profiles.robert_1  instance = "2ef2d3b9"  cn-north-1-aws
profiles.robert_2  instance = "343ade38"  ap-shanghai-tencentcloud
profiles.robert_3  instance = "554671b1"  ap-guangzhou-tencentcloud
```

Four instances across four regions, one id. And it is not only a multi-instance hazard —
querying the portal for the default profile on that same machine returned:

```
{"id":160812,"name":"5e53fbfb","serviceId":2}   ← what [oauth.gh-test].instance_id held
{"id":160813,"name":"340a06ea","serviceId":1}   ← the instance the profile actually names
```

The token's value came from userinfo's "default" instance, which was not the Lakehouse one
(`serviceId` 1, the only kind `resolveInstanceIdByName` accepts). So a single-profile,
single-login setup was already submitting under the wrong id.

**The fix.** `ConnectionConfig` gains `instanceId`, read from the profile's `instance_id`;
every request-time read goes through it (`execInstanceId(ctx)` in cz-cli, `config.instanceId`
in the SDK session). Provisioning writes it per profile from the enumeration, which already
carried it — so a login needs no extra request, and because that write is unconditional it
also corrects a value an older version cached. A profile without one is resolved by name via
`serviceInstanceList` on first use and written back, in the shape `patchProfileUserId`
already established. `[oauth.<id>]` stops storing it, and `parseOAuthEntry` stops requiring
it — that half matters as much: the old reader *demanded* the field, so dropping the write
without dropping the requirement would have made every newly written section read as invalid
and signed users out.

`AuthToken.instanceId` is now **optional** rather than gone. Full removal would take
`login.ts`, `token.ts`, `cookie-token.ts`, `studio-context.ts`, `login-browser.ts` and the
public `Credential` shape with it, and a standalone SDK password login has no profile to read
from — the login response is its only source. It is documented as not authoritative for a
profile-backed connection, and cz-cli no longer reads it anywhere.

## Verification

- `@clickzetta/ai-gateway`: typecheck clean, 72/72 tests.
- `cz-cli`: typecheck clean, full isolated suite green, `test:e2e:help` 114/114.
- `packages/tui`: typecheck clean; suite unchanged from baseline (203 pass / 8 pre-existing
  `tui sync` failures, identical with the patch reverted).
- `packages/opencode`: `test/cli/run/footer.view.test.tsx` — the one test that asserts a
  spinner renders, over a modified path — 22 pass / 0 fail.
- Four new tests were mutation-checked (reverting the fix they cover turns them red): the
  stale-profile balance guard, the stream-cache write, the 404 probe-model branch and the
  daily-reset freshness rule.
- Exercised against `uat-aimesh` (single period). `cn-shanghai-alicloud-aimesh` sends no
  quota headers at all as of 2026-09-01 while still enforcing a quota — there the token
  rows are simply absent and the balance row still paints.
- `installer-windows.test.ts` runs the GENERATED installer end to end against a fixture
  archive with `uname` and `curl` stubbed, asserting a Windows install lands `cz-cli.exe`,
  both `cz-agent` wrappers, the runtime assets and `install.json` — plus a case proving the
  extraction fallback works with `unzip` genuinely unreachable, and a POSIX regression case.
  Reverting the platform mapping turns 4 of its 5 cases red.
- Neither Windows change was exercised on Windows — no Windows machine available here. The
  spinner fix removes the dependency on the path match regardless of why it fails; the
  installer's shell logic is covered by the end-to-end test above, but that the shipped
  `cz-cli.exe` then runs is untested by it.

## Fixed after the first review pass

- **A stale `CZ_PROFILE` no longer paints another account's cash balance.** This was a real
  regression in the first revision, and its description wrongly called the fallback
  pre-existing — it wasn't. The pre-header code reached the right outcome by a different
  route (it gated the billing read on `name === current` in two places); collapsing the
  profile walk dropped both gates. `fetchQuotaSnapshot` now follows the policy
  `readProfileInfo` already documents. Covered by a test, mutation-checked.
- **A cached reading can no longer outlive the credential it describes.** The sticky reader
  (don't blank a live figure when a gateway sends no headers) is now separate from a
  context reader that runs on mount, session switch and provider switch and clears when the
  now-active credential has nothing cached.
- The cache write no longer waits for the stream's `finish` part.
- `ai-gateway quota` distinguishes a 404 on a guessed probe model from an unreadable quota.
- `recordGatewayQuota` no longer calls `mkdirSync` per request, and prunes expired entries.
- `parseClickzettaQuota`'s "is this a reading" filter now counts `used`, matching the
  formatter's used-only branch.
- Two inaccurate comments corrected, and INTRUSIVE #12 gained a `Verify:` field plus the
  substitute grep, wired into the re-baseline procedure.
- `agent llm test`'s `quotas` key now has behavioral tests pinning its shape, including the
  no-headers case.

## Legacy surfaces dropped

The quota half is a clean break from the Portal-poll behaviour, not a compatibility layer
over it, and two leftovers that pretended otherwise are gone:

- **`readGatewayQuota` no longer takes `maxAgeMs`.** Whether a reading is still worth
  showing is not one question but several — a daily allowance stops being true at its reset,
  a lifetime one never does — so the caller answers it with `updated_at` and the periods in
  hand, which is what `readHeaderQuota` now does in full. The parameter only ever duplicated
  the coarsest half of that decision, and after the reader took the whole of it, nothing
  passed one. Its test now pins the contract that remains: the reading carries the moment it
  was taken.
- **`parseClickzettaQuota` no longer accepts array-valued headers.** `HeaderSource` is
  `Headers | Record<string, string | undefined>` — the two shapes response headers actually
  arrive in here (fetch's `Headers` at the CLI sites, the AI SDK's `SharedV3Headers` at the
  provider). The array shape is node's raw-headers form, which nothing passes; the branch's
  only test proved the branch existed.

Already gone with the feature itself: the `/clickzetta-portal/user/listApiKeys` route,
`maskApiKey`, `matchKeyUsage`, `QuotaSnapshot`'s `used`/`limit`/`period`/`alias` fields, and
the walk over every configured Profile hunting the one whose portal knew the selected key.

## Fixed after the second review pass

- `readHeaderQuota` drops a `daily` reading taken before the counter reset instead of
  relying on a fixed duration, which no window under a day can express. Conservative:
  a different calendar date in either local or UTC time counts as reset.
- `abbreviate` gained a billions tier, so a lifetime ceiling reads `1.0B`, not `1000.0M`.
- `quotaRows` names the limiter scope when more than one reports, and sorts by it, so a
  tenant-wide cap cannot render as an unlabelled duplicate of the key's own.
- `recordQuota` cannot fail a request that already succeeded — the guard is inside it, so
  neither call site can forget it.
- `ai-gateway quota` arms `setGatewayDebug`, so `--debug` is no longer accepted-and-ignored.
- `llm/gateway-error.ts` re-exports from three narrow subpaths rather than the root
  `@clickzetta/ai-gateway` barrel, so the pre-bundled TUI asset never has the AI SDK in
  reach. Measured: the asset is 73,318 bytes either way and never contained the provider
  machinery — bun shook it out — so this is defence in depth, not a size fix.
- `HelpCase` gained `expectText` so epilogue prose is asserted as prose, not as a
  subcommand.
