### PR TITLE
fix(release): support x64 CPUs without AVX2

### DIFF
--- a/.github/actions/setup-bun-runtime/action.yml
+++ b/.github/actions/setup-bun-runtime/action.yml
@@ -22,4 +22,3 @@ runs:
       with:
         bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
-

--- a/.github/actions/setup-bun-runtime/action.yml
+++ b/.github/actions/setup-bun-runtime/action.yml
@@ -1,0 +1,25 @@
+name: Setup Bun runtime
+description: Install the pinned Bun runtime with baseline support on x64
+runs:
+  using: composite
+  steps:
+    - name: Get baseline download URL
+      id: bun-url
+      shell: bash
+      run: |
+        if [ "$RUNNER_ARCH" = "X64" ]; then
+          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
+          case "$RUNNER_OS" in
+            macOS)   OS=darwin ;;
+            Linux)   OS=linux ;;
+            Windows) OS=windows ;;
+          esac
+          echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
+        bun-download-url: ${{ steps.bun-url.outputs.url }}
+

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -8,25 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Get baseline download URL
-      id: bun-url
-      shell: bash
-      run: |
-        if [ "$RUNNER_ARCH" = "X64" ]; then
-          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
-          case "$RUNNER_OS" in
-            macOS)   OS=darwin ;;
-            Linux)   OS=linux ;;
-            Windows) OS=windows ;;
-          esac
-          echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-      with:
-        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
-        bun-download-url: ${{ steps.bun-url.outputs.url }}
+    - uses: ./.github/actions/setup-bun-runtime
 
     - name: Get cache directory
       id: cache

--- a/.github/workflows/baseline-test.yml
+++ b/.github/workflows/baseline-test.yml
@@ -1,0 +1,47 @@
+name: baseline-test
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/baseline-test.yml
+      - .github/workflows/release-cos.yml
+      - packages/cz-cli/script/**
+      - packages/cz-cli/src/bootstrap/**
+      - packages/opencode/package.json
+      - scripts/check-baseline.sh
+      - bun.lock
+  push:
+    paths:
+      - .github/workflows/baseline-test.yml
+      - .github/workflows/release-cos.yml
+      - packages/cz-cli/script/**
+      - packages/cz-cli/src/bootstrap/**
+      - packages/opencode/package.json
+      - scripts/check-baseline.sh
+      - bun.lock
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-x64:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-bun
+      - name: Build the release binary
+        working-directory: packages/cz-cli
+        env:
+          OPENCODE_HOST_ONLY: "1"
+          OPENCODE_VERSION: "0.0.0-baseline-test"
+        run: bun run script/build.ts --skip-embed-web-ui
+      - name: Install CPU emulator
+        run: sudo apt-get update && sudo apt-get install -y qemu-user
+      - name: Run without AVX or AVX2
+        run: sh scripts/check-baseline.sh packages/opencode/dist/cz-cli-linux-x64/bin/cz-cli

--- a/.github/workflows/baseline-test.yml
+++ b/.github/workflows/baseline-test.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/baseline-test.yml
       - .github/workflows/release-cos.yml
+      - .github/actions/setup-bun*/**
       - packages/cz-cli/script/**
       - packages/cz-cli/src/bootstrap/**
       - packages/opencode/package.json
@@ -14,6 +15,7 @@ on:
     paths:
       - .github/workflows/baseline-test.yml
       - .github/workflows/release-cos.yml
+      - .github/actions/setup-bun*/**
       - packages/cz-cli/script/**
       - packages/cz-cli/src/bootstrap/**
       - packages/opencode/package.json
@@ -42,6 +44,6 @@ jobs:
           OPENCODE_VERSION: "0.0.0-baseline-test"
         run: bun run script/build.ts --skip-embed-web-ui
       - name: Install CPU emulator
-        run: sudo apt-get update && sudo apt-get install -y qemu-user
+        run: sudo apt-get -o Acquire::Retries=3 update && sudo apt-get -o Acquire::Retries=3 install -y qemu-user
       - name: Run without AVX or AVX2
         run: sh scripts/check-baseline.sh packages/opencode/dist/cz-cli-linux-x64/bin/cz-cli

--- a/.github/workflows/cz-test.yml
+++ b/.github/workflows/cz-test.yml
@@ -64,6 +64,10 @@ jobs:
         # of it, per the reasoning above and in each of those call sites.
         run: bun run test
 
+      - name: Run npm installer tests
+        working-directory: packages/npm/cz-cli
+        run: node --test test/install.test.mjs
+
       # UPSTREAM-PATCHES.md's re-baseline checklist points at these three files
       # as the enforcement for their respective ledger entries (7, 9), but they
       # live inside upstream packages and are only named by test.yml's

--- a/.github/workflows/cz-test.yml
+++ b/.github/workflows/cz-test.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run npm installer tests
         working-directory: packages/npm/cz-cli
-        run: node --test test/install.test.mjs
+        run: node --test test/*.test.mjs
 
       # UPSTREAM-PATCHES.md's re-baseline checklist points at these three files
       # as the enforcement for their respective ledger entries (7, 9), but they

--- a/.github/workflows/release-cos.yml
+++ b/.github/workflows/release-cos.yml
@@ -166,14 +166,19 @@ jobs:
         include:
           - os: linux
             runner: ubuntu-latest
+            bun-target: linux-x64-baseline
           - os: linux
             runner: ubuntu-24.04-arm
+            bun-target: linux-arm64
           - os: darwin
             runner: macos-latest
+            bun-target: darwin-arm64
           - os: darwin
             runner: macos-15-intel
+            bun-target: darwin-x64-baseline
           - os: win32
             runner: windows-latest
+            bun-target: windows-x64-baseline
     runs-on: ${{ matrix.runner }}
     env:
       GH_REPO: ${{ github.repository }}
@@ -211,7 +216,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          # Use the same runtime for the build host and compiled artifact.
+          bun-download-url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-${{ matrix.bun-target }}.zip
 
       - uses: actions/setup-node@v4
         with:
@@ -269,13 +275,11 @@ jobs:
             sleep 1
           done
 
-      - name: Build and upload ${{ matrix.os }} targets
+      - name: Build ${{ matrix.os }} targets
         env:
           OPENCODE_VERSION: ${{ needs.resolve-release.outputs.version }}
           OPENCODE_ARCHIVE: "1"
           OPENCODE_HOST_ONLY: "1"
-          OPENCODE_RELEASE: "1"
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLICKZETTA_OTEL_ENDPOINT: ${{ secrets.CLICKZETTA_OTEL_ENDPOINT }}
           CLICKZETTA_OTEL_HEADERS: ${{ secrets.CLICKZETTA_OTEL_HEADERS }}
         # cz-1.17.11: the cz-cli release builder lives in packages/cz-cli/script/build.ts
@@ -283,6 +287,23 @@ jobs:
         # It chdir's into packages/opencode and writes dist there, so the downstream
         # packages/opencode/dist paths below stay correct.
         run: cd packages/cz-cli && bun run script/build.ts
+
+      - name: Verify Linux x64 without AVX
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user
+          sh scripts/check-baseline.sh packages/opencode/dist/cz-cli-linux-x64/bin/cz-cli
+
+      - name: Upload verified archives
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          shopt -s nullglob
+          archives=(packages/opencode/dist/cz-cli-*.zip packages/opencode/dist/cz-cli-*.tar.gz)
+          test "${#archives[@]}" -gt 0
+          gh release upload "${{ needs.resolve-release.outputs.tag }}" "${archives[@]}" --clobber --repo "${{ github.repository }}"
 
   upload-installer:
     needs: [resolve-release, build]

--- a/.github/workflows/release-cos.yml
+++ b/.github/workflows/release-cos.yml
@@ -169,10 +169,10 @@ jobs:
             bun-target: linux-x64-baseline
           - os: linux
             runner: ubuntu-24.04-arm
-            bun-target: linux-arm64
+            bun-target: linux-aarch64
           - os: darwin
             runner: macos-latest
-            bun-target: darwin-arm64
+            bun-target: darwin-aarch64
           - os: darwin
             runner: macos-15-intel
             bun-target: darwin-x64-baseline

--- a/.github/workflows/release-cos.yml
+++ b/.github/workflows/release-cos.yml
@@ -166,22 +166,15 @@ jobs:
         include:
           - os: linux
             runner: ubuntu-latest
-            bun-target: linux-x64-baseline
           - os: linux
             runner: ubuntu-24.04-arm
-            bun-target: linux-aarch64
           - os: darwin
             runner: macos-latest
-            bun-target: darwin-aarch64
           - os: darwin
             runner: macos-15-intel
-            bun-target: darwin-x64-baseline
           - os: win32
             runner: windows-latest
-            bun-target: windows-x64-baseline
     runs-on: ${{ matrix.runner }}
-    env:
-      GH_REPO: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
 
@@ -214,10 +207,7 @@ jobs:
           done
           echo "Synced $count skills from clickzetta-skills repo"
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          # Use the same runtime for the build host and compiled artifact.
-          bun-download-url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-${{ matrix.bun-target }}.zip
+      - uses: ./.github/actions/setup-bun-runtime
 
       - uses: actions/setup-node@v4
         with:
@@ -291,8 +281,8 @@ jobs:
       - name: Verify Linux x64 without AVX
         if: runner.os == 'Linux' && runner.arch == 'X64'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install -y qemu-user
           sh scripts/check-baseline.sh packages/opencode/dist/cz-cli-linux-x64/bin/cz-cli
 
       - name: Upload verified archives

--- a/packages/cz-cli/script/build.ts
+++ b/packages/cz-cli/script/build.ts
@@ -149,17 +149,12 @@ const allTargets: {
   },
 ]
 
-// cz_change: honor Script.hostOnly (OPENCODE_HOST_ONLY / OPENCODE_RELEASE) so each
-// CI matrix runner builds ONLY its own platform target. Without this every runner
-// builds all targets and races on `gh release upload --clobber`. Vendored from
-// upstream opencode build.ts (lost when this file was split off). MUST also drop the
-// baseline (avx2:false) and abi (musl) variants: the host os+arch can match several
-// entries (e.g. win32-x64 AND win32-x64-baseline), and the baseline/abi variants need
-// extra Bun runtime artifacts (bun-<os>-<arch>-baseline) whose download is flaky and was
-// failing the win32 build. Single-target release CI wants exactly one native binary.
-const hostAvx2Only = (item: (typeof allTargets)[number]) =>
+// cz_change: release runners build one host artifact. Baseline runtime selection
+// happens at compile time below, independently of the public archive/package name.
+// Keep musl and explicitly suffixed variants for the full cross-platform build.
+const hostTarget = (item: (typeof allTargets)[number]) =>
   item.os === process.platform && item.arch === process.arch && item.avx2 !== false && item.abi === undefined
-const platformTargets = Script.hostOnly ? allTargets.filter(hostAvx2Only) : allTargets
+const platformTargets = Script.hostOnly ? allTargets.filter(hostTarget) : allTargets
 
 const targets = singleFlag
   ? platformTargets.filter((item) => {
@@ -167,8 +162,8 @@ const targets = singleFlag
         return false
       }
 
-      // When building for the current platform, prefer a single native binary by default.
-      // Baseline binaries require additional Bun artifacts and can be flaky to download.
+      // Only emit the extra suffixed artifact on request. The unsuffixed x64
+      // artifact already uses the same baseline runtime.
       if (item.avx2 === false) {
         return baselineFlag
       }
@@ -248,7 +243,10 @@ for (const item of targets) {
       autoloadDotenv: false,
       autoloadTsconfig: true,
       autoloadPackageJson: true,
-      target: name.replace(DIST_PREFIX, "bun") as any,
+      // cz_change: every x64 artifact uses Bun's SSE4.2 baseline runtime. Keep the
+      // existing public names so npm, direct downloads and upgrades all get the
+      // compatible binary without separate CPU detection or optional packages.
+      target: name.replace(DIST_PREFIX, "bun").replace(/-x64(?!-baseline)/, "-x64-baseline") as Bun.Build.CompileTarget,
       outfile: `dist/${name}/bin/cz-cli`,
       execArgv: [`--user-agent=cz-cli/${Script.version}`, "--use-system-ca", "--"],
       windows: {},

--- a/packages/cz-cli/test/installer-windows.test.ts
+++ b/packages/cz-cli/test/installer-windows.test.ts
@@ -64,6 +64,7 @@ function stubs(input: {
   tar?: "extracts" | "fails"
   powershell?: "extracts"
   marker: string
+  avx2?: boolean
 }) {
   const bin = join(work, `stub-bin-${Math.random().toString(36).slice(2)}`)
   mkdirSync(bin, { recursive: true })
@@ -75,7 +76,19 @@ function stubs(input: {
 
   write("uname", `#!/bin/sh\ncase "$1" in\n  -s) echo "${input.unameS}" ;;\n  -m) echo "${input.unameM}" ;;\n  *) echo "${input.unameS}" ;;\nesac\n`)
   // download() calls: curl -fL --progress-bar URL -o DEST
-  write("curl", `#!/bin/sh\nDEST=""\nwhile [ $# -gt 0 ]; do\n  if [ "$1" = "-o" ]; then DEST="$2"; fi\n  shift\ndone\ncp ${JSON.stringify(input.archive)} "$DEST"\n`)
+  write(
+    "curl",
+    `#!/bin/sh\nDEST=""\nwhile [ $# -gt 0 ]; do\n  if [ "$1" = "-o" ]; then DEST="$2"; fi\n  shift\ndone\ncp ${JSON.stringify(input.archive)} "$DEST"\n`,
+  )
+
+  if (input.avx2 !== undefined) {
+    const grep = Bun.spawnSync(["sh", "-c", "command -v grep"]).stdout.toString().trim()
+    write(
+      "grep",
+      `#!/bin/sh\nif [ "$*" = "-qwi avx2 /proc/cpuinfo" ]; then exit ${input.avx2 ? 0 : 1}; fi\nexec '${grep}' "$@"\n`,
+    )
+    write("ldd", '#!/bin/sh\necho "ldd (GNU libc) 2.36"\n')
+  }
 
   if (input.tar === "fails") write("tar", "#!/bin/sh\nexit 1\n")
   // extract_zip calls: tar -xf ARCHIVE -C DIR
@@ -110,6 +123,7 @@ function stubs(input: {
 
 function runInstaller(input: {
   platformKey: string
+  avx2?: boolean
   binaryName: string
   unameS: string
   unzip?: "real" | "absent"
@@ -138,6 +152,7 @@ function runInstaller(input: {
     ...(input.tar ? { tar: input.tar } : {}),
     ...(input.powershell ? { powershell: input.powershell } : {}),
     marker,
+    avx2: input.avx2,
   })
   const result = Bun.spawnSync(["sh", script], {
     env: { PATH: path, HOME: home, INSTALL_DIR: installDir, NON_INTERACTIVE: "1" },
@@ -243,5 +258,20 @@ describe("install.sh on Git Bash", () => {
     expect(existsSync(join(r.installDir, "cz-cli"))).toBe(true)
     expect(existsSync(join(r.installDir, "cz-cli.exe"))).toBe(false)
     expect(existsSync(join(r.installDir, "cz-agent.cmd"))).toBe(false)
+  })
+})
+
+describe("install.sh CPU compatibility", () => {
+  test.each([false, true])("installs the published x64 package with AVX2=%s", (avx2) => {
+    const result = runInstaller({
+      platformKey: "linux-x64",
+      binaryName: "cz-cli",
+      unameS: "Linux",
+      avx2,
+    })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("linux-x64")
+    expect(existsSync(join(result.installDir, "cz-cli"))).toBe(true)
+    expect(existsSync(join(result.installDir, "tui-quota-runtime.js"))).toBe(true)
   })
 })

--- a/packages/cz-cli/test/installer-windows.test.ts
+++ b/packages/cz-cli/test/installer-windows.test.ts
@@ -24,8 +24,8 @@ import { renderBootstrapSh } from "../../../scripts/cos-release.mjs"
 const ROOT = join(import.meta.dir, "..", "..", "..")
 let work: string
 
-/** A stand-in for the published archive: bin/ zipped, exactly as archivePlatform does. */
-function fixtureArchive(binaryName: string) {
+/** Archive the fixture contents in the same format as the platform release. */
+function fixtureArchive(binaryName: string, format: "zip" | "tar.gz") {
   const staging = join(work, "staging")
   mkdirSync(staging, { recursive: true })
   writeFileSync(join(staging, binaryName), "#!/bin/sh\necho 2.0.4\n")
@@ -33,16 +33,16 @@ function fixtureArchive(binaryName: string) {
   writeFileSync(join(staging, "setup.sh"), readFileSync(join(ROOT, "scripts", "setup.sh")))
   // One runtime asset, enough to prove setup.sh's copy loop still runs.
   writeFileSync(join(staging, "tui-quota-runtime.js"), "// stub\n")
-  const archive = join(work, "cz-cli.zip")
+  const archive = join(work, `cz-cli.${format}`)
   // `zip -rq` APPENDS to an existing archive, and the Cygwin/MSYS case builds twice in one
   // work dir — so remove it first rather than accumulating entries.
   rmSync(archive, { force: true })
-  const zipped = Bun.spawnSync(["zip", "-rq", archive, "."], { cwd: staging })
+  const packed = Bun.spawnSync(format === "zip" ? ["zip", "-rq", archive, "."] : ["tar", "-czf", archive, "."], { cwd: staging })
   // Check it. An unchecked fixture build is why this file once flaked: a bad archive makes
   // the installer fail at verify_checksum, and a case asserting on the EXTRACTION error
   // then fails with no hint that its input was never valid.
-  if (zipped.exitCode !== 0 || !existsSync(archive) || readFileSync(archive).byteLength === 0) {
-    throw new Error(`fixture archive build failed (exit ${zipped.exitCode}): ${zipped.stderr.toString()}`)
+  if (packed.exitCode !== 0 || !existsSync(archive) || readFileSync(archive).byteLength === 0) {
+    throw new Error(`fixture archive build failed (exit ${packed.exitCode}): ${packed.stderr.toString()}`)
   }
   return { archive, checksum: createHash("sha256").update(readFileSync(archive)).digest("hex") }
 }
@@ -81,6 +81,7 @@ function stubs(input: {
     `#!/bin/sh\nDEST=""\nwhile [ $# -gt 0 ]; do\n  if [ "$1" = "-o" ]; then DEST="$2"; fi\n  shift\ndone\ncp ${JSON.stringify(input.archive)} "$DEST"\n`,
   )
 
+  // Catch a regression that reintroduces CPU detection and selects an unpublished alias.
   if (input.avx2 !== undefined) {
     const grep = Bun.spawnSync(["sh", "-c", "command -v grep"]).stdout.toString().trim()
     write(
@@ -130,14 +131,15 @@ function runInstaller(input: {
   tar?: "extracts" | "fails"
   powershell?: "extracts"
 }) {
-  const { archive, checksum } = fixtureArchive(input.binaryName)
+  const format = input.unameS === "Linux" ? "tar.gz" : "zip"
+  const { archive, checksum } = fixtureArchive(input.binaryName, format)
   const script = join(work, "install.sh")
   writeFileSync(
     script,
     renderBootstrapSh({
       version: "2.0.4",
       channel: "stable",
-      platforms: { [input.platformKey]: { url: "https://example.invalid/cz-cli.zip", archive: "cz-cli.zip", format: "zip", checksum } },
+      platforms: { [input.platformKey]: { url: `https://example.invalid/cz-cli.${format}`, archive: `cz-cli.${format}`, format, checksum } },
     }),
   )
   const home = join(work, "home")

--- a/packages/npm/cz-cli/test/install.test.mjs
+++ b/packages/npm/cz-cli/test/install.test.mjs
@@ -108,10 +108,17 @@ test("getPlatformSpec maps supported npm package names", async () => {
   )
 })
 
+test("getPlatformSpec maps Linux release packages", async () => {
+  const { getPlatformSpec } = await loadModule()
+  for (const arch of ["x64", "arm64"]) {
+    assert.equal(getPlatformSpec({ platform: "linux", arch }).packageName, `@clickzetta/cz-cli-linux-${arch}`)
+  }
+})
+
 test("getPlatformSpec rejects unsupported package combinations", async () => {
   const { getPlatformSpec } = await loadModule()
   assert.equal(getPlatformSpec({ platform: "win32", arch: "arm64" }), null)
-  assert.equal(getPlatformSpec({ platform: "linux", arch: "x64" }), null)
+  assert.equal(getPlatformSpec({ platform: "linux", arch: "ia32" }), null)
   assert.equal(getPlatformSpec({ platform: "freebsd", arch: "x64" }), null)
 })
 
@@ -122,6 +129,8 @@ test("package.json optionalDependencies only list published platform packages", 
     [
       "@clickzetta/cz-cli-darwin-arm64",
       "@clickzetta/cz-cli-darwin-x64",
+      "@clickzetta/cz-cli-linux-arm64",
+      "@clickzetta/cz-cli-linux-x64",
       "@clickzetta/cz-cli-win32-x64",
     ],
   )

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Exercise the shipped Linux x64 executable on a CPU model with SSE4.2 but no AVX.
+set -eu
+
+BINARY="${1:?Usage: check-baseline.sh <linux-x64-binary>}"
+export CLICKZETTA_DISABLE_AUTOUPDATE=1
+
+for command in version help; do
+  timeout 120 qemu-x86_64 -cpu Nehalem "$BINARY" "--$command"
+done
+timeout 120 qemu-x86_64 -cpu Nehalem "$BINARY" agent --help

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -1,9 +1,24 @@
 #!/bin/sh
-# Exercise the shipped Linux x64 executable on a CPU model with SSE4.2 but no AVX.
+# Check CLI startup and argument parsing, not TUI rendering or provider execution.
 set -eu
 
 BINARY="${1:?Usage: check-baseline.sh <linux-x64-binary>}"
 export CLICKZETTA_DISABLE_AUTOUPDATE=1
+
+# Prove this QEMU invocation rejects AVX before trusting the startup checks.
+CONTROL_DIR=$(mktemp -d)
+trap 'rm -rf "$CONTROL_DIR"' EXIT
+ulimit -c 0
+printf '%s\n' 'int main(void) { __asm__ volatile ("vzeroupper"); return 0; }' > "$CONTROL_DIR/avx.c"
+cc "$CONTROL_DIR/avx.c" -o "$CONTROL_DIR/avx"
+status=0
+timeout 10 qemu-x86_64 -cpu Nehalem "$CONTROL_DIR/avx" > "$CONTROL_DIR/output" 2>&1 || status=$?
+if [ "$status" -ne 132 ]; then
+  cat "$CONTROL_DIR/output" >&2
+  echo "AVX control must fail with SIGILL (132), got $status" >&2
+  exit 1
+fi
+echo "AVX control rejected with SIGILL"
 
 for command in version help; do
   timeout 120 qemu-x86_64 -cpu Nehalem "$BINARY" "--$command"

--- a/scripts/cos-release.mjs
+++ b/scripts/cos-release.mjs
@@ -472,19 +472,15 @@ platform() {
   # runs in when a Windows user pipes it to bash. The win32 archives are built and
   # published like every other platform, so map onto them instead of letting the raw
   # uname string fall through to "unsupported platform", which read as "no Windows build
-  # exists". Deliberately matching install.ps1's \`win32-$Arch\`, baseline included: it
-  # does not select the -baseline build either, so a pre-AVX2 Windows CPU is an open gap
-  # in BOTH installers rather than a new one here.
+  # exists". This matches install.ps1's \`win32-$Arch\` platform key.
   case "$OS" in
     mingw*|msys*|cygwin*) OS="win32" ;;
   esac
 
   SUFFIX=""
   if [ "$OS" = "linux" ]; then
-    # baseline: x64 CPUs without AVX2 need the non-AVX2 build.
-    if [ "$ARCH" = "x64" ] && ! grep -qwi avx2 /proc/cpuinfo 2>/dev/null; then
-      SUFFIX="-baseline"
-    fi
+    # All x64 release artifacts use Bun's baseline runtime, including the
+    # unsuffixed package. No AVX2 detection or separate download is needed.
     # libc: use the statically-linked musl build on musl distros, when forced
     # via CZ_LIBC=musl, or when the host glibc is older than the glibc binary's
     # minimum (GLIBC_2.25, e.g. CentOS/RHEL 7 at 2.17).


### PR DESCRIPTION
Prefer baseline x64 compatibility over CPU-specific optimization and verify startup without AVX before publishing.
