### PR TITLE
fix(agent): unify trace settings and simplify write guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,34 @@ cz-cli <command> [options]
 
 Every command takes `--help`.
 
+## CLI configuration
+
+Store CLI preferences in `~/.clickzetta/czcli.json`, alongside settings such as
+`autoupdate`:
+
+```json
+{
+  "autoupdate": false,
+  "otel_record_content": true
+}
+```
+
+When tracing is configured, `otel_record_content` controls recording LLM
+inputs/outputs and tool arguments/results. Content can include code and data;
+existing redaction and size limits still apply. Setting it to `false` keeps spans,
+status, token usage, and available profile identity attributes, but omits content.
+
+Content recording precedence is `OPENCODE_OTEL_RECORD_CONTENT` (`0`/`1`), then
+`otel_record_content`, then the legacy top-level `telemetry` boolean in
+`~/.clickzetta/profiles.toml`, then `true`. Missing files and missing keys use the
+same default. Setup writes new preferences to `czcli.json`; existing legacy
+preferences remain readable.
+
+The shared config reader also accepts `~/.clickzetta/czcli.jsonc`, followed by
+`$XDG_CONFIG_HOME/clickzetta/{opencode.jsonc,opencode.json,config.json}` (XDG defaults
+to `~/.config`). Later files override earlier files per key for content
+recording. Automatic updates use their existing migration into `czcli.json`.
+
 ## Output
 
 Output is machine-readable by default: a `{"data": …}` envelope on success, a

--- a/packages/cz-cli/src/agent-system-prompt.ts
+++ b/packages/cz-cli/src/agent-system-prompt.ts
@@ -171,7 +171,6 @@ export const CLICKZETTA_AGENT_SYSTEM_PROMPT = [
   "## Key Rules",
   "",
   "**SQL is async by default**. Use `--sync` for SELECT when you need data immediately.",
-  "**Write approval workflow**: SQL, schema create/drop, table create/drop/load, and fs mb/rb/rm use the same approval workflow. Start each new operation without approval-override flags so the CLI can evaluate it. If the response has `status: action_required`, show the user the operation, target and reason, ask for explicit approval, and wait. Follow `issues[].remediation` and `next_steps` only after approval. A rejection is not permission to retry. Do not bypass the check through another command, tool, SDK, or direct API. An approved retry must preserve the operation, profile/workspace/schema, paths, variables, and settings; changed operations must be checked and approved again.",
   "**Always pass `--type` when creating tasks** (SQL/PYTHON/SHELL/SPARK/FLOW/MERGE).",
   "**Draft vs published matters**: `cz-cli task content <task>` shows draft only. Before validating cron/retry/readiness/scheduled behavior, run `cz-cli task status <task>` first. If draft changes are not published yet, publish them before drawing conclusions.",
   "**Flow tasks use `task flow *` commands exclusively** — never use `task save-content` or `task deploy` on flow nodes.",

--- a/packages/cz-cli/src/bootstrap/opencode-injection.ts
+++ b/packages/cz-cli/src/bootstrap/opencode-injection.ts
@@ -48,10 +48,10 @@ import {
 // Base env applied on EVERY cz-cli invocation, at the very top of main(), before
 // opencode or its TUI Worker reads any flag. Order preserved from the original
 // runtime.main(): autoupdate → project-config → otel.
-export function applyBaseOpencodeEnv(): void {
+export async function applyBaseOpencodeEnv(): Promise<void> {
   disableUpstreamAutoupdate()
   disableProjectConfigByDefault()
-  applyDefaultOtelEnv()
+  await applyDefaultOtelEnv()
 }
 
 // Agent-runtime-only injection. Call from the agent branch AFTER the base env and

--- a/packages/cz-cli/src/bootstrap/runtime.ts
+++ b/packages/cz-cli/src/bootstrap/runtime.ts
@@ -59,7 +59,7 @@ export async function main(args: string[], agentRuntime = false): Promise<number
   // disable repo-local project config, telemetry defaults) at the very top of main()
   // — before opencode or the TUI server Worker reads any flag. All injection is
   // centralized in opencode-injection.ts; see its REGISTRY comment for the full list.
-  applyBaseOpencodeEnv()
+  await applyBaseOpencodeEnv()
 
   if (!globalHandlersRegistered) {
     globalHandlersRegistered = true

--- a/packages/cz-cli/src/commands/setup.ts
+++ b/packages/cz-cli/src/commands/setup.ts
@@ -1,3 +1,4 @@
+import { ConfigOtel } from "../config/otel.js"
 import type { Argv } from "yargs"
 import * as p from "@clack/prompts"
 import { spawn } from "node:child_process"
@@ -9,7 +10,7 @@ import { JobStatus, getCurrentUser, DEFAULT_CONNECTION, getToken, listUserWorksp
 import type { GlobalArgs } from "../cli.js"
 import { success, error } from "../output/index.js"
 import { logOperation } from "../logger.js"
-import { setTelemetry, getTelemetry, AUTH_TYPE, loadProfiles, type ProfileEntry, patchProfileUserId } from "../connection/profile-store.js"
+import { AUTH_TYPE, loadProfiles, type ProfileEntry, patchProfileUserId } from "../connection/profile-store.js"
 import { parseJdbcUrl } from "../connection/jdbc.js"
 import { readLlmEntries, writeLlmEntries } from "../llm/native-config.js"
 import { decodeCredential, provisionProfileFromCredential, ProvisionError } from "../connection/provision.js"
@@ -24,10 +25,10 @@ const setupStartMs = Date.now()
 
 /** Returns the telemetry value — skips prompt if already configured. */
 async function resolveTelemetry(): Promise<boolean> {
-  const existing = getTelemetry()
+  const existing = await ConfigOtel.recordContent()
   if (existing !== undefined) return existing
-  const chosen = await askYesNo("Enable telemetry to help improve cz-cli? This shares LLM call traces and tool execution data. No code content is collected. (Y/n) ")
-  setTelemetry(chosen)
+  const chosen = await askYesNo("Record LLM inputs/outputs and tool arguments/results in traces? Content may include code and data. (Y/n) ")
+  await ConfigOtel.setRecordContent(chosen)
   return chosen
 }
 
@@ -462,7 +463,7 @@ async function saveJdbcProfile(
   parsed: NonNullable<ReturnType<typeof parseJdbcSetupProfile>>,
 ): Promise<void> {
   saveProfile(profileName, parsed.profile)
-  if (getTelemetry() === undefined) setTelemetry(telemetry)
+  if ((await ConfigOtel.recordContent()) === undefined) await ConfigOtel.setRecordContent(telemetry)
   let userId: number | undefined
   try {
     const serviceUrl = toServiceUrl(String(parsed.profile.service ?? ""), parsed.profile.protocol === "http" ? "http" : "https")
@@ -1243,7 +1244,7 @@ async function runModernSetupFlowNonTTY(
         )
         return
       }
-      await saveJdbcProfile(profileName, format, argv, getTelemetry() ?? true, parsed)
+      await saveJdbcProfile(profileName, format, argv, (await ConfigOtel.recordContent()) ?? true, parsed)
       return
     }
     // custom URL (non-JDBC): return login URL with /login?ref=cz-cli
@@ -1618,10 +1619,10 @@ async function runExistingAccountFlowNonTTY(
   }
   saveProfile(profileName, profile)
   await tryFetchAndSaveClickzettaApiKey(auth.serviceUrl, auth.token, instance.instanceName)
-  if (getTelemetry() === undefined) setTelemetry(true)
+  if ((await ConfigOtel.recordContent()) === undefined) await ConfigOtel.setRecordContent(true)
   await trackSetup({
     success: true,
-    telemetry: getTelemetry() ?? true,
+    telemetry: (await ConfigOtel.recordContent()) ?? true,
     userId: auth.userId || undefined,
     collected: { username, instance: instance.instanceName, workspace: workspace.workspaceName, service: auth.service },
     argv: argv as Record<string, unknown>,

--- a/packages/cz-cli/src/config/cz-config.ts
+++ b/packages/cz-cli/src/config/cz-config.ts
@@ -11,7 +11,7 @@
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { parse as parseToml } from "smol-toml"
+import { parse } from "smol-toml"
 import { jsonc } from "opencode/config/parse"
 import { parseBoolish } from "../util/boolish.js"
 
@@ -56,9 +56,9 @@ export function czConfigCandidates(home?: string, env: NodeJS.ProcessEnv = proce
  * Writers use strict mode so an invalid file cannot be replaced by an empty object.
  */
 export function parseCzConfigText(text: string, options: { strict?: boolean } = {}): Record<string, unknown> {
-  for (const parse of [jsonc, parseToml] as const) {
+  for (const decode of [jsonc, parse] as const) {
     try {
-      const parsed = parse(text, CZ_CONFIG_FILE)
+      const parsed = decode(text, CZ_CONFIG_FILE)
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as Record<string, unknown>
     } catch {
       // try the next format
@@ -66,6 +66,20 @@ export function parseCzConfigText(text: string, options: { strict?: boolean } = 
   }
   if (options.strict) throw new Error(`Invalid config in ${CZ_CONFIG_FILE}; expected a JSON, JSONC, or TOML object`)
   return {}
+}
+
+/** Update the canonical file without copying overrides from other config files. */
+export async function writeCzConfig(values: Record<string, unknown>) {
+  const file = path.join(homeDirectory(), CLICKZETTA_DIR, "czcli.json")
+  const text = await fs.readFile(file, "utf-8").catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return undefined
+    throw error
+  })
+  const config = text === undefined ? {} : parseCzConfigText(text, { strict: true })
+  await fs.mkdir(path.dirname(file), { recursive: true })
+  const temporary = `${file}.${crypto.randomUUID()}.tmp`
+  await Bun.write(temporary, JSON.stringify({ ...config, ...values }, null, 2) + "\n", { mode: 0o600 })
+  await fs.rename(temporary, file)
 }
 
 /** Merged config across all candidates, later files winning key by key. */

--- a/packages/cz-cli/src/config/otel.ts
+++ b/packages/cz-cli/src/config/otel.ts
@@ -1,0 +1,15 @@
+export * as ConfigOtel from "./otel"
+
+import { czConfigBool, writeCzConfig } from "./cz-config.js"
+
+/** Persisted preference only: bootstrap also sets the env var from defaults. */
+export async function recordContent() {
+  const configured = await czConfigBool("otel_record_content")
+  if (configured !== undefined) return configured
+  const { getTelemetry } = await import("../connection/profile-store.js")
+  return getTelemetry()
+}
+
+export async function setRecordContent(enabled: boolean) {
+  await writeCzConfig({ otel_record_content: enabled })
+}

--- a/packages/cz-cli/src/connection/context.ts
+++ b/packages/cz-cli/src/connection/context.ts
@@ -119,11 +119,48 @@ export function connectionContext(args: Partial<CliArgs> = {}): Promise<Connecti
 // A switch retargets everything the profile determines, so nothing resolved under the
 // previous one may survive it. `set()` is the only way the active profile changes after
 // startup (profile-context.ts).
-Profile.onChange(() => cache.clear())
+Profile.onChange(() => {
+  cache.clear()
+  ensured = undefined
+})
 
 /** Test-only: drop memoised contexts between tests sharing a process. */
 export function clearConnectionContextForTest(): void {
   cache.clear()
+  ensured = undefined
+}
+
+let ensured: Promise<void> | undefined
+
+/**
+ * Resolve this profile's identity now, for a caller that only wants the WRITE-BACK.
+ *
+ * `identity()` is lazy on purpose (see its doc comment): the SQL path must not pay a portal
+ * round trip for a user id it never reads. The cost of that laziness is that a profile
+ * whose login never learned its userId — login-browser keeps a token whose userinfo fetch
+ * failed, leaving userId at 0 — has nothing to fill it in, because no other agent-path
+ * reader asks for the user either. Telemetry then attributes a whole session to no one.
+ * This is the one entry point that resolves for that reason alone; it returns nothing,
+ * because the value it produces is the `user_id` on the profile.
+ *
+ * Free where it is already known: `resolveUser` answers from the profile's cached `user_id`
+ * + `account_id` without calling the portal, so on a warm profile this only builds the
+ * context — itself memoised for the life of the process, as is this.
+ *
+ * Never rejects. Every failure here — no profile, no credential, an instance name the
+ * portal will not resolve — is one the callers already degrade for.
+ */
+export function ensureIdentityResolved(args: Partial<CliArgs> = {}): Promise<void> {
+  // No row for the active profile means the write-back below cannot fire either — its guard
+  // needs an entry that matches this connection — so resolving would spend a portal round
+  // trip and throw the answer away. The one caller that resolves for the write alone must
+  // not pay for that.
+  if (!readProfileEntry(args.profile ?? Profile.current())) return Promise.resolve()
+  ensured ??= connectionContext(args)
+    .then((ctx) => ctx.identity())
+    .then(() => undefined)
+    .catch(() => undefined)
+  return ensured
 }
 
 async function derive(config: ConnectionConfig, profileName: string | undefined): Promise<ConnectionContext> {

--- a/packages/cz-cli/src/connection/profile-store.ts
+++ b/packages/cz-cli/src/connection/profile-store.ts
@@ -143,7 +143,7 @@ export function saveProfiles(profiles: Record<string, ProfileEntry>): void {
 /**
  * Set `default_profile` to `name`, preserving every other top-level key and the
  * profiles table. Uses the same CLICKZETTA_TEST_HOME-aware, atomic, 0600 write
- * as the rest of this module. Mirrors {@link saveProfiles}/{@link setTelemetry}:
+ * as the rest of this module. Mirrors {@link saveProfiles}:
  * a missing/corrupt file starts fresh, but a failed write propagates so the
  * caller's error handler can report it.
  */
@@ -416,7 +416,7 @@ export function setAuthTypeIfAbsent(profileName: string | undefined, authType: A
   }
 }
 
-/** Returns the current telemetry setting, or undefined if not yet configured. */
+/** Legacy content preference; new settings are written to czcli.json. */
 export function getTelemetry(): boolean | undefined {
   try {
     const text = readFileSync(profilesFile(), "utf-8")
@@ -426,17 +426,6 @@ export function getTelemetry(): boolean | undefined {
   } catch {
     return undefined
   }
-}
-
-export function setTelemetry(enabled: boolean): void {
-  let existing: Record<string, unknown> = {}
-  try {
-    const text = readFileSync(profilesFile(), "utf-8")
-    existing = parseTOML(text) as Record<string, unknown>
-  } catch {}
-  existing.telemetry = enabled
-  const content = stringifyTOML(existing)
-  writeProfilesFile(content)
 }
 
 /**

--- a/packages/cz-cli/src/connection/telemetry.ts
+++ b/packages/cz-cli/src/connection/telemetry.ts
@@ -1,0 +1,40 @@
+import { current } from "./profile-context.js"
+import { profileStoreFingerprint, readProfileEntry } from "./profile-store.js"
+
+const FIELDS = [
+  ["user_id", "enduser.id"],
+  ["instance", "instance.name"],
+  ["workspace", "workspace.name"],
+  ["service", "service.url"],
+] as const
+
+let cache: { key: string; attributes: Record<string, string> } | undefined
+
+/**
+ * Read the active profile on each operation; never cache identity on the SDK resource.
+ *
+ * Memoised on the profile-store FINGERPRINT rather than on a clock: this runs once per span,
+ * log record and metric, so the TOML parse it used to do every time is worth avoiding — but
+ * a time-based cache would hide a `user_id` that a `cz-cli sql` subprocess just wrote for
+ * the length of the window, and picking that write up on the next span is how a session
+ * that started without an id recovers one. The fingerprint is a read of a small file plus a
+ * hash; the parse happens only when the file changed.
+ */
+export function profileTelemetryAttributes(): Record<string, string> {
+  const profile = current()
+  const key = JSON.stringify([profileStoreFingerprint(), profile ?? null])
+  if (cache?.key === key) return cache.attributes
+  const entry = readProfileEntry(profile)
+  const attributes: Record<string, string> = entry
+    ? Object.fromEntries(
+        FIELDS.flatMap(([field, attribute]) => {
+          const value = entry[field]
+          if (typeof value === "string" && value.trim()) return [[attribute, value]]
+          if (typeof value === "number" && Number.isFinite(value)) return [[attribute, String(value)]]
+          return []
+        }),
+      )
+    : {}
+  cache = { key, attributes }
+  return attributes
+}

--- a/packages/cz-cli/src/opencode-plugin/otel/handlers.ts
+++ b/packages/cz-cli/src/opencode-plugin/otel/handlers.ts
@@ -1,3 +1,5 @@
+import { ensureIdentityResolved } from "../../connection/context.js"
+import { profileTelemetryAttributes } from "../../connection/telemetry.js"
 import { context, SpanKind, trace, SpanStatusCode, type Span } from "@opentelemetry/api"
 import { SeverityNumber, type Logger } from "@opentelemetry/api-logs"
 import {
@@ -209,6 +211,12 @@ export function initHandlers(logger: Logger, recordContent?: boolean) {
   _logger = logger
   _recordContent = recordContent ?? true
   setRawRequestCaptureEnabled(_recordContent)
+  // Everything below attributes its span from the profile's `user_id`, and on a headless
+  // run (`agent run`, `serve`) nothing else asks the portal who the user is — the TUI's
+  // profile panel, which does, never paints. So resolve it once here, where telemetry
+  // declares what it needs, rather than from the attribute builder: a span must not be
+  // able to start a portal call. Not awaited, and it cannot reject.
+  void ensureIdentityResolved()
 }
 
 function sessionAttributes(
@@ -234,6 +242,7 @@ function emitLog(input: {
     severityText: input.severityText,
     body: input.body,
     attributes: {
+      ...profileTelemetryAttributes(),
       "event.name": input.eventName,
       ...input.attributes,
     },
@@ -264,6 +273,7 @@ function openTurnSpan(sessionID: string) {
     "prompt",
     {
       attributes: {
+        ...profileTelemetryAttributes(),
         "opencode.session.id": sessionID,
         ...(parentID ? { "opencode.session.parent.id": parentID } : {}),
       },
@@ -535,6 +545,7 @@ export function handleEvent(event: SubscribedEvent) {
             sessionID: p.sessionID ?? "",
             attributes: sessionAttributes(p.sessionID, {
               "gen_ai.conversation.id": p.sessionID ?? "",
+              ...profileTelemetryAttributes(),
               "gen_ai.operation.name": "chat",
             }),
           })
@@ -681,6 +692,7 @@ export function handleEvent(event: SubscribedEvent) {
           const span = tracer.startSpan(`chat ${modelID}`, {
             kind: SpanKind.CLIENT,
             attributes: {
+              ...profileTelemetryAttributes(),
               "gen_ai.operation.name": "chat",
               "gen_ai.provider.name": model?.providerID ?? "",
               "gen_ai.request.model": modelID,
@@ -739,7 +751,8 @@ export function handleEvent(event: SubscribedEvent) {
           }
           if (tokens.input) m.tokenUsage.record(tokens.input, { "gen_ai.token.type": "input", ...modelAttrs })
           if (tokens.output) m.tokenUsage.record(tokens.output, { "gen_ai.token.type": "output", ...modelAttrs })
-          if (durationMs != null) m.operationDuration.record(durationMs / 1000, { "gen_ai.operation.name": "chat", ...modelAttrs })
+          if (durationMs != null) m.operationDuration.record(durationMs / 1000, { ...profileTelemetryAttributes(),
+              "gen_ai.operation.name": "chat", ...modelAttrs })
           emitLog({
             severityNumber: SeverityNumber.INFO,
             severityText: "INFO",
@@ -798,6 +811,7 @@ export function handleEvent(event: SubscribedEvent) {
             if (!tracingEnabled("tool")) break
             const span = tracer.startSpan(`execute_tool ${toolName}`, {
               attributes: {
+                ...profileTelemetryAttributes(),
                 "gen_ai.operation.name": "execute_tool",
                 "gen_ai.tool.name": toolName,
                 // Recommended by the convention and previously missing; these tools run

--- a/packages/cz-cli/src/opencode-plugin/tui-quota-data.ts
+++ b/packages/cz-cli/src/opencode-plugin/tui-quota-data.ts
@@ -31,7 +31,7 @@ import { join } from "node:path"
 import { toServiceUrl } from "@clickzetta/sdk"
 import { resolveConnectionConfig } from "../connection/config.js"
 import * as Profile from "../connection/profile-context.js"
-import { deriveAuthType, explicitAuthType, loadProfiles } from "../connection/profile-store.js"
+import { deriveAuthType, explicitAuthType, loadProfiles, patchProfileUserId } from "../connection/profile-store.js"
 // Re-exported, not redefined: tui-quota-runtime.ts publishes these to the .tsx renderer,
 // and commands/ai-gateway.ts needs the same answer — see llm/clickzetta-entry.ts.
 import { classifyClickzettaEntry, resolveClickzettaEntry } from "../llm/clickzetta-entry.js"
@@ -256,28 +256,31 @@ export function clearUserNameCacheForTest(): void {
 }
 
 /**
- * POST getCurrentUser and pull out the login handle, or undefined on any failure
- * or an envelope that doesn't carry one.
+ * POST getCurrentUser and pull out the login handle and the numeric id, or undefined on
+ * any failure or an envelope that doesn't carry them.
  *
- * `name` is the login handle; `accountDisplayName` is the tenant and is already
- * covered by `accountName` elsewhere. Nothing else from this payload is used — it
- * also carries a phone number and an email, which have no place in a status panel.
+ * `name` is the login handle, for display; `id` is what telemetry attributes a span to, and
+ * is returned rather than dropped because this response is the only place on the agent path
+ * that carries it. `accountDisplayName` is the tenant and is already covered by
+ * `accountName` elsewhere. Nothing else from this payload is used — it also carries a phone
+ * number and an email, which have no place in a status panel.
  *
  * `fetchProfileUserName`'s only caller now — fetchProfileSnapshot stopped needing a user
  * name when the token half moved to response headers. The four-part envelope check (record /
  * isPortalOk / record data / string name) stays here rather than inline because that shape
  * is the portal's, not this function's, and it was written once for two callers.
  */
-async function readCurrentUserName(
+async function readCurrentUser(
   baseUrl: string,
   token: string,
   signal: AbortSignal | undefined,
-): Promise<string | undefined> {
+): Promise<{ name?: string; id?: number } | undefined> {
   try {
     const payload = await portalRead(baseUrl, CURRENT_USER_PATH, token, { method: "POST", signal })
     if (!isRecord(payload) || !isPortalOk(payload.code) || !isRecord(payload.data)) return undefined
     const name = typeof payload.data.name === "string" ? payload.data.name.trim() : ""
-    return name || undefined
+    const id = Number(payload.data.id)
+    return { name: name || undefined, id: Number.isFinite(id) && id > 0 ? id : undefined }
   } catch (error) {
     if (signal?.aborted) throw error
     return undefined
@@ -323,10 +326,18 @@ export async function fetchProfileUserName(
     // instead of the indicator silently going blank (this file kept its own
     // fetch for host probing and cancellation, but not its own credential).
     const credential = await profileTokenSource(config).get()
-    const name = await readCurrentUserName(toServiceUrl(config.service, config.protocol), credential.token, input.signal)
-    if (!name) return undefined
-    userNameCache.set(info.profile, name)
-    return { profile: info.profile, name }
+    const user = await readCurrentUser(toServiceUrl(config.service, config.protocol), credential.token, input.signal)
+    // The same response carries the numeric id, and this is the only thing on the agent path
+    // that asks the portal who the user is. Telemetry attributes every span from the
+    // profile's `user_id`, which a login can fail to learn (login-browser keeps a token whose
+    // userinfo fetch failed) and which nothing else here would ever fill in — so record it
+    // while it is in hand rather than spend a second round trip on it later. Safe to write
+    // under: `info.profile` is the profile this credential was built from, and
+    // patchProfileUserId only fills an absent field and never throws.
+    if (user?.id) patchProfileUserId(info.profile, user.id)
+    if (!user?.name) return undefined
+    userNameCache.set(info.profile, user.name)
+    return { profile: info.profile, name: user.name }
   } catch {
     return undefined
   }

--- a/packages/cz-cli/src/otel-defaults.ts
+++ b/packages/cz-cli/src/otel-defaults.ts
@@ -1,7 +1,3 @@
-import { existsSync, readFileSync } from "fs"
-import os from "os"
-import path from "path"
-
 /**
  * Internal OTel telemetry defaults — single source of truth for cz-cli package.
  *
@@ -23,17 +19,7 @@ export const OTEL_DEFAULTS = {
   headers: typeof CLICKZETTA_OTEL_HEADERS === "string" ? CLICKZETTA_OTEL_HEADERS : "",
 }
 
-function shouldRecordOtelContent() {
-  const profilesPath = path.join(process.env.CLICKZETTA_TEST_HOME || os.homedir(), ".clickzetta", "profiles.toml")
-  if (!existsSync(profilesPath)) return true
-  try {
-    return /^telemetry\s*=\s*true/m.test(readFileSync(profilesPath, "utf-8"))
-  } catch {
-    return true
-  }
-}
-
-export function applyDefaultOtelEnv() {
+export async function applyDefaultOtelEnv() {
   if (!process.env.OPENCODE_OTLP_ENDPOINT && OTEL_DEFAULTS.endpoint) {
     process.env.OPENCODE_OTLP_ENDPOINT = OTEL_DEFAULTS.endpoint
   }
@@ -44,7 +30,8 @@ export function applyDefaultOtelEnv() {
     process.env.OPENCODE_OTLP_PROTOCOL = OTEL_PROTOCOL
   }
   if (!process.env.OPENCODE_OTEL_RECORD_CONTENT) {
-    process.env.OPENCODE_OTEL_RECORD_CONTENT = shouldRecordOtelContent() ? "1" : "0"
+    const { ConfigOtel } = await import("./config/otel.js")
+    process.env.OPENCODE_OTEL_RECORD_CONTENT = ((await ConfigOtel.recordContent()) ?? true) ? "1" : "0"
   }
   if (!process.env.OPENCODE_SERVICE_NAME) {
     process.env.OPENCODE_SERVICE_NAME = "cz-agent"

--- a/packages/cz-cli/src/telemetry.ts
+++ b/packages/cz-cli/src/telemetry.ts
@@ -1,6 +1,4 @@
-import { readFileSync } from "fs"
-import { join } from "path"
-import { homedir } from "os"
+import { profileTelemetryAttributes } from "./connection/telemetry.js"
 import { OTEL_DEFAULTS } from "./otel-defaults.js"
 import { VERSION } from "./version.js"
 import { currentTraceContext } from "./trace.js"
@@ -221,33 +219,6 @@ function commandAttributes(event: CommandEvent) {
   ]
 }
 
-function getResourceAttributes(): Record<string, string> {
-  try {
-    const toml = readFileSync(join(homedir(), ".clickzetta", "profiles.toml"), "utf-8")
-    const defaultMatch = toml.match(/^default_profile\s*=\s*"?([^"\n]+)"?/m)
-    const profileName = defaultMatch?.[1]?.trim() ?? "default"
-    const sectionHeader = `[profiles.${profileName}]`
-    const sectionIdx = toml.indexOf(sectionHeader)
-    if (sectionIdx < 0) return {}
-    const afterHeader = toml.slice(sectionIdx + sectionHeader.length)
-    const nextSection = afterHeader.indexOf("\n[")
-    const block = nextSection >= 0 ? afterHeader.slice(0, nextSection) : afterHeader
-    const get = (key: string) => block.match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"))?.[1]?.trim()
-    const attrs: Record<string, string> = {}
-    const userId = get("user_id")
-    const instance = get("instance")
-    const workspace = get("workspace")
-    const service = get("service")
-    if (userId) attrs["enduser.id"] = userId
-    if (instance) attrs["instance.name"] = instance
-    if (workspace) attrs["workspace.name"] = workspace
-    if (service) attrs["service.url"] = service
-    return attrs
-  } catch {
-    return {}
-  }
-}
-
 /**
  * Fire-and-forget: send a command execution event to the OTLP collector.
  * Never throws, never blocks CLI exit.
@@ -255,7 +226,7 @@ function getResourceAttributes(): Record<string, string> {
 export function trackCommand(event: CommandEvent): Promise<void> {
   if (!OTEL_DEFAULTS.endpoint) return Promise.resolve()
   try {
-    const resourceAttrs = event.resourceAttributes ?? getResourceAttributes()
+    const resourceAttrs = event.resourceAttributes ?? profileTelemetryAttributes()
     const now = Date.now()
     const traceContext = currentTraceContext()
     const body = {

--- a/packages/cz-cli/test/otel-config.test.ts
+++ b/packages/cz-cli/test/otel-config.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { mkdtemp, mkdir, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { ConfigOtel } from "../src/config/otel.js"
+import { applyDefaultOtelEnv } from "../src/otel-defaults.js"
+
+let home = ""
+let previous: Record<string, string | undefined> = {}
+
+beforeEach(async () => {
+  previous = Object.fromEntries(
+    [
+      "CLICKZETTA_TEST_HOME",
+      "XDG_CONFIG_HOME",
+      "OPENCODE_OTEL_RECORD_CONTENT",
+      "OPENCODE_OTLP_ENDPOINT",
+      "OPENCODE_OTLP_HEADERS",
+      "OPENCODE_OTLP_PROTOCOL",
+      "OPENCODE_SERVICE_NAME",
+    ].map((key) => [key, process.env[key]]),
+  )
+  home = await mkdtemp(path.join(os.tmpdir(), "cz-otel-config-"))
+  process.env.CLICKZETTA_TEST_HOME = home
+  process.env.XDG_CONFIG_HOME = path.join(home, "xdg")
+  delete process.env.OPENCODE_OTEL_RECORD_CONTENT
+  await mkdir(path.join(home, ".clickzetta"))
+})
+
+afterEach(async () => {
+  Object.entries(previous).forEach(([key, value]) => {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  })
+  await rm(home, { recursive: true, force: true })
+})
+
+test.each([
+  [undefined, "1"],
+  ["[profiles.default]\nuser_id = 42\n", "1"],
+  ["telemetry = false\n", "0"],
+  ["telemetry = true\n", "1"],
+  ["[profiles.default]\ntelemetry = false\n", "1"],
+  ['"telemetry" = false\n', "0"],
+])("legacy preference %j resolves to %s", async (profiles, expected) => {
+  if (profiles !== undefined) await Bun.write(path.join(home, ".clickzetta/profiles.toml"), profiles)
+  await applyDefaultOtelEnv()
+  expect(process.env.OPENCODE_OTEL_RECORD_CONTENT).toBe(expected)
+})
+
+test.each([true, false])("new preference %s overrides legacy", async (enabled) => {
+  await Bun.write(path.join(home, ".clickzetta/profiles.toml"), `telemetry = ${!enabled}\n`)
+  await ConfigOtel.setRecordContent(enabled)
+  await applyDefaultOtelEnv()
+  expect(process.env.OPENCODE_OTEL_RECORD_CONTENT).toBe(enabled ? "1" : "0")
+})
+
+test.each(["0", "1"])("explicit environment %s overrides persisted preferences", async (value) => {
+  await ConfigOtel.setRecordContent(value === "0")
+  process.env.OPENCODE_OTEL_RECORD_CONTENT = value
+  await applyDefaultOtelEnv()
+  expect(process.env.OPENCODE_OTEL_RECORD_CONTENT).toBe(value)
+})
+
+test("XDG overrides canonical config using the existing config rules", async () => {
+  await ConfigOtel.setRecordContent(true)
+  await mkdir(path.join(home, "xdg/clickzetta"), { recursive: true })
+  await Bun.write(path.join(home, "xdg/clickzetta/config.json"), '{"otel_record_content": false}')
+  await applyDefaultOtelEnv()
+  expect(process.env.OPENCODE_OTEL_RECORD_CONTENT).toBe("0")
+})
+
+test("setup preference writes preserve other settings and leave profiles untouched", async () => {
+  const file = path.join(home, ".clickzetta/czcli.json")
+  const profiles = path.join(home, ".clickzetta/profiles.toml")
+  await Bun.write(file, '{ // existing settings\n "autoupdate": false, "sql_split": false, }')
+  await Bun.write(profiles, "telemetry = true\n[profiles.default]\nuser_id = 42\n")
+  const before = await Bun.file(profiles).text()
+  await ConfigOtel.setRecordContent(false)
+  expect(await Bun.file(file).json()).toEqual({ autoupdate: false, sql_split: false, otel_record_content: false })
+  expect(await Bun.file(profiles).text()).toBe(before)
+  expect(await ConfigOtel.recordContent()).toBe(false)
+})
+
+test("invalid config is not overwritten by setup", async () => {
+  const file = path.join(home, ".clickzetta/czcli.json")
+  await Bun.write(file, '{"autoupdate":')
+  await expect(ConfigOtel.setRecordContent(false)).rejects.toThrow("Invalid config")
+  expect(await Bun.file(file).text()).toBe('{"autoupdate":')
+})
+
+test("injected defaults do not mask an unconfigured setup preference", async () => {
+  await applyDefaultOtelEnv()
+  expect(process.env.OPENCODE_OTEL_RECORD_CONTENT).toBe("1")
+  expect(await ConfigOtel.recordContent()).toBeUndefined()
+})

--- a/packages/cz-cli/test/otel-span-build.test.ts
+++ b/packages/cz-cli/test/otel-span-build.test.ts
@@ -1,4 +1,9 @@
-import { expect, test, describe, beforeEach } from "bun:test"
+import { expect, test, describe, beforeEach, afterEach } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { ConnectionEnv } from "../src/connection/env.js"
+import { saveProfiles } from "../src/connection/profile-store.js"
 import { InMemorySpanExporter, SimpleSpanProcessor, BasicTracerProvider } from "@opentelemetry/sdk-trace-base"
 import { trace } from "@opentelemetry/api"
 
@@ -870,5 +875,48 @@ describe("the credential shapes that leaked", () => {
     busy()
     const args = String(named("execute_tool odd")[0]!.attributes["gen_ai.tool.call.arguments"])
     expect(args).toContain("<redacted:cycle>")
+  })
+})
+
+describe("active profile attribution", () => {
+  let home = ""
+  let previousHome: string | undefined
+  let previousProfile: string | undefined
+
+  beforeEach(async () => {
+    previousHome = process.env.CLICKZETTA_TEST_HOME
+    previousProfile = ConnectionEnv.profileName()
+    home = await mkdtemp(path.join(os.tmpdir(), "cz-span-profile-"))
+    process.env.CLICKZETTA_TEST_HOME = home
+    saveProfiles({ first: { user_id: 11, instance: "one" }, second: { user_id: 22, workspace: "two" } })
+  })
+
+  afterEach(async () => {
+    if (previousHome === undefined) delete process.env.CLICKZETTA_TEST_HOME
+    else process.env.CLICKZETTA_TEST_HOME = previousHome
+    if (previousProfile === undefined) ConnectionEnv.unpin()
+    else ConnectionEnv.pin(previousProfile)
+    await rm(home, { recursive: true, force: true })
+  })
+
+  test("prompt, llm, tool spans and logs carry the current profile even with content off", () => {
+    initHandlers(logger as Parameters<typeof initHandlers>[0], false)
+    ;["first", "second"].forEach((profile) => {
+      ConnectionEnv.pin(profile)
+      busy()
+      assistantMessage()
+      part({ id: "start", type: "step-start" })
+      part({ id: "tool", type: "tool", tool: "bash", callID: "call", state: { status: "running", input: { command: "pwd" } } })
+      part({ id: "tool", type: "tool", tool: "bash", callID: "call", state: { status: "completed", output: "/tmp" } })
+      part({ id: "finish", type: "step-finish", reason: "stop" })
+      send("session.idle", { sessionID: SESSION })
+    })
+    ;["prompt", "chat claude-opus-5", "execute_tool bash"].forEach((name) => {
+      expect(named(name).map((span) => span.attributes["enduser.id"])).toEqual(["11", "22"])
+      expect(named(name)[1]!.attributes["instance.name"]).toBeUndefined()
+      expect(named(name)[1]!.attributes["workspace.name"]).toBe("two")
+    })
+    expect(named("execute_tool bash")[0]!.attributes["gen_ai.tool.call.arguments"]).toBeUndefined()
+    expect(emitted("opencode.tool.finished").map((record) => record.attributes["enduser.id"])).toEqual(["11", "22"])
   })
 })

--- a/packages/cz-cli/test/profile-telemetry.test.ts
+++ b/packages/cz-cli/test/profile-telemetry.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { mkdtemp, mkdir, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { ConnectionEnv } from "../src/connection/env.js"
+import { saveProfiles, setDefaultProfile } from "../src/connection/profile-store.js"
+import { profileTelemetryAttributes } from "../src/connection/telemetry.js"
+import { trackCommand } from "../src/telemetry.js"
+import { OTEL_DEFAULTS } from "../src/otel-defaults.js"
+
+let home = ""
+let previousHome: string | undefined
+let previousProfile: string | undefined
+const endpoint = OTEL_DEFAULTS.endpoint
+
+beforeEach(async () => {
+  previousHome = process.env.CLICKZETTA_TEST_HOME
+  previousProfile = ConnectionEnv.profileName()
+  home = await mkdtemp(path.join(os.tmpdir(), "cz-profile-telemetry-"))
+  process.env.CLICKZETTA_TEST_HOME = home
+  await mkdir(path.join(home, ".clickzetta"))
+  ConnectionEnv.unpin()
+  saveProfiles({
+    first: { user_id: 11, instance: "first-instance" },
+    "second.profile": {
+      user_id: 22,
+      instance: "second-instance",
+      workspace: "ws",
+      service: "https://example.test",
+      pat: "secret",
+    },
+    empty: {},
+  })
+  setDefaultProfile("first")
+})
+
+afterEach(async () => {
+  if (previousHome === undefined) delete process.env.CLICKZETTA_TEST_HOME
+  else process.env.CLICKZETTA_TEST_HOME = previousHome
+  if (previousProfile === undefined) ConnectionEnv.unpin()
+  else ConnectionEnv.pin(previousProfile)
+  OTEL_DEFAULTS.endpoint = endpoint
+  await rm(home, { recursive: true, force: true })
+})
+
+test("active profile overrides the default, including quoted TOML profile names", () => {
+  ConnectionEnv.pin("second.profile")
+  expect(profileTelemetryAttributes()).toEqual({
+    "enduser.id": "22",
+    "instance.name": "second-instance",
+    "workspace.name": "ws",
+    "service.url": "https://example.test",
+  })
+})
+
+test("profile switches and file updates are reflected without retaining previous identity", () => {
+  expect(profileTelemetryAttributes()["enduser.id"]).toBe("11")
+  ConnectionEnv.pin("second.profile")
+  expect(profileTelemetryAttributes()["enduser.id"]).toBe("22")
+  saveProfiles({ "second.profile": { user_id: 33 } })
+  expect(profileTelemetryAttributes()).toEqual({ "enduser.id": "33" })
+  ConnectionEnv.pin("missing")
+  expect(profileTelemetryAttributes()).toEqual({})
+})
+
+test("missing profile fields stay absent", () => {
+  ConnectionEnv.pin("empty")
+  expect(profileTelemetryAttributes()).toEqual({})
+})
+
+test("command export includes the active profile resource attributes", async () => {
+  ConnectionEnv.pin("second.profile")
+  const received: unknown[] = []
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      received.push(await request.json())
+      return new Response(null, { status: 202 })
+    },
+  })
+  OTEL_DEFAULTS.endpoint = server.url.toString().replace(/\/$/, "")
+  try {
+    await trackCommand({ command: "sql", success: true, duration_ms: 1 })
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({
+      resourceLogs: [
+        {
+          resource: {
+            attributes: expect.arrayContaining([
+              { key: "enduser.id", value: { stringValue: "22" } },
+              { key: "instance.name", value: { stringValue: "second-instance" } },
+              { key: "workspace.name", value: { stringValue: "ws" } },
+            ]),
+          },
+        },
+      ],
+    })
+    expect(JSON.stringify(received)).not.toContain("secret")
+  } finally {
+    await server.stop(true)
+  }
+})

--- a/packages/cz-cli/test/setup-credential-llm.test.ts
+++ b/packages/cz-cli/test/setup-credential-llm.test.ts
@@ -66,7 +66,8 @@ function runSetup(args: string[]) {
   const llm = readLlmEntries()
   if (originalTestHome === undefined) delete process.env.CLICKZETTA_TEST_HOME
   else process.env.CLICKZETTA_TEST_HOME = originalTestHome
-  return { result, profiles, llm }
+  const config = JSON.parse(readFileSync(join(home, ".clickzetta", "czcli.json"), "utf-8"))
+  return { result, profiles, llm, config }
 }
 
 describe("setup --credential", () => {
@@ -115,7 +116,7 @@ describe("setup --credential", () => {
 
 describe("setup --login-method custom --login <jdbc>", () => {
   test("writes a profile directly from a complete JDBC connection string", () => {
-    const { result, profiles } = runSetup([
+    const { result, profiles, config } = runSetup([
       "--name", "jdbc",
       "--login-method", "custom",
       "--login", "jdbc:clickzetta://00000000.cn-hangzhou-alicloud.api.clickzetta.com/workspace?username=alice&password=secret&schema=public&virtualCluster=DEFAULT",
@@ -123,6 +124,8 @@ describe("setup --login-method custom --login <jdbc>", () => {
 
     expect(result.status).toBe(0)
     expect(profiles.default_profile).toBe("jdbc")
+    expect(profiles.telemetry).toBeUndefined()
+    expect(config.otel_record_content).toBe(true)
     expect(profiles.profiles).toEqual({
       jdbc: {
         username: "alice",

--- a/packages/cz-cli/test/telemetry-identity.test.ts
+++ b/packages/cz-cli/test/telemetry-identity.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The profile's `user_id` — telemetry's `enduser.id` — gets filled in on the agent path.
+ * Run: bun test test/telemetry-identity.test.ts
+ *
+ * A login normally writes it, but one that could not learn it keeps the token anyway
+ * (login-browser leaves userId at 0), and nothing on the agent path reads the user
+ * afterwards: `identity()` is lazy, so it never resolved and whole sessions were exported
+ * attributed to no one. Two fills, one per path — the TUI's profile panel, from the portal
+ * response it already makes, and `ensureIdentityResolved` for a headless run where that
+ * panel never paints.
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { requireTestHome, stubStudioContext } from "./support/cz-fixtures"
+
+const { profileTelemetryAttributes } = await import("../src/connection/telemetry.ts")
+const { clearConnectionContextForTest, ensureIdentityResolved } = await import("../src/connection/context.ts")
+const { fetchProfileUserName } = await import("../src/opencode-plugin/tui-quota-data.ts")
+
+const previousProfile = process.env.CZ_PROFILE
+const profilesPath = () => join(requireTestHome(), ".clickzetta", "profiles.toml")
+
+/**
+ * An OAuth profile that does not know its user: no `user_id` on the row, none on the token,
+ * and no `account_id` — so nothing short-circuits and the portal has to answer. No
+ * `username` either, which is what sends the profile panel to the portal for a display name.
+ */
+function writeProfileWithoutUserId() {
+  writeFileSync(
+    profilesPath(),
+    [
+      'default_profile = "sess_0"', "",
+      "[oauth.sess]",
+      'access_token = "at"', 'refresh_token = "rt"',
+      "expire_time_ms = 3600000", `obtained_at = ${Date.now()}`, "",
+      "[profiles.sess_0]",
+      'service = "uat-api.clickzetta.com"', 'instance = "inst"', 'workspace = "wanxin_test_04"',
+      'oauth = "sess"', 'auth_type = "oauth"', "",
+    ].join("\n"),
+    "utf-8",
+  )
+}
+
+beforeEach(() => {
+  delete process.env.CZ_PROFILE
+  delete process.env.CZ_INSTANCE
+  clearConnectionContextForTest()
+})
+
+afterEach(() => {
+  if (previousProfile === undefined) delete process.env.CZ_PROFILE
+  else process.env.CZ_PROFILE = previousProfile
+})
+
+test("the profile panel's name lookup records the id that came with it", async () => {
+  writeProfileWithoutUserId()
+  const ctx = stubStudioContext()
+
+  expect(profileTelemetryAttributes()["enduser.id"]).toBeUndefined()
+  await expect(fetchProfileUserName()).resolves.toEqual({ profile: "sess_0", name: ctx.userName })
+
+  expect(readFileSync(profilesPath(), "utf-8")).toContain(`user_id = ${ctx.userId}`)
+  expect(profileTelemetryAttributes()["enduser.id"]).toBe(String(ctx.userId))
+})
+
+test("a headless run resolves it without that panel", async () => {
+  writeProfileWithoutUserId()
+  const ctx = stubStudioContext()
+
+  await ensureIdentityResolved()
+
+  expect(profileTelemetryAttributes()["enduser.id"]).toBe(String(ctx.userId))
+})
+
+test("resolving is memoised and never rejects, even with nothing to resolve against", async () => {
+  writeFileSync(profilesPath(), 'default_profile = "gone"\n', "utf-8")
+
+  await ensureIdentityResolved()
+  await ensureIdentityResolved()
+
+  expect(profileTelemetryAttributes()).toEqual({})
+})


### PR DESCRIPTION
Unify OTel content settings, attach active profile identity to telemetry, and remove redundant write approval guidance from the agent prompt.
